### PR TITLE
pre_encrypted_img: Updated component to support mbedtls-3.1 APIs

### DIFF
--- a/esp_encrypted_img/README.md
+++ b/esp_encrypted_img/README.md
@@ -7,8 +7,7 @@ This component can help in integrating pre encrypted firmware in over-the-air up
 
 ## Image Format
 
-![Image Format](image_format.png)
-
+![Image Format](https://raw.githubusercontent.com/espressif/idf-extra-components/master/esp_encrypted_img/image_format.png)
     typedef struct {
         char magic[4];
         char enc_gcm[384];
@@ -29,7 +28,7 @@ Note:
 
 ## Tool Info
 
-This component also contains tool ([esp_enc_img_gen.py](tools/esp_enc_img_gen.py)) to generate encrypted images using RSA3072 public key.
+This component also contains tool ([esp_enc_img_gen.py](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img/tools/esp_enc_img_gen.py)) to generate encrypted images using RSA3072 public key.
 
 To know more about the tool, use command:
 `python esp_enc_img-gen.py --help`
@@ -37,4 +36,4 @@ To know more about the tool, use command:
 
 ## API Reference
 
-To learn more about how to use this component, please check API Documentation from header file [esp_encrypted_img.h](include/esp_encrypted_img.h)
+To learn more about how to use this component, please check API Documentation from header file [esp_encrypted_img.h](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img/include/esp_encrypted_img.h)

--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:


### PR DESCRIPTION
In this PR:
* Updated `esp_encrypted_img` component to add support for mbedtls-3.1 APIs.
* Updated README.md of `esp_encrypted_img` component for rendering in [Component Manager](https://components.espressif.com/component/espressif/esp_encrypted_img)