### PR TITLE
ci: Check runner labels

### DIFF
--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -74,7 +74,7 @@ jobs:
         exclude:
           - idf_ver: "release-v4.3"
             idf_target: esp32s3 # ESP32S3 support started with version 4.4
-    runs-on: [self-hosted, linux, docker, esp32] # Unfortunately `${{ matrix.idf_target }}` is not accepted here
+    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}"]
     container:
       image: python:3.7-buster
       options: --privileged # Privileged mode has access to serial ports


### PR DESCRIPTION
Fix the initial slack off solution of `runs-on` tags.

This fixes the failing nightly tests.