### PR TITLE
ci: Fix IDF v4.3 build

### DIFF
--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v1
         with:
           submodules: 'true'
       - name: Build Test Application


### PR DESCRIPTION
espressif/idf/release-v4.3 branch reverted newer (>2.17) git version. So we need to use GH action checkout @v1 