### PR TITLE
ci: add static analysis with clang-tidy

### DIFF
--- a/.github/filter_sarif.py
+++ b/.github/filter_sarif.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import json
+import typing
+
+
+def process(in_file: typing.TextIO, out_file: typing.TextIO, include_prefix_list: typing.List[str]) -> None:
+    in_json = json.load(in_file)
+    if len(in_json['runs']) != 1:
+        raise NotImplementedError('Only 1 run is supported')
+    in_results = in_json['runs'][0]['results']
+    out_results = []
+    for result in in_results:
+        locations = result['locations']
+        if len(locations) != 1:
+            raise NotImplementedError('Only 1 location is supported')
+        artifact_location = locations[0]['physicalLocation']['artifactLocation']
+        uri = artifact_location['uri']
+        new_uri = None
+        for include_prefix in include_prefix_list:
+            if uri.startswith(include_prefix):
+                new_uri = uri.replace(include_prefix, '')
+                break
+        if not new_uri:
+            continue
+        new_result = copy.deepcopy(result)
+        new_result['locations'][0]['physicalLocation']['artifactLocation']['uri'] = new_uri
+        out_results.append(new_result)
+
+    out_json = copy.deepcopy(in_json)
+    out_json['runs'][0]['results'] = out_results
+    json.dump(out_json, out_file, indent=True)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o', '--output', type=argparse.FileType('w'), help='Output filtered SARIF file')
+    parser.add_argument('--include-prefix', required=True, action='append',
+                        help='File prefix for source code to include in analysis')
+    parser.add_argument('input_file', type=argparse.FileType('r'), help='Input SARIF file')
+    args = parser.parse_args()
+    process(args.input_file, args.output, args.include_prefix)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,51 @@
+name: Run clang-tidy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Run clang-tidy
+    runs-on: ubuntu-20.04
+    container: espressif/idf:latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - name: Run code analysis
+        shell: bash
+        env:
+          IDF_TOOLCHAIN: clang
+          IDF_TARGET: esp32
+        working-directory: test_app
+        run: |
+          ${IDF_PATH}/tools/idf_tools.py --non-interactive install xtensa-clang
+          . ${IDF_PATH}/export.sh
+          which -a clang-tidy || true
+          pip install pyclang codereport
+          curl -sSL https://raw.githubusercontent.com/espressif/llvm-project/xtensa_release_12.0.1/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -o run-clang-tidy.py
+          chmod +x run-clang-tidy.py
+          curl -sSL https://github.com/psastras/sarif-rs/releases/download/clang-tidy-sarif-latest/clang-tidy-sarif-x86_64-unknown-linux-gnu -o clang-tidy-sarif
+          chmod +x clang-tidy-sarif
+          export PATH=$PWD:$PATH
+          idf.py clang-check
+          idf.py clang-html-report
+          ./clang-tidy-sarif -o results.sarif.raw warnings.txt
+          python3 $GITHUB_WORKSPACE/.github/filter_sarif.py -o results.sarif --include-prefix ${GITHUB_WORKSPACE}/test_app/managed_components/espressif__  --include-prefix ${GITHUB_WORKSPACE}/ results.sarif.raw
+          cp results.sarif ../
+          cp results.sarif.raw ../
+          cp warnings.txt ../
+      - uses: actions/upload-artifact@v2
+        with:
+          path: |
+            warnings.txt
+            results.sarif
+            results.sarif.raw
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif
+          category: clang-tidy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![Build and Run Test Application](https://github.com/espressif/idf-extra-components/actions/workflows/build_and_run_test_app.yml/badge.svg)](https://github.com/espressif/idf-extra-components/actions/workflows/build_and_run_test_app.yml)
+[![Build and Run Test Application](https://github.com/espressif/idf-extra-components/actions/workflows/build_and_run_test_app.yml/badge.svg?branch=master)](https://github.com/espressif/idf-extra-components/actions/workflows/build_and_run_test_app.yml)
+[![Clang-Tidy](https://github.com/espressif/idf-extra-components/actions/workflows/clang-tidy.yml/badge.svg?branch=master)](https://github.com/espressif/idf-extra-components/security/code-scanning?query=is%3Aopen+branch%3Amaster)
 
 # Espressif IDF Extra Components
 


### PR DESCRIPTION
One of the options to address https://github.com/espressif/idf-extra-components/issues/25.

1. https://github.com/espressif/clang-tidy-runner is used to run clang-tidy on the test app
2. Resulting warnings.txt file is converted to SARIF format using https://github.com/psastras/sarif-rs/tree/main/clang-tidy-sarif
3. At this point, the issues list contains also warnings reported for ESP-IDF source code. We use `filter_sarif.py` to include only issues reported for the source code from this repository. At the same time, we convert absolute paths to relative, which helps Github associate the issue with the file in the repository.
4. Resulting filtered SARIF file is uploaded to Github as Code Quality result.

Note that the CI job takes about 12 minutes to run. Not sure if it's okay to run it for PRs, or we should only run it for the master branch.

The results look as follows:

* open issues: https://github.com/igrr/idf-extra-components/security/code-scanning
* example if the file is in idf-extra-components repo: https://github.com/igrr/idf-extra-components/security/code-scanning/486
* example if the file is in a submodule: https://github.com/igrr/idf-extra-components/security/code-scanning/485
* analysis results for this PR: https://github.com/espressif/idf-extra-components/security/code-scanning?query=is%3Aopen+pr%3A28+

Future work: https://github.com/espressif/clang-tidy-runner/issues/7, https://github.com/espressif/clang-tidy-runner/issues/9