### PR TITLE
esp_encrypted_img: fix doc comments and readme formatting

### DIFF
--- a/esp_encrypted_img/README.md
+++ b/esp_encrypted_img/README.md
@@ -8,14 +8,17 @@ This component can help in integrating pre encrypted firmware in over-the-air up
 ## Image Format
 
 ![Image Format](https://raw.githubusercontent.com/espressif/idf-extra-components/master/esp_encrypted_img/image_format.png)
-    typedef struct {
-        char magic[4];
-        char enc_gcm[384];
-        char iv[16];
-        char bin_size[4];
-        char auth[16];
-        char extra_header[88];
-    } pre_enc_bin_header;
+
+```c
+typedef struct {
+    char magic[4];
+    char enc_gcm[384];
+    char iv[16];
+    char bin_size[4];
+    char auth[16];
+    char extra_header[88];
+} pre_enc_bin_header;
+```
 
 The above struct represents encrypted image header.
 

--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/include/esp_encrypted_img.h
+++ b/esp_encrypted_img/include/esp_encrypted_img.h
@@ -78,7 +78,7 @@ esp_decrypt_handle_t esp_encrypted_img_decrypt_start(const esp_decrypt_cfg_t *cf
 *
 * @note args->data_out must be freed after use provided args->data_out_len is greater than 0
 *
-* @param[in]        ctx                 pointer to esp_decrypt_handle_t
+* @param[in]        ctx                 esp_decrypt_handle_t handle
 * @param[in/out]    args                pointer to pre_enc_decrypt_arg_t
 *
 * @return
@@ -92,7 +92,7 @@ esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t ctx, pre_enc_decry
 /**
 * @brief  Clean-up decryption process.
 *
-* @param[in]   ctx   pointer to esp_decrypt_handle_t structure
+* @param[in]   ctx   esp_decrypt_handle_t handle
 *
 * @return
 *    - ESP_FAIL    On failure


### PR DESCRIPTION
Sorry for the extra PR, this is just a very quick follow up to update the doc comments to reflect the changes from #17 
(forgot to update them)

I've also fixed a formatting issue in the README