### PR TITLE
coap: Updated submodule to fix Mbed TLS `v3.2.1`-related errors

### DIFF
--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.0~4"
+version: "4.3.1-rc.1"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:

--- a/coap/port/include/coap_config_posix.h
+++ b/coap/port/include/coap_config_posix.h
@@ -47,7 +47,7 @@ struct in6_pktinfo {
 #define IPV6_PKTINFO IPV6_CHECKSUM
 
 #define PACKAGE_NAME "libcoap-posix"
-#define PACKAGE_VERSION "4.3.0"
+#define PACKAGE_VERSION "4.3.1-rc1"
 
 #ifdef CONFIG_MBEDTLS_TLS_ENABLED
 #define HAVE_MBEDTLS


### PR DESCRIPTION
- Updated submodule to fix Mbed TLS v3.2.1-related build errors
- Upstream PR: https://github.com/obgm/libcoap/pull/893