### PR TITLE
esp_encrypted_img: make code const-correct

### DIFF
--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.1"
+version: "2.0.2"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/include/esp_encrypted_img.h
+++ b/esp_encrypted_img/include/esp_encrypted_img.h
@@ -50,7 +50,7 @@ typedef struct {
 } esp_decrypt_cfg_t;
 
 typedef struct {
-    char *data_in;          /*!< Pointer to data to be decrypted */
+    const char *data_in;    /*!< Pointer to data to be decrypted */
     size_t data_in_len;     /*!< Input data length */
     char *data_out;         /*!< Pointer to decrypted data */
     size_t data_out_len;    /*!< Output data length */

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -66,7 +66,7 @@ static uint32_t esp_enc_img_magic = 0x0788b6cf;
 
 typedef struct esp_encrypted_img_handle esp_encrypted_img_t;
 
-static int decipher_gcm_key(char *enc_gcm, esp_encrypted_img_t *handle)
+static int decipher_gcm_key(const char *enc_gcm, esp_encrypted_img_t *handle)
 {
     int ret = 1;
     size_t olen = 0;


### PR DESCRIPTION
Me again, `pre_enc_decrypt_arg_t.data_in` is not modified so can be `const`.

Without this change in C++ you have to add a bunch of `const_cast<char*>` to workaround this, if your inputs are marked const. 
