### PR TITLE
esp_encrypted_img: fix for unused variable error during build

### DIFF
--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -180,7 +180,9 @@ static esp_err_t process_bin(esp_encrypted_img_t *handle, pre_enc_decrypt_arg_t 
 {
     size_t data_len = args->data_in_len;
     size_t data_out_size = args->data_out_len;
+#if !(MBEDTLS_VERSION_NUMBER < 0x03000000)
     size_t olen;
+#endif
     handle->binary_file_read += data_len - curr_index;
     int dec_len = 0;
     if (handle->binary_file_read != handle->binary_file_len) {


### PR DESCRIPTION
Updated code to fix unused variable error during build