### PR TITLE
Ignore format warnings

### DIFF
--- a/coap/CMakeLists.txt
+++ b/coap/CMakeLists.txt
@@ -42,3 +42,4 @@ idf_component_register(SRCS "${srcs}"
 #
 # TODO: find a way to move this to a port header
 target_compile_definitions(${COMPONENT_LIB} PUBLIC WITH_POSIX)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.0~1"
+version: "4.3.0~2"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:

--- a/pcap/CMakeLists.txt
+++ b/pcap/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS "src/pcap.c"
                        INCLUDE_DIRS "include")
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/pcap/idf_component.yml
+++ b/pcap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: PCAP file writer
 url: https://github.com/espressif/idf-extra-components/tree/master/pcap
 dependencies:

--- a/sh2lib/CMakeLists.txt
+++ b/sh2lib/CMakeLists.txt
@@ -2,3 +2,4 @@ idf_component_register(SRCS "sh2lib.c"
                     INCLUDE_DIRS .
                     REQUIRES http_parser
                     PRIV_REQUIRES lwip esp-tls)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")

--- a/sh2lib/idf_component.yml
+++ b/sh2lib/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2"
+version: "1.0.3"
 description: HTTP2 TLS Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/sh2lib
 dependencies:


### PR DESCRIPTION
This is the first step to fix IDF's format warnings.

IDF has globally enabled compiler option `-Wno-format`. The fix will be in three steps:
1. add `-Wno-format` to affected components
2. disable the global option  `-Wno-format`
3. fix format warnings for each component