### PR TITLE
led_strip: added led strip driver v2

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Upload components to component service
         uses: espressif/upload-components-ci-action@v1
         with:
-          directories: "bdc_motor;cbor;jsmn;libsodium;pid_ctrl;qrcode;nghttp;sh2lib;expat;esp_encrypted_img;coap;pcap;json_generator;json_parser;usb/usb_host_cdc_acm;usb/usb_host_msc"
+          directories: "bdc_motor;cbor;jsmn;led_strip;libsodium;pid_ctrl;qrcode;nghttp;sh2lib;expat;esp_encrypted_img;coap;pcap;json_generator;json_parser;usb/usb_host_cdc_acm;usb/usb_host_msc"
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/led_strip/CMakeLists.txt
+++ b/led_strip/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(srcs "src/led_strip_api.c")
+
+if(CONFIG_SOC_RMT_SUPPORTED)
+    list(APPEND srcs "src/led_strip_rmt_dev.c" "src/led_strip_rmt_encoder.c")
+endif()
+
+idf_component_register(SRCS ${srcs}
+                       INCLUDE_DIRS "include" "interface"
+                       PRIV_REQUIRES "driver")

--- a/led_strip/LICENSE
+++ b/led_strip/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/led_strip/README.md
+++ b/led_strip/README.md
@@ -1,0 +1,10 @@
+# LED Strip Component
+
+This directory contains an implementation for addressable LEDs by different peripherals. Currently only RMT is supported as the led strip backend.
+
+The driver should be compatible with:
+
+* [WS2812](http://www.world-semi.com/Certifications/WS2812B.html)
+* SK68XX
+
+To learn more about how to use this component, please check API Documentation from header file [led_strip.h](./include/led_strip.h).

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,0 +1,5 @@
+version: "2.0.0"
+description: Driver for Addressable LED Strip (WS2812, etc)
+url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
+dependencies:
+  idf: ">=5.0"

--- a/led_strip/include/led_strip.h
+++ b/led_strip/include/led_strip.h
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief LED strip handle
+ */
+typedef struct led_strip_t *led_strip_handle_t;
+
+/**
+ * @brief Set RGB for a specific pixel
+ *
+ * @param strip: LED strip
+ * @param index: index of pixel to set
+ * @param red: red part of color
+ * @param green: green part of color
+ * @param blue: blue part of color
+ *
+ * @return
+ *      - ESP_OK: Set RGB for a specific pixel successfully
+ *      - ESP_ERR_INVALID_ARG: Set RGB for a specific pixel failed because of invalid parameters
+ *      - ESP_FAIL: Set RGB for a specific pixel failed because other error occurred
+ */
+esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue);
+
+/**
+ * @brief Refresh memory colors to LEDs
+ *
+ * @param strip: LED strip
+ *
+ * @return
+ *      - ESP_OK: Refresh successfully
+ *      - ESP_FAIL: Refresh failed because some other error occurred
+ *
+ * @note:
+ *      After updating the LED colors in the memory, a following invocation of this API is needed to flush colors to strip.
+ */
+esp_err_t led_strip_refresh(led_strip_handle_t strip);
+
+/**
+ * @brief Clear LED strip (turn off all LEDs)
+ *
+ * @param strip: LED strip
+ *
+ * @return
+ *      - ESP_OK: Clear LEDs successfully
+ *      - ESP_FAIL: Clear LEDs failed because some other error occurred
+ */
+esp_err_t led_strip_clear(led_strip_handle_t strip);
+
+/**
+ * @brief Free LED strip resources
+ *
+ * @param strip: LED strip
+ *
+ * @return
+ *      - ESP_OK: Free resources successfully
+ *      - ESP_FAIL: Free resources failed because error occurred
+ */
+esp_err_t led_strip_del(led_strip_handle_t strip);
+
+/**
+ * @brief LED Strip Configuration
+ */
+typedef struct {
+    uint32_t strip_gpio_num; /*!< GPIO number that used by LED strip */
+    uint32_t max_leds;       /*!< Maximum LEDs in a single strip */
+} led_strip_config_t;
+
+/**
+ * @brief LED Strip RMT specific configuration
+ */
+typedef struct {
+    uint32_t resolution_hz; /*!< RMT tick resolution, if set to zero, a default resolution (10MHz) will be applied */
+} led_strip_rmt_config_t;
+
+/**
+ * @brief Create LED strip based on RMT TX channel
+ *
+ * @param led_config LED strip configuration
+ * @param rmt_config RMT specific configuration
+ * @param ret_strip Returned LED strip handle
+ * @return
+ *      - ESP_OK: create LED strip handle successfully
+ *      - ESP_ERR_INVALID_ARG: create LED strip handle failed because of invalid argument
+ *      - ESP_ERR_NO_MEM: create LED strip handle failed because of out of memory
+ *      - ESP_FAIL: create LED strip handle failed because some other error
+ */
+esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const led_strip_rmt_config_t *rmt_config, led_strip_handle_t *ret_strip);
+
+#ifdef __cplusplus
+}
+#endif

