### PR TITLE
sh2lib: Bump version to 1.0.1

### DIFF
--- a/sh2lib/idf_component.yml
+++ b/sh2lib/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: HTTP2 TLS Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/sh2lib
 dependencies:

--- a/sh2lib/sh2lib.c
+++ b/sh2lib/sh2lib.c
@@ -242,6 +242,7 @@ int sh2lib_connect(struct sh2lib_config_t *cfg, struct sh2lib_handle *hd)
         .alpn_protos = proto,
         .cacert_buf = cfg->cacert_buf,
         .cacert_bytes = cfg->cacert_bytes,
+        .crt_bundle_attach = cfg->crt_bundle_attach,
         .non_block = true,
         .timeout_ms = 10 * 1000,
     };

--- a/sh2lib/sh2lib.h
+++ b/sh2lib/sh2lib.h
@@ -41,6 +41,9 @@ struct sh2lib_config_t {
     const char *uri;                    /*!< Pointer to the URI that should be connected to */
     const unsigned char *cacert_buf;    /*!< Pointer to the buffer containing CA certificate */
     unsigned int cacert_bytes;          /*!< Size of the CA certifiacte pointed by cacert_buf */
+    esp_err_t (*crt_bundle_attach)(void *conf);
+    /*!< Function pointer to esp_crt_bundle_attach. Enables the use of certification
+         bundle for server verification, must be enabled in menuconfig */
 };
 
 /** Flag indicating receive stream is reset */


### PR DESCRIPTION
Changes:
1) Enabled support for esp_crt_bundle with esp_tls.