### PR TITLE
Extend test_app builds

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,10 +8,15 @@ jobs:
   build:
     strategy:
       matrix:
-        idf_ver: ["v4.3"]
-        idf_target: ["esp32"]
+        idf_ver: ["release-v4.3", "release-v4.4", "latest"]
+        idf_target: ["esp32", "esp32c3"] # @todo ESP32S2 has less RAM and the test_app will not fit
+        include:
+          - idf_ver: "release-v4.4"
+            idf_target: esp32s3
+          - idf_ver: "latest"
+            idf_target: esp32s3
     runs-on: ubuntu-20.04
-    container: espressif/idf:release-${{ matrix.idf_ver }}
+    container: espressif/idf:${{ matrix.idf_ver }}
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Build test app also for ESP32S3, C3 on idf >= v4.3

ESP32S2 has less RAM, so the test_app will not fit.