### PR TITLE
Some fixes/enhancements for esp_encrypted_img

### DIFF
--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -72,12 +72,10 @@ jobs:
             idf_target: esp32s3 # ESP32S3 support started with version 4.4
     runs-on: [self-hosted, linux, docker, esp32] # Unfortunately `${{ matrix.idf_target }}` is not accepted here
     container:
-      image: python:3.7-slim-buster
+      image: python:3.7-buster
       options: --privileged # Privileged mode has access to serial ports
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: test_app_bin_${{ matrix.idf_target }}_${{ matrix.idf_ver }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,8 +8,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3

--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "2.0.0"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2"
+version: "1.0.3"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/include/esp_encrypted_img.h
+++ b/esp_encrypted_img/include/esp_encrypted_img.h
@@ -86,7 +86,7 @@ esp_decrypt_handle_t esp_encrypted_img_decrypt_start(const esp_decrypt_cfg_t *cf
 *    - ESP_ERR_DECRYPT_IN_PROGRESS      Decryption is in process
 *    - ESP_OK                           Success
 */
-esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t *ctx, pre_enc_decrypt_arg_t *args);
+esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t ctx, pre_enc_decrypt_arg_t *args);
 
 
 /**
@@ -98,7 +98,7 @@ esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t *ctx, pre_enc_decr
 *    - ESP_FAIL    On failure
 *    - ESP_OK
 */
-esp_err_t esp_encrypted_img_decrypt_end(esp_decrypt_handle_t *ctx);
+esp_err_t esp_encrypted_img_decrypt_end(esp_decrypt_handle_t ctx);
 
 
 #ifdef __cplusplus

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -160,7 +160,7 @@ esp_decrypt_handle_t esp_encrypted_img_decrypt_start(const esp_decrypt_cfg_t *cf
     handle->rsa_len = cfg->rsa_pub_key_len;
     handle->state = ESP_PRE_ENC_IMG_READ_MAGIC;
 
-    esp_decrypt_handle_t *ctx = (esp_decrypt_handle_t *)handle;
+    esp_decrypt_handle_t ctx = (esp_decrypt_handle_t)handle;
     return ctx;
 
 failure:
@@ -280,7 +280,7 @@ static void read_and_cache_data(esp_encrypted_img_t *handle, pre_enc_decrypt_arg
     handle->binary_file_read += MIN(args->data_in_len - temp, data_left);
 }
 
-esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t *ctx, pre_enc_decrypt_arg_t *args)
+esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t ctx, pre_enc_decrypt_arg_t *args)
 {
     if (ctx == NULL || args == NULL || args->data_in == NULL) {
         return ESP_ERR_INVALID_ARG;
@@ -427,7 +427,7 @@ esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t *ctx, pre_enc_decr
     return ESP_OK;
 }
 
-esp_err_t esp_encrypted_img_decrypt_end(esp_decrypt_handle_t *ctx)
+esp_err_t esp_encrypted_img_decrypt_end(esp_decrypt_handle_t ctx)
 {
     if (ctx == NULL) {
         return ESP_ERR_INVALID_ARG;

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -402,7 +402,7 @@ esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t ctx, pre_enc_decry
             return ESP_ERR_NOT_FINISHED;
         }
     }
-/* falls through */
+    /* falls through */
     case ESP_PRE_ENC_DATA_DECODE_STATE:
         err = process_bin(handle, args, curr_index);
         return err;

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -402,7 +402,7 @@ esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t ctx, pre_enc_decry
             return ESP_ERR_NOT_FINISHED;
         }
     }
-    /* falls through */
+/* falls through */
     case ESP_PRE_ENC_DATA_DECODE_STATE:
         err = process_bin(handle, args, curr_index);
         return err;

--- a/esp_encrypted_img/test/test.c
+++ b/esp_encrypted_img/test/test.c
@@ -8,9 +8,9 @@
 
 #include "unity.h"
 #if __has_include("esp_random.h")
-  #include "esp_random.h"
+#include "esp_random.h"
 #else
-  #include "esp_system.h"
+#include "esp_system.h"
 #endif
 #include "esp_encrypted_img.h"
 

--- a/esp_encrypted_img/test/test.c
+++ b/esp_encrypted_img/test/test.c
@@ -7,7 +7,7 @@
 #include <freertos/FreeRTOS.h>
 
 #include "unity.h"
-#include "esp_system.h"
+#include "esp_random.h"
 #include "esp_encrypted_img.h"
 
 extern const uint8_t rsa_private_pem_start[] asm("_binary_test_rsa_private_key_pem_start");

--- a/esp_encrypted_img/test/test.c
+++ b/esp_encrypted_img/test/test.c
@@ -7,7 +7,11 @@
 #include <freertos/FreeRTOS.h>
 
 #include "unity.h"
-#include "esp_random.h"
+#if __has_include("esp_random.h")
+  #include "esp_random.h"
+#else
+  #include "esp_system.h"
+#endif
 #include "esp_encrypted_img.h"
 
 extern const uint8_t rsa_private_pem_start[] asm("_binary_test_rsa_private_key_pem_start");

--- a/esp_encrypted_img/test/test.c
+++ b/esp_encrypted_img/test/test.c
@@ -20,7 +20,7 @@ TEST_CASE("Sending all data at once", "[encrypted_img]")
         .rsa_pub_key = (char *)rsa_private_pem_start,
         .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
