### PR TITLE
`libsodium`: Added forward compatibility with `mbedtls-3.x`

### DIFF
--- a/libsodium/idf_component.yml
+++ b/libsodium/idf_component.yml
@@ -1,5 +1,5 @@
 
-version: "1.0.19"
+version: "1.0.20"
 description: libsodium port to ESP
 url: https://github.com/espressif/idf-extra-components/tree/master/libsodium
 dependencies:

--- a/libsodium/port/crypto_hash_mbedtls/crypto_hash_sha256_mbedtls.c
+++ b/libsodium/port/crypto_hash_mbedtls/crypto_hash_sha256_mbedtls.c
@@ -4,6 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mbedtls/version.h>
+
+/* Keep forward-compatibility with Mbed TLS 3.x */
+#if (MBEDTLS_VERSION_NUMBER < 0x03000000)
+#define MBEDTLS_2_X_COMPAT
+#else /* !(MBEDTLS_VERSION_NUMBER < 0x03000000) */
+/* Macro wrapper for struct's private members */
+#ifndef MBEDTLS_ALLOW_PRIVATE_ACCESS
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+#endif /* MBEDTLS_ALLOW_PRIVATE_ACCESS */
+#endif /* !(MBEDTLS_VERSION_NUMBER < 0x03000000) */
+
 #include "crypto_hash_sha256.h"
 #include "mbedtls/sha256.h"
 #include <string.h>
@@ -55,7 +67,11 @@ crypto_hash_sha256_init(crypto_hash_sha256_state *state)
 {
     mbedtls_sha256_context ctx;
     mbedtls_sha256_init(&ctx);
+#ifdef MBEDTLS_2_X_COMPAT
     int ret = mbedtls_sha256_starts_ret(&ctx, 0);
+#else
+    int ret = mbedtls_sha256_starts(&ctx, 0);
+#endif /* MBEDTLS_2_X_COMPAT */
     if (ret != 0) {
         return ret;
     }
@@ -69,7 +85,11 @@ crypto_hash_sha256_update(crypto_hash_sha256_state *state,
 {
     mbedtls_sha256_context ctx;
     sha256_libsodium_to_mbedtls(&ctx, state);
+#ifdef MBEDTLS_2_X_COMPAT
     int ret = mbedtls_sha256_update_ret(&ctx, in, inlen);
+#else
+    int ret = mbedtls_sha256_update(&ctx, in, inlen);
+#endif /* MBEDTLS_2_X_COMPAT */
     if (ret != 0) {
         return ret;
     }
@@ -82,12 +102,20 @@ crypto_hash_sha256_final(crypto_hash_sha256_state *state, unsigned char *out)
 {
     mbedtls_sha256_context ctx;
     sha256_libsodium_to_mbedtls(&ctx, state);
+#ifdef MBEDTLS_2_X_COMPAT
     return mbedtls_sha256_finish_ret(&ctx, out);
+#else
+    return mbedtls_sha256_finish(&ctx, out);
+#endif /* MBEDTLS_2_X_COMPAT */
 }
 
 int
 crypto_hash_sha256(unsigned char *out, const unsigned char *in,
                    unsigned long long inlen)
 {
+#ifdef MBEDTLS_2_X_COMPAT
     return mbedtls_sha256_ret(in, inlen, out, 0);
+#else
+    return mbedtls_sha256(in, inlen, out, 0);
+#endif /* MBEDTLS_2_X_COMPAT */
 }

--- a/libsodium/port/crypto_hash_mbedtls/crypto_hash_sha512_mbedtls.c
+++ b/libsodium/port/crypto_hash_mbedtls/crypto_hash_sha512_mbedtls.c
@@ -4,6 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mbedtls/version.h>
+
+/* Keep forward-compatibility with Mbed TLS 3.x */
+#if (MBEDTLS_VERSION_NUMBER < 0x03000000)
+#define MBEDTLS_2_X_COMPAT
+#else /* !(MBEDTLS_VERSION_NUMBER < 0x03000000) */
+/* Macro wrapper for struct's private members */
+#ifndef MBEDTLS_ALLOW_PRIVATE_ACCESS
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+#endif /* MBEDTLS_ALLOW_PRIVATE_ACCESS */
+#endif /* !(MBEDTLS_VERSION_NUMBER < 0x03000000) */
+
 #include "crypto_hash_sha512.h"
 #include "mbedtls/sha512.h"
 #include <string.h>
@@ -59,7 +71,11 @@ crypto_hash_sha512_init(crypto_hash_sha512_state *state)
 {
     mbedtls_sha512_context ctx;
     mbedtls_sha512_init(&ctx);
+#ifdef MBEDTLS_2_X_COMPAT
     int ret = mbedtls_sha512_starts_ret(&ctx, 0);
+#else
+    int ret = mbedtls_sha512_starts(&ctx, 0);
+#endif /* MBEDTLS_2_X_COMPAT */
     if (ret != 0) {
         return ret;
     }
@@ -73,7 +89,11 @@ crypto_hash_sha512_update(crypto_hash_sha512_state *state,
 {
     mbedtls_sha512_context ctx;
     sha512_libsodium_to_mbedtls(&ctx, state);
+#ifdef MBEDTLS_2_X_COMPAT
     int ret = mbedtls_sha512_update_ret(&ctx, in, inlen);
+#else
+    int ret = mbedtls_sha512_update(&ctx, in, inlen);
+#endif /* MBEDTLS_2_X_COMPAT */
     if (ret != 0) {
         return ret;
     }
@@ -86,12 +106,20 @@ crypto_hash_sha512_final(crypto_hash_sha512_state *state, unsigned char *out)
 {
     mbedtls_sha512_context ctx;
     sha512_libsodium_to_mbedtls(&ctx, state);
+#ifdef MBEDTLS_2_X_COMPAT
     return mbedtls_sha512_finish_ret(&ctx, out);
+#else
+    return mbedtls_sha512_finish(&ctx, out);
+#endif /* MBEDTLS_2_X_COMPAT */
 }
 
 int
 crypto_hash_sha512(unsigned char *out, const unsigned char *in,
                    unsigned long long inlen)
 {
+#ifdef MBEDTLS_2_X_COMPAT
     return mbedtls_sha512_ret(in, inlen, out, 0);
+#else
+    return mbedtls_sha512(in, inlen, out, 0);
+#endif /* MBEDTLS_2_X_COMPAT */
 }


### PR DESCRIPTION
- Added `MBEDTLS_ALLOW_PRIVATE_ACCESS` to access private struct members wherever necessary (keeping backward compatibility)
- Updated deprecated functions from hashing module (E.g. `mbedtls_sha256_starts_ret()` -> `mbedtls_sha256_starts()`)