### PR TITLE
`sh2lib`: Update deprecated `esp_tls` API

### DIFF
--- a/sh2lib/idf_component.yml
+++ b/sh2lib/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: HTTP2 TLS Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/sh2lib
 dependencies:


### PR DESCRIPTION
- Update deprecated API `esp_tls_conn_http_new` with `esp_tls_conn_http_new_sync`
- __Note:__ The new API is merged in ESP-IDF `master` at https://github.com/espressif/esp-idf/commit/864c59c091f0711d0f7062be919d1e8aae5ec13e.