--- a/led_strip/interface/led_strip_interface.h
+++ b/led_strip/interface/led_strip_interface.h
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct led_strip_t led_strip_t; /*!< Type of LED strip */
+
+/**
+ * @brief LED strip interface definition
+ */
+struct led_strip_t {
+    /**
+     * @brief Set RGB for a specific pixel
+     *
+     * @param strip: LED strip
+     * @param index: index of pixel to set
+     * @param red: red part of color
+     * @param green: green part of color
+     * @param blue: blue part of color
+     *
+     * @return
+     *      - ESP_OK: Set RGB for a specific pixel successfully
+     *      - ESP_ERR_INVALID_ARG: Set RGB for a specific pixel failed because of invalid parameters
+     *      - ESP_FAIL: Set RGB for a specific pixel failed because other error occurred
+     */
+    esp_err_t (*set_pixel)(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue);
+
+    /**
+     * @brief Refresh memory colors to LEDs
+     *
+     * @param strip: LED strip
+     * @param timeout_ms: timeout value for refreshing task
+     *
+     * @return
+     *      - ESP_OK: Refresh successfully
+     *      - ESP_FAIL: Refresh failed because some other error occurred
+     *
+     * @note:
+     *      After updating the LED colors in the memory, a following invocation of this API is needed to flush colors to strip.
+     */
+    esp_err_t (*refresh)(led_strip_t *strip);
+
+    /**
+     * @brief Clear LED strip (turn off all LEDs)
+     *
+     * @param strip: LED strip
+     * @param timeout_ms: timeout value for clearing task
+     *
+     * @return
+     *      - ESP_OK: Clear LEDs successfully
+     *      - ESP_FAIL: Clear LEDs failed because some other error occurred
+     */
+    esp_err_t (*clear)(led_strip_t *strip);
+
+    /**
+     * @brief Free LED strip resources
+     *
+     * @param strip: LED strip
+     *
+     * @return
+     *      - ESP_OK: Free resources successfully
+     *      - ESP_FAIL: Free resources failed because error occurred
+     */
+    esp_err_t (*del)(led_strip_t *strip);
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/led_strip/src/led_strip_api.c
+++ b/led_strip/src/led_strip_api.c
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "esp_log.h"
+#include "esp_check.h"
+#include "led_strip.h"
+#include "led_strip_interface.h"
+
+static const char *TAG = "led_strip";
+
+esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->set_pixel(strip, index, red, green, blue);
+}
+
+esp_err_t led_strip_refresh(led_strip_handle_t strip)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->refresh(strip);
+}
+
+esp_err_t led_strip_clear(led_strip_handle_t strip)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->clear(strip);
+}
+
+esp_err_t led_strip_del(led_strip_handle_t strip)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->del(strip);
+}

