### PR TITLE
ci: build with extra warnings and -Werror

### DIFF
--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -30,6 +30,9 @@ jobs:
         working-directory: test_app
         run: |
           . ${IDF_PATH}/export.sh
+          export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
+          export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
+          export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
           idf.py build
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_test_app_usb.yml
+++ b/.github/workflows/build_test_app_usb.yml
@@ -25,6 +25,9 @@ jobs:
         working-directory: usb/test_app
         run: |
           . ${IDF_PATH}/export.sh
+          export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
+          export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
+          export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
           idf.py build
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Build with -Werror to prevent new warnings from being introduced. The set of extra warning flags matches ESP-IDF internal CI builds.

- [x] build passes with extra flags
- [x] build fails when a warning is added (https://github.com/espressif/idf-extra-components/runs/7720984491?check_suite_focus=true#step:4:1252)

Closes https://github.com/espressif/idf-extra-components/issues/79