### PR TITLE
libsodium: Bump version to 1.0.19

### DIFF
--- a/libsodium/idf_component.yml
+++ b/libsodium/idf_component.yml
@@ -1,6 +1,6 @@
 
-version: "1.0.18"
-description: libsodium port to ESP32
+version: "1.0.19"
+description: libsodium port to ESP
 url: https://github.com/espressif/idf-extra-components/tree/master/libsodium
 dependencies:
   idf: ">=4.2"


### PR DESCRIPTION
This breaks alignment with upstream libsodium versioning.
But, libsodium doesn't use semantic versioning;
version 1.0.18 is being continuously updated. (https://download.libsodium.org/libsodium/releases/)

Closes #19 