--- a/led_strip/src/led_strip_rmt_dev.c
+++ b/led_strip/src/led_strip_rmt_dev.c
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <sys/cdefs.h>
+#include "esp_log.h"
+#include "esp_check.h"
+#include "driver/rmt_tx.h"
+#include "led_strip.h"
+#include "led_strip_interface.h"
+#include "led_strip_rmt_encoder.h"
+
+#define LED_STRIP_RMT_DEFAULT_RESOLUTION 10000000 // 10MHz resolution
+
+static const char *TAG = "led_strip_rmt";
+
+typedef struct {
+    led_strip_t base;
+    rmt_channel_handle_t rmt_chan;
+    rmt_encoder_handle_t strip_encoder;
+    uint32_t strip_len;
+    uint8_t pixel_buf[];
+} led_strip_rmt_obj;
+
+static esp_err_t led_strip_rmt_set_pixel(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    ESP_RETURN_ON_FALSE(index < rmt_strip->strip_len, ESP_ERR_INVALID_ARG, TAG, "index out of maximum number of LEDs");
+    uint32_t start = index * 3;
+    // In thr order of GRB, as LED strip like WS2812 sends out pixels in this order
+    rmt_strip->pixel_buf[start + 0] = green & 0xFF;
+    rmt_strip->pixel_buf[start + 1] = red & 0xFF;
+    rmt_strip->pixel_buf[start + 2] = blue & 0xFF;
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_rmt_refresh(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    rmt_transmit_config_t tx_conf = {
+        .loop_count = 0,
+    };
+    ESP_RETURN_ON_ERROR(rmt_transmit(rmt_strip->rmt_chan, rmt_strip->strip_encoder, rmt_strip->pixel_buf,
+                                     rmt_strip->strip_len * 3, &tx_conf), TAG, "transmit pixels by RMT failed");
+    ESP_RETURN_ON_ERROR(rmt_tx_wait_all_done(rmt_strip->rmt_chan, -1), TAG, "flush RMT channel failed");
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_rmt_clear(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    // Write zero to turn off all leds
+    memset(rmt_strip->pixel_buf, 0, rmt_strip->strip_len * 3);
+    return led_strip_rmt_refresh(strip);
+}
+
+static esp_err_t led_strip_rmt_del(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    ESP_RETURN_ON_ERROR(rmt_disable(rmt_strip->rmt_chan), TAG, "disable RMT channel failed");
+    ESP_RETURN_ON_ERROR(rmt_del_channel(rmt_strip->rmt_chan), TAG, "delete RMT channel failed");
+    ESP_RETURN_ON_ERROR(rmt_del_encoder(rmt_strip->strip_encoder), TAG, "delete strip encoder failed");
+    free(rmt_strip);
+    return ESP_OK;
+}
+
+esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const led_strip_rmt_config_t *rmt_config, led_strip_handle_t *ret_strip)
+{
+    led_strip_rmt_obj *rmt_strip = NULL;
+    esp_err_t ret = ESP_OK;
+    ESP_GOTO_ON_FALSE(led_config && rmt_config && ret_strip, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+    rmt_strip = calloc(1, sizeof(led_strip_rmt_obj) + led_config->max_leds * 3);
+    ESP_GOTO_ON_FALSE(rmt_strip, ESP_ERR_NO_MEM, err, TAG, "no mem for rmt strip");
+    uint32_t resolution = rmt_config->resolution_hz ? rmt_config->resolution_hz : LED_STRIP_RMT_DEFAULT_RESOLUTION;
+    rmt_tx_channel_config_t rmt_chan_config = {
+        .clk_src = RMT_CLK_SRC_DEFAULT,
+        .gpio_num = led_config->strip_gpio_num,
+        .mem_block_symbols = 64,
+        .resolution_hz = resolution,
+        .trans_queue_depth = 4,
+    };
+    ESP_GOTO_ON_ERROR(rmt_new_tx_channel(&rmt_chan_config, &rmt_strip->rmt_chan), err, TAG, "create RMT TX channel failed");
+
+    led_strip_encoder_config_t strip_encoder_conf = {
+        .resolution = resolution,
+    };
+    ESP_GOTO_ON_ERROR(rmt_new_led_strip_encoder(&strip_encoder_conf, &rmt_strip->strip_encoder), err, TAG, "create LED strip encoder failed");
+
+    ESP_GOTO_ON_ERROR(rmt_enable(rmt_strip->rmt_chan), err, TAG, "enable RMT channel failed");
+
+    rmt_strip->strip_len = led_config->max_leds;
+    rmt_strip->base.set_pixel = led_strip_rmt_set_pixel;
+    rmt_strip->base.refresh = led_strip_rmt_refresh;
+    rmt_strip->base.clear = led_strip_rmt_clear;
+    rmt_strip->base.del = led_strip_rmt_del;
+
+    *ret_strip = &rmt_strip->base;
+    return ESP_OK;
+err:
+    if (rmt_strip) {
+        if (rmt_strip->rmt_chan) {
+            rmt_del_channel(rmt_strip->rmt_chan);
+        }
+        if (rmt_strip->strip_encoder) {
+            rmt_del_encoder(rmt_strip->strip_encoder);
+        }
+        free(rmt_strip);
+    }
+    return ret;
+}

--- a/led_strip/src/led_strip_rmt_encoder.c
+++ b/led_strip/src/led_strip_rmt_encoder.c
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp_check.h"
+#include "led_strip_rmt_encoder.h"
+
+static const char *TAG = "led_rmt_encoder";
+
+typedef struct {
+    rmt_encoder_t base;
+    rmt_encoder_t *bytes_encoder;
+    rmt_encoder_t *copy_encoder;
+    int state;
+    rmt_symbol_word_t reset_code;
+} rmt_led_strip_encoder_t;
+
+static size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_encoder_handle_t bytes_encoder = led_encoder->bytes_encoder;
+    rmt_encoder_handle_t copy_encoder = led_encoder->copy_encoder;
+    rmt_encode_state_t session_state = 0;
+    rmt_encode_state_t state = 0;
+    size_t encoded_symbols = 0;
+    switch (led_encoder->state) {
+    case 0: // send RGB data
+        encoded_symbols += bytes_encoder->encode(bytes_encoder, channel, primary_data, data_size, &session_state);
+        if (session_state & RMT_ENCODING_COMPLETE) {
+            led_encoder->state = 1; // switch to next state when current encoding session finished
+        }
+        if (session_state & RMT_ENCODING_MEM_FULL) {
+            state |= RMT_ENCODING_MEM_FULL;
+            goto out; // yield if there's no free space for encoding artifacts
+        }
+    // fall-through
+    case 1: // send reset code
+        encoded_symbols += copy_encoder->encode(copy_encoder, channel, &led_encoder->reset_code,
+                                                sizeof(led_encoder->reset_code), &session_state);
+        if (session_state & RMT_ENCODING_COMPLETE) {
+            led_encoder->state = 0; // back to the initial encoding session
+            state |= RMT_ENCODING_COMPLETE;
+        }
+        if (session_state & RMT_ENCODING_MEM_FULL) {
+            state |= RMT_ENCODING_MEM_FULL;
+            goto out; // yield if there's no free space for encoding artifacts
+        }
+    }
+out:
+    *ret_state = state;
+    return encoded_symbols;
+}
+
+static esp_err_t rmt_del_led_strip_encoder(rmt_encoder_t *encoder)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_del_encoder(led_encoder->bytes_encoder);
+    rmt_del_encoder(led_encoder->copy_encoder);
+    free(led_encoder);
+    return ESP_OK;
+}
+
+static esp_err_t rmt_led_strip_encoder_reset(rmt_encoder_t *encoder)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_encoder_reset(led_encoder->bytes_encoder);
+    rmt_encoder_reset(led_encoder->copy_encoder);
+    led_encoder->state = 0;
+    return ESP_OK;
+}
+
+esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder)
+{
+    esp_err_t ret = ESP_OK;
+    rmt_led_strip_encoder_t *led_encoder = NULL;
+    ESP_GOTO_ON_FALSE(config && ret_encoder, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+    led_encoder = calloc(1, sizeof(rmt_led_strip_encoder_t));
+    ESP_GOTO_ON_FALSE(led_encoder, ESP_ERR_NO_MEM, err, TAG, "no mem for led strip encoder");
+    led_encoder->base.encode = rmt_encode_led_strip;
+    led_encoder->base.del = rmt_del_led_strip_encoder;
+    led_encoder->base.reset = rmt_led_strip_encoder_reset;
+    // different led strip might have its own timing requirements, following parameter is for WS2812
+    rmt_bytes_encoder_config_t bytes_encoder_config = {
+        .bit0 = {
+            .level0 = 1,
+            .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
+            .level1 = 0,
+            .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
+        },
+        .bit1 = {
+            .level0 = 1,
+            .duration0 = 0.9 * config->resolution / 1000000, // T1H=0.9us
+            .level1 = 0,
+            .duration1 = 0.3 * config->resolution / 1000000, // T1L=0.3us
+        },
+        .flags.msb_first = 1 // WS2812 transfer bit order: G7...G0R7...R0B7...B0
+    };
+    ESP_GOTO_ON_ERROR(rmt_new_bytes_encoder(&bytes_encoder_config, &led_encoder->bytes_encoder), err, TAG, "create bytes encoder failed");
+    rmt_copy_encoder_config_t copy_encoder_config = {};
+    ESP_GOTO_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_config, &led_encoder->copy_encoder), err, TAG, "create copy encoder failed");
+
+    uint32_t reset_ticks = config->resolution / 1000000 * 50 / 2; // reset code duration defaults to 50us
+    led_encoder->reset_code = (rmt_symbol_word_t) {
+        .level0 = 0,
+        .duration0 = reset_ticks,
+        .level1 = 0,
+        .duration1 = reset_ticks,
+    };
+    *ret_encoder = &led_encoder->base;
+    return ESP_OK;
+err:
+    if (led_encoder) {
+        if (led_encoder->bytes_encoder) {
+            rmt_del_encoder(led_encoder->bytes_encoder);
+        }
+        if (led_encoder->copy_encoder) {
+            rmt_del_encoder(led_encoder->copy_encoder);
+        }
+        free(led_encoder);
+    }
+    return ret;
+}

