### PR TITLE
bdc_motor: added BDC motor control library

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Upload components to component service
         uses: espressif/upload-components-ci-action@v1
         with:
-          directories: "cbor;jsmn;libsodium;pid_ctrl;qrcode;nghttp;sh2lib;expat;esp_encrypted_img;coap;pcap;json_generator;json_parser;usb/usb_host_cdc_acm;usb/usb_host_msc"
+          directories: "bdc_motor;cbor;jsmn;libsodium;pid_ctrl;qrcode;nghttp;sh2lib;expat;esp_encrypted_img;coap;pcap;json_generator;json_parser;usb/usb_host_cdc_acm;usb/usb_host_msc"
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/bdc_motor/CMakeLists.txt
+++ b/bdc_motor/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(srcs "src/bdc_motor.c")
+
+if(CONFIG_SOC_MCPWM_SUPPORTED)
+    list(APPEND srcs "src/bdc_motor_mcpwm_impl.c")
+endif()
+
+idf_component_register(SRCS ${srcs}
+                       INCLUDE_DIRS "include" "interface"
+                       PRIV_REQUIRES "driver")

--- a/bdc_motor/LICENSE
+++ b/bdc_motor/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/bdc_motor/README.md
+++ b/bdc_motor/README.md
@@ -1,0 +1,5 @@
+# Brushed DC Motor Control
+
+This directory contains an implementation for Brushed DC Motor by different peripherals. Currently only MCPWM is supported as the BDC motor backend.
+
+To learn more about how to use this component, please check API Documentation from header file [bdc_motor.h](./include/bdc_motor.h).

--- a/bdc_motor/idf_component.yml
+++ b/bdc_motor/idf_component.yml
@@ -1,0 +1,5 @@
+version: "0.1.0"
+description: Brushed DC Motor Control Driver
+url: https://github.com/espressif/idf-extra-components/tree/master/bdc_motor
+dependencies:
+  idf: ">=5.0"

