### PR TITLE
coap: ignore format warnings

### DIFF
--- a/coap/CMakeLists.txt
+++ b/coap/CMakeLists.txt
@@ -37,4 +37,5 @@ set(srcs
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS "${include_dirs}"
                     REQUIRES lwip mbedtls)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")
 

--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.0~3"
+version: "4.3.0~4"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:


### PR DESCRIPTION
Added `-Wno-format` argument which was accidentally removed with https://github.com/espressif/idf-extra-components/pull/75

See https://github.com/espressif/idf-extra-components/pull/64 for more details