--- a/led_strip/src/led_strip_rmt_encoder.h
+++ b/led_strip/src/led_strip_rmt_encoder.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "driver/rmt_encoder.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Type of led strip encoder configuration
+ */
+typedef struct {
+    uint32_t resolution; /*!< Encoder resolution, in Hz */
+} led_strip_encoder_config_t;
+
+/**
+ * @brief Create RMT encoder for encoding LED strip pixels into RMT symbols
+ *
+ * @param[in] config Encoder configuration
+ * @param[out] ret_encoder Returned encoder handle
+ * @return
+ *      - ESP_ERR_INVALID_ARG for any invalid arguments
+ *      - ESP_ERR_NO_MEM out of memory when creating led strip encoder
+ *      - ESP_OK if creating encoder successfully
+ */
+esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # 3. Add here if the component is compatible with IDF >= v5.0
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
-    list(APPEND EXTRA_COMPONENT_DIRS ../bdc_motor ../sh2lib ../nghttp)
+    list(APPEND EXTRA_COMPONENT_DIRS ../bdc_motor ../led_strip ../sh2lib ../nghttp)
 endif()
 
 # !This section should NOT be touched when adding new component!


### PR DESCRIPTION
Moved from [ESP-IDF example common component](https://github.com/espressif/esp-idf/tree/master/examples/common_components/led_strip).

Previously the led_strip (version 1) has been deprecated, and this new version is based on the new RMT driver in ESP-IDF 5.0.