--- a/bdc_motor/include/bdc_motor.h
+++ b/bdc_motor/include/bdc_motor.h
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Brushed DC Motor handle
+ */
+typedef struct bdc_motor_t *bdc_motor_handle_t;
+
+/**
+ * @brief Enable BDC motor
+ *
+ * @param motor: BDC Motor handle
+ *
+ * @return
+ *      - ESP_OK: Enable motor successfully
+ *      - ESP_ERR_INVALID_ARG: Enable motor failed because of invalid parameters
+ *      - ESP_FAIL: Enable motor failed because other error occurred
+ */
+esp_err_t bdc_motor_enable(bdc_motor_handle_t motor);
+
+/**
+ * @brief Disable BDC motor
+ *
+ * @param motor: BDC Motor handle
+ *
+ * @return
+ *      - ESP_OK: Disable motor successfully
+ *      - ESP_ERR_INVALID_ARG: Disable motor failed because of invalid parameters
+ *      - ESP_FAIL: Disable motor failed because other error occurred
+ */
+esp_err_t bdc_motor_disable(bdc_motor_handle_t motor);
+
+/**
+ * @brief Set speed for bdc motor
+ *
+ * @param motor: BDC Motor handle
+ * @param speed: BDC speed
+ *
+ * @return
+ *      - ESP_OK: Set motor speed successfully
+ *      - ESP_ERR_INVALID_ARG: Set motor speed failed because of invalid parameters
+ *      - ESP_FAIL: Set motor speed failed because other error occurred
+ */
+esp_err_t bdc_motor_set_speed(bdc_motor_handle_t motor, uint32_t speed);
+
+/**
+ * @brief Forward BDC motor
+ *
+ * @param motor: BDC Motor handle
+ *
+ * @return
+ *      - ESP_OK: Forward motor successfully
+ *      - ESP_FAIL: Forward motor failed because some other error occurred
+ */
+esp_err_t bdc_motor_forward(bdc_motor_handle_t motor);
+
+/**
+ * @brief Reverse BDC Motor
+ *
+ * @param strip: BDC Motor handle
+ *
+ * @return
+ *      - ESP_OK: Reverse motor successfully
+ *      - ESP_FAIL: Reverse motor failed because some other error occurred
+ */
+esp_err_t bdc_motor_reverse(bdc_motor_handle_t motor);
+
+/**
+ * @brief Stop motor in a coast way (a.k.a Fast Decay)
+ *
+ * @param motor: BDC Motor handle
+ *
+ * @return
+ *      - ESP_OK: Stop motor successfully
+ *      - ESP_FAIL: Stop motor failed because some other error occurred
+ */
+esp_err_t bdc_motor_coast(bdc_motor_handle_t motor);
+
+/**
+ * @brief Stop motor in a brake way (a.k.a Slow Decay)
+ *
+ * @param motor: BDC Motor handle
+ *
+ * @return
+ *      - ESP_OK: Stop motor successfully
+ *      - ESP_FAIL: Stop motor failed because some other error occurred
+ */
+esp_err_t bdc_motor_brake(bdc_motor_handle_t motor);
+
+/**
+ * @brief Free BDC Motor resources
+ *
+ * @param strip: BDC Motor handle
+ *
+ * @return
+ *      - ESP_OK: Free resources successfully
+ *      - ESP_FAIL: Free resources failed because error occurred
+ */
+esp_err_t bdc_motor_del(bdc_motor_handle_t motor);
+
+/**
+ * @brief BDC Motor Configuration
+ */
+typedef struct {
+    uint32_t pwma_gpio_num; /*!< BDC Motor PWM A gpio number */
+    uint32_t pwmb_gpio_num; /*!< BDC Motor PWM B gpio number */
+    uint32_t pwm_freq_hz;   /*!< PWM frequency, in Hz */
+} bdc_motor_config_t;
+
+/**
+ * @brief BDC Motor MCPWM specific configuration
+ */
+typedef struct {
+    int group_id;           /*!< MCPWM group number */
+    uint32_t resolution_hz; /*!< MCPWM timer resolution */
+} bdc_motor_mcpwm_config_t;
+
+/**
+ * @brief Create BDC Motor based on MCPWM peripheral
+ *
+ * @param motor_config: BDC Motor configuration
+ * @param mcpwm_config: MCPWM specific configuration
+ * @param ret_motor Returned BDC Motor handle
+ * @return
+ *      - ESP_OK: Create BDC Motor handle successfully
+ *      - ESP_ERR_INVALID_ARG: Create BDC Motor handle failed because of invalid argument
+ *      - ESP_ERR_NO_MEM: Create BDC Motor handle failed because of out of memory
+ *      - ESP_FAIL: Create BDC Motor handle failed because some other error
+ */
+esp_err_t bdc_motor_new_mcpwm_device(const bdc_motor_config_t *motor_config, const bdc_motor_mcpwm_config_t *mcpwm_config, bdc_motor_handle_t *ret_motor);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bdc_motor/interface/bdc_motor_interface.h
+++ b/bdc_motor/interface/bdc_motor_interface.h
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct bdc_motor_t bdc_motor_t; /*!< Type of BDC motor */
+
+/**
+ * @brief BDC motor interface definition
+ */
+struct bdc_motor_t {
+    /**
+     * @brief Enable BDC motor
+     *
+     * @param motor: BDC Motor handle
+     *
+     * @return
+     *      - ESP_OK: Enable motor successfully
+     *      - ESP_ERR_INVALID_ARG: Enable motor failed because of invalid parameters
+     *      - ESP_FAIL: Enable motor failed because other error occurred
+     */
+    esp_err_t (*enable)(bdc_motor_t *motor);
+
+    /**
+     * @brief Disable BDC motor
+     *
+     * @param motor: BDC Motor handle
+     *
+     * @return
+     *      - ESP_OK: Disable motor successfully
+     *      - ESP_ERR_INVALID_ARG: Disable motor failed because of invalid parameters
+     *      - ESP_FAIL: Disable motor failed because other error occurred
+     */
+    esp_err_t (*disable)(bdc_motor_t *motor);
+
+    /**
+     * @brief Set speed for bdc motor
+     *
+     * @param motor: BDC Motor handle
+     * @param speed: BDC speed
+     *
+     * @return
+     *      - ESP_OK: Set motor speed successfully
+     *      - ESP_ERR_INVALID_ARG: Set motor speed failed because of invalid parameters
+     *      - ESP_FAIL: Set motor speed failed because other error occurred
+     */
+    esp_err_t (*set_speed)(bdc_motor_t *motor, uint32_t speed);
+
+    /**
+     * @brief Forward BDC motor
+     *
+     * @param motor: BDC Motor handle
+     *
+     * @return
+     *      - ESP_OK: Forward motor successfully
+     *      - ESP_FAIL: Forward motor failed because some other error occurred
+     */
+    esp_err_t (*forward)(bdc_motor_t *motor);
+
+    /**
+     * @brief Reverse BDC Motor
+     *
+     * @param motor: BDC Motor handle
+     *
+     * @return
+     *      - ESP_OK: Reverse motor successfully
+     *      - ESP_FAIL: Reverse motor failed because some other error occurred
+     */
+    esp_err_t (*reverse)(bdc_motor_t *motor);
+
+    /**
+     * @brief Stop motor in a coast way (a.k.a Fast Decay)
+     *
+     * @param motor: BDC Motor handle
+     *
+     * @return
+     *      - ESP_OK: Stop motor successfully
+     *      - ESP_FAIL: Stop motor failed because some other error occurred
+     */
+    esp_err_t (*coast)(bdc_motor_t *motor);
+
+    /**
+     * @brief Stop motor in a brake way (a.k.a Slow Decay)
+     *
+     * @param motor: BDC Motor handle
+     *
+     * @return
+     *      - ESP_OK: Stop motor successfully
+     *      - ESP_FAIL: Stop motor failed because some other error occurred
+     */
+    esp_err_t (*brake)(bdc_motor_t *motor);
+
+    /**
+     * @brief Free BDC Motor handle resources
+     *
+     * @param motor: BDC Motor handle
+     *
+     * @return
+     *      - ESP_OK: Free resources successfully
+     *      - ESP_FAIL: Free resources failed because error occurred
+     */
+    esp_err_t (*del)(bdc_motor_t *motor);
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/bdc_motor/src/bdc_motor.c
+++ b/bdc_motor/src/bdc_motor.c
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <sys/cdefs.h>
+#include "esp_log.h"
+#include "esp_check.h"
+#include "bdc_motor.h"
+#include "bdc_motor_interface.h"
+
+static const char *TAG = "bdc_motor";
+
+esp_err_t bdc_motor_enable(bdc_motor_handle_t motor)
+{
+    ESP_RETURN_ON_FALSE(motor, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return motor->enable(motor);
+}
+
+esp_err_t bdc_motor_disable(bdc_motor_handle_t motor)
+{
+    ESP_RETURN_ON_FALSE(motor, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return motor->disable(motor);
+}
+
+esp_err_t bdc_motor_set_speed(bdc_motor_handle_t motor, uint32_t speed)
+{
+    ESP_RETURN_ON_FALSE(motor, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return motor->set_speed(motor, speed);
+}
+
+esp_err_t bdc_motor_forward(bdc_motor_handle_t motor)
+{
+    ESP_RETURN_ON_FALSE(motor, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return motor->forward(motor);
+}
+
+esp_err_t bdc_motor_reverse(bdc_motor_handle_t motor)
+{
+    ESP_RETURN_ON_FALSE(motor, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return motor->reverse(motor);
+}
+
+esp_err_t bdc_motor_coast(bdc_motor_handle_t motor)
+{
+    ESP_RETURN_ON_FALSE(motor, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return motor->coast(motor);
+}
+
+esp_err_t bdc_motor_brake(bdc_motor_handle_t motor)
+{
+    ESP_RETURN_ON_FALSE(motor, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return motor->brake(motor);
+}
+
+esp_err_t bdc_motor_del(bdc_motor_handle_t motor)
+{
+    ESP_RETURN_ON_FALSE(motor, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return motor->del(motor);
+}

--- a/bdc_motor/src/bdc_motor_mcpwm_impl.c
+++ b/bdc_motor/src/bdc_motor_mcpwm_impl.c
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <sys/cdefs.h>
+#include "esp_log.h"
+#include "esp_check.h"
+#include "driver/mcpwm_prelude.h"
+#include "bdc_motor.h"
+#include "bdc_motor_interface.h"
+
+static const char *TAG = "bdc_motor_mcpwm";
+
+typedef struct {
+    bdc_motor_t base;
+    mcpwm_timer_handle_t timer;
+    mcpwm_oper_handle_t operator;
+    mcpwm_cmpr_handle_t cmpa;
+    mcpwm_cmpr_handle_t cmpb;
+    mcpwm_gen_handle_t gena;
+    mcpwm_gen_handle_t genb;
+} bdc_motor_mcpwm_obj;
+
+static esp_err_t bdc_motor_mcpwm_set_speed(bdc_motor_t *motor, uint32_t speed)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = __containerof(motor, bdc_motor_mcpwm_obj, base);
+    ESP_RETURN_ON_ERROR(mcpwm_comparator_set_compare_value(mcpwm_motor->cmpa, speed), TAG, "set compare value failed");
+    ESP_RETURN_ON_ERROR(mcpwm_comparator_set_compare_value(mcpwm_motor->cmpb, speed), TAG, "set compare value failed");
+    return ESP_OK;
+}
+
+static esp_err_t bdc_motor_mcpwm_enable(bdc_motor_t *motor)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = __containerof(motor, bdc_motor_mcpwm_obj, base);
+    ESP_RETURN_ON_ERROR(mcpwm_timer_enable(mcpwm_motor->timer), TAG, "enable timer failed");
+    ESP_RETURN_ON_ERROR(mcpwm_timer_start_stop(mcpwm_motor->timer, MCPWM_TIMER_START_NO_STOP), TAG, "start timer failed");
+    return ESP_OK;
+}
+
+static esp_err_t bdc_motor_mcpwm_disable(bdc_motor_t *motor)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = __containerof(motor, bdc_motor_mcpwm_obj, base);
+    ESP_RETURN_ON_ERROR(mcpwm_timer_start_stop(mcpwm_motor->timer, MCPWM_TIMER_STOP_EMPTY), TAG, "stop timer failed");
+    ESP_RETURN_ON_ERROR(mcpwm_timer_disable(mcpwm_motor->timer), TAG, "disable timer failed");
+    return ESP_OK;
+}
+
+static esp_err_t bdc_motor_mcpwm_forward(bdc_motor_t *motor)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = __containerof(motor, bdc_motor_mcpwm_obj, base);
+    ESP_RETURN_ON_ERROR(mcpwm_generator_set_force_level(mcpwm_motor->gena, -1, true), TAG, "disable force level for gena failed");
+    ESP_RETURN_ON_ERROR(mcpwm_generator_set_force_level(mcpwm_motor->genb, 0, true), TAG, "set force level for genb failed");
+    return ESP_OK;
+}
+
+static esp_err_t bdc_motor_mcpwm_reverse(bdc_motor_t *motor)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = __containerof(motor, bdc_motor_mcpwm_obj, base);
+    ESP_RETURN_ON_ERROR(mcpwm_generator_set_force_level(mcpwm_motor->genb, -1, true), TAG, "disable force level for genb failed");
+    ESP_RETURN_ON_ERROR(mcpwm_generator_set_force_level(mcpwm_motor->gena, 0, true), TAG, "set force level for gena failed");
+    return ESP_OK;
+}
+
+static esp_err_t bdc_motor_mcpwm_coast(bdc_motor_t *motor)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = __containerof(motor, bdc_motor_mcpwm_obj, base);
+    ESP_RETURN_ON_ERROR(mcpwm_generator_set_force_level(mcpwm_motor->gena, 0, true), TAG, "set force level for gena failed");
+    ESP_RETURN_ON_ERROR(mcpwm_generator_set_force_level(mcpwm_motor->genb, 0, true), TAG, "set force level for genb failed");
+    return ESP_OK;
+}
+
+static esp_err_t bdc_motor_mcpwm_brake(bdc_motor_t *motor)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = __containerof(motor, bdc_motor_mcpwm_obj, base);
+    ESP_RETURN_ON_ERROR(mcpwm_generator_set_force_level(mcpwm_motor->gena, 1, true), TAG, "set force level for gena failed");
+    ESP_RETURN_ON_ERROR(mcpwm_generator_set_force_level(mcpwm_motor->genb, 1, true), TAG, "set force level for genb failed");
+    return ESP_OK;
+}
+
+static esp_err_t bdc_motor_mcpwm_del(bdc_motor_t *motor)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = __containerof(motor, bdc_motor_mcpwm_obj, base);
+    mcpwm_del_generator(mcpwm_motor->gena);
+    mcpwm_del_generator(mcpwm_motor->genb);
+    mcpwm_del_comparator(mcpwm_motor->cmpa);
+    mcpwm_del_comparator(mcpwm_motor->cmpb);
+    mcpwm_del_operator(mcpwm_motor->operator);
+    mcpwm_del_timer(mcpwm_motor->timer);
+    free(mcpwm_motor);
+    return ESP_OK;
+}
+
+esp_err_t bdc_motor_new_mcpwm_device(const bdc_motor_config_t *motor_config, const bdc_motor_mcpwm_config_t *mcpwm_config, bdc_motor_handle_t *ret_motor)
+{
+    bdc_motor_mcpwm_obj *mcpwm_motor = NULL;
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(motor_config && mcpwm_config && ret_motor, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+    mcpwm_motor = calloc(1, sizeof(bdc_motor_mcpwm_obj));
+    ESP_GOTO_ON_FALSE(mcpwm_motor, ESP_ERR_NO_MEM, err, TAG, "no mem for rmt motor");
+
+    // mcpwm timer
+    mcpwm_timer_config_t timer_config = {
+        .group_id = mcpwm_config->group_id,
+        .clk_src = MCPWM_TIMER_CLK_SRC_DEFAULT,
+        .resolution_hz = mcpwm_config->resolution_hz,
+        .period_ticks = mcpwm_config->resolution_hz / motor_config->pwm_freq_hz,
+        .count_mode = MCPWM_TIMER_COUNT_MODE_UP,
+    };
+    ESP_GOTO_ON_ERROR(mcpwm_new_timer(&timer_config, &mcpwm_motor->timer), err, TAG, "create MCPWM timer failed");
+
+    mcpwm_operator_config_t operator_config = {
+        .group_id = mcpwm_config->group_id,
+    };
+    ESP_GOTO_ON_ERROR(mcpwm_new_operator(&operator_config, &mcpwm_motor->operator), err, TAG, "create MCPWM operator failed");
+
+    ESP_GOTO_ON_ERROR(mcpwm_operator_connect_timer(mcpwm_motor->operator, mcpwm_motor->timer), err, TAG, "connect timer and operator failed");
+
+    mcpwm_comparator_config_t comparator_config = {
+        .flags.update_cmp_on_tez = true,
+    };
+    ESP_GOTO_ON_ERROR(mcpwm_new_comparator(mcpwm_motor->operator, &comparator_config, &mcpwm_motor->cmpa), err, TAG, "create comparator failed");
+    ESP_GOTO_ON_ERROR(mcpwm_new_comparator(mcpwm_motor->operator, &comparator_config, &mcpwm_motor->cmpb), err, TAG, "create comparator failed");
+
+    // set the initial compare value for both comparators
+    mcpwm_comparator_set_compare_value(mcpwm_motor->cmpa, 0);
+    mcpwm_comparator_set_compare_value(mcpwm_motor->cmpb, 0);
+
+    mcpwm_generator_config_t generator_config = {
+        .gen_gpio_num = motor_config->pwma_gpio_num,
+    };
+    ESP_GOTO_ON_ERROR(mcpwm_new_generator(mcpwm_motor->operator, &generator_config, &mcpwm_motor->gena), err, TAG, "create generator failed");
+    generator_config.gen_gpio_num = motor_config->pwmb_gpio_num;
+    ESP_GOTO_ON_ERROR(mcpwm_new_generator(mcpwm_motor->operator, &generator_config, &mcpwm_motor->genb), err, TAG, "create generator failed");
+
+    mcpwm_generator_set_actions_on_timer_event(mcpwm_motor->gena,
+            MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY, MCPWM_GEN_ACTION_HIGH),
+            MCPWM_GEN_TIMER_EVENT_ACTION_END());
+    mcpwm_generator_set_actions_on_compare_event(mcpwm_motor->gena,
+            MCPWM_GEN_COMPARE_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, mcpwm_motor->cmpa, MCPWM_GEN_ACTION_LOW),
+            MCPWM_GEN_COMPARE_EVENT_ACTION_END());
+    mcpwm_generator_set_actions_on_timer_event(mcpwm_motor->genb,
+            MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY, MCPWM_GEN_ACTION_HIGH),
+            MCPWM_GEN_TIMER_EVENT_ACTION_END());
+    mcpwm_generator_set_actions_on_compare_event(mcpwm_motor->genb,
+            MCPWM_GEN_COMPARE_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, mcpwm_motor->cmpb, MCPWM_GEN_ACTION_LOW),
+            MCPWM_GEN_COMPARE_EVENT_ACTION_END());
+
+    mcpwm_motor->base.enable = bdc_motor_mcpwm_enable;
+    mcpwm_motor->base.disable = bdc_motor_mcpwm_disable;
+    mcpwm_motor->base.forward = bdc_motor_mcpwm_forward;
+    mcpwm_motor->base.reverse = bdc_motor_mcpwm_reverse;
+    mcpwm_motor->base.coast = bdc_motor_mcpwm_coast;
+    mcpwm_motor->base.brake = bdc_motor_mcpwm_brake;
+    mcpwm_motor->base.set_speed = bdc_motor_mcpwm_set_speed;
+    mcpwm_motor->base.del = bdc_motor_mcpwm_del;
+    *ret_motor = &mcpwm_motor->base;
+    return ESP_OK;
+
+err:
+    if (mcpwm_motor) {
+        if (mcpwm_motor->gena) {
+            mcpwm_del_generator(mcpwm_motor->gena);
+        }
+        if (mcpwm_motor->genb) {
+            mcpwm_del_generator(mcpwm_motor->genb);
+        }
+        if (mcpwm_motor->cmpa) {
+            mcpwm_del_comparator(mcpwm_motor->cmpa);
+        }
+        if (mcpwm_motor->cmpb) {
+            mcpwm_del_comparator(mcpwm_motor->cmpb);
+        }
+        if (mcpwm_motor->operator) {
+            mcpwm_del_operator(mcpwm_motor->operator);
+        }
+        if (mcpwm_motor->timer) {
+            mcpwm_del_timer(mcpwm_motor->timer);
+        }
+        free(mcpwm_motor);
+    }
+    return ret;
+}

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # 3. Add here if the component is compatible with IDF >= v5.0
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
-    list(APPEND EXTRA_COMPONENT_DIRS ../sh2lib ../nghttp)
+    list(APPEND EXTRA_COMPONENT_DIRS ../bdc_motor ../sh2lib ../nghttp)
 endif()
 
 # !This section should NOT be touched when adding new component!


### PR DESCRIPTION
Copied from [the BDC example](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/mcpwm/mcpwm_bdc_speed_control/components/bdc_motor)

The interface there should be much close to a "stable" one, so it's time to publish it to the component registry.

No test_app is added for now, but we have one test in the esp-idf example.