-    esp_decrypt_handle_t *ctx = esp_encrypted_img_decrypt_start(&cfg);
+    esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
 
     pre_enc_decrypt_arg_t *args = calloc(1, sizeof(pre_enc_decrypt_arg_t));
@@ -50,7 +50,7 @@ TEST_CASE("Sending 1 byte data at once", "[encrypted_img]")
         .rsa_pub_key = (char *)rsa_private_pem_start,
         .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
-    esp_decrypt_handle_t *ctx = esp_encrypted_img_decrypt_start(&cfg);
+    esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
 
     pre_enc_decrypt_arg_t *args = calloc(1, sizeof(pre_enc_decrypt_arg_t));
@@ -151,7 +151,7 @@ TEST_CASE("Invalid Magic", "[encrypted_img]")
         .rsa_pub_key = (char *)rsa_private_pem_start,
         .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
-    esp_decrypt_handle_t *ctx = esp_encrypted_img_decrypt_start(&cfg);
+    esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
 
     pre_enc_decrypt_arg_t *args = calloc(1, sizeof(pre_enc_decrypt_arg_t));
@@ -244,7 +244,7 @@ TEST_CASE("Invalid Image", "[encrypted_img]")
         .rsa_pub_key = (char *)rsa_private_pem_start,
         .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
-    esp_decrypt_handle_t *ctx = esp_encrypted_img_decrypt_start(&cfg);
+    esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
 
     pre_enc_decrypt_arg_t *args = calloc(1, sizeof(pre_enc_decrypt_arg_t));
@@ -272,7 +272,7 @@ TEST_CASE("Sending random size data at once", "[encrypted_img]")
         .rsa_pub_key = (char *)rsa_private_pem_start,
         .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
-    esp_decrypt_handle_t *ctx = esp_encrypted_img_decrypt_start(&cfg);
+    esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
 
     pre_enc_decrypt_arg_t *args = calloc(1, sizeof(pre_enc_decrypt_arg_t));

--- a/esp_encrypted_img/tools/esp_enc_img_gen.py
+++ b/esp_encrypted_img/tools/esp_enc_img_gen.py
@@ -56,7 +56,7 @@ def encrypt(input_file: str, rsa_key_file_name: str, output_file: str) -> None:
     encrypted_gcm_key = public_key.encrypt(gcm_key, padding.PKCS1v15())
     ciphertext, authtag = encrypt_binary(data, gcm_key, iv)
 
-    with open(output_file, 'ab') as image:
+    with open(output_file, 'wb') as image:
         image.write(esp_enc_img_magic.to_bytes(MAGIC_SIZE, 'little'))
         image.write((encrypted_gcm_key))
         image.write((iv))
@@ -98,7 +98,7 @@ def decrypt(input_file: str, rsa_key: str, output_file: str) -> None:
 
     decrypted_binary = decrypt_binary(enc_bin, auth, gcm_key, iv)
 
-    with open(output_file, 'ab') as file:
+    with open(output_file, 'wb') as file:
         file.write(decrypted_binary)
     print('Done')
 

--- a/libsodium/port/randombytes_esp32.c
+++ b/libsodium/port/randombytes_esp32.c
@@ -5,9 +5,9 @@
  */
 #include "sdkconfig.h"
 #if __has_include("esp_random.h")
-  #include "esp_random.h"
+#include "esp_random.h"
 #else
-  #include "esp_system.h"
+#include "esp_system.h"
 #endif
 #include "randombytes_internal.h"
 

--- a/libsodium/port/randombytes_esp32.c
+++ b/libsodium/port/randombytes_esp32.c
@@ -3,8 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "sdkconfig.h"
+#include "esp_random.h"
 #include "randombytes_internal.h"
-#include "esp_system.h"
 
 static const char *randombytes_esp32xx_implementation_name(void)
 {

--- a/libsodium/port/randombytes_esp32.c
+++ b/libsodium/port/randombytes_esp32.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "sdkconfig.h"
-#include "esp_random.h"
+#if __has_include("esp_random.h")
+  #include "esp_random.h"
+#else
+  #include "esp_system.h"
+#endif
 #include "randombytes_internal.h"
 
 static const char *randombytes_esp32xx_implementation_name(void)


### PR DESCRIPTION
Love the `esp_encrypted_img` component and I've been trying it out in a C++ ESP IDF project, 
this PR just addresses a few small issues I found.

The first is that the `esp_encrypted_img_<whateever>` functions currently accept `esp_decrypt_handle_t*` parameter rather than a `esp_decrypt_handle_t`.
This is not correct and produces compiler errors in C++ (`esp_decrypt_handle_t` is already the handle pointer) 

The next is that there seemed a bunch of unnecessary memory allocations with (`calloc()`), moving the `gcm_key` and `iv` directly into the `esp_encrypted_img_handle` only adds 48 bytes to it (and it is already dynamically allocated), 
and also simplifies the setup/error handling. Likewise, `got_auth` is only 16 bytes and can be allocated on the stack.

Finally, there was a possible memory leak of `rsa_pem`, if `esp_encrypted_img_decrypt_end()` was called without doing any decryption. This might happen if you wanted to cancel the decryption (e.g. a network error meant you could not download the firmware).