### PR TITLE
ci: clang-tidy fixes

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -25,16 +25,15 @@ jobs:
           ${IDF_PATH}/tools/idf_tools.py --non-interactive install xtensa-clang
           . ${IDF_PATH}/export.sh
           which -a clang-tidy || true
-          pip install pyclang codereport
+          pip install pyclang~=0.2.0
           curl -sSL https://raw.githubusercontent.com/espressif/llvm-project/xtensa_release_12.0.1/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -o run-clang-tidy.py
           chmod +x run-clang-tidy.py
           curl -sSL https://github.com/psastras/sarif-rs/releases/download/clang-tidy-sarif-latest/clang-tidy-sarif-x86_64-unknown-linux-gnu -o clang-tidy-sarif
           chmod +x clang-tidy-sarif
           export PATH=$PWD:$PATH
-          idf.py clang-check
-          idf.py clang-html-report
+          idf.py clang-check --include-paths $GITHUB_WORKSPACE --exclude-paths $PWD
           ./clang-tidy-sarif -o results.sarif.raw warnings.txt
-          python3 $GITHUB_WORKSPACE/.github/filter_sarif.py -o results.sarif --include-prefix ${GITHUB_WORKSPACE}/test_app/managed_components/espressif__  --include-prefix ${GITHUB_WORKSPACE}/ results.sarif.raw
+          python3 $GITHUB_WORKSPACE/.github/filter_sarif.py -o results.sarif --include-prefix ${GITHUB_WORKSPACE}/ results.sarif.raw
           cp results.sarif ../
           cp results.sarif.raw ../
           cp warnings.txt ../


### PR DESCRIPTION
- upgrade clang-tidy-runner to 0.2.0.
- use new '--include-paths' and '--exclude-paths' arguments of
  clang-tidy-runner to limit the issues reported.
- don't install codereport and don't build an HTML report, fixing
  the Jinja2 version incompatibility issue.