### PR TITLE
[Test] coap_config_posix.h: Set up defines for correct mutex usage

### DIFF
--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.0"
+version: "4.3.0~1"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:

--- a/coap/port/include/coap_config_posix.h
+++ b/coap/port/include/coap_config_posix.h
@@ -30,6 +30,8 @@
 #define HAVE_NETDB_H
 #define HAVE_NETINET_IN_H
 #define HAVE_STRUCT_CMSGHDR
+#define HAVE_PTHREAD_H
+#define HAVE_PTHREAD_MUTEX_LOCK
 #define COAP_DISABLE_TCP 0
 
 #define ipi_spec_dst ipi_addr


### PR DESCRIPTION
if COAP_CONSTRAINED_STACK is defined (is for esp-idf), the mutexes set up
to protect the critical sections were not working as expected and were just
dummy entries.

Use the pthread_ version of the mutex instead by defining HAVE_PTHREAD_H
and HAVE_PTHREAD_MUTEX_LOCK.