### PR TITLE
components: esp_foc: added esp FoC motor control

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Upload components to component service
         uses: espressif/upload-components-ci-action@v1
         with:
-          directories: "bdc_motor;cbor;jsmn;led_strip;libsodium;pid_ctrl;qrcode;nghttp;sh2lib;expat;esp_encrypted_img;coap;pcap;json_generator;json_parser;usb/usb_host_cdc_acm;usb/usb_host_msc"
+          directories: "bdc_motor;cbor;jsmn;led_strip;libsodium;pid_ctrl;qrcode;nghttp;sh2lib;expat;esp_encrypted_img;coap;pcap;json_generator;json_parser;esp_foc;usb/usb_host_cdc_acm;usb/usb_host_msc"
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/esp_foc/CMakeLists.txt
+++ b/esp_foc/CMakeLists.txt
@@ -1,0 +1,14 @@
+idf_build_get_property(target IDF_TARGET)
+
+set(requires driver freertos esp_system esp_timer)  
+set(srcs "esp_foc.c" "esp_foc_consts.c")
+set(includes "include" "drivers")
+
+list(APPEND srcs   "drivers/inverter_3pwm_ledc.c"
+                    "drivers/rotor_sensor_as5600.c"
+                    "drivers/rotor_sensor_dummy.c"
+                    "drivers/os_interface.c")
+
+idf_component_register(SRCS "${srcs}"
+                       INCLUDE_DIRS "${includes}"
+                       PRIV_REQUIRES "${requires}")

--- a/esp_foc/Kconfig
+++ b/esp_foc/Kconfig
@@ -1,0 +1,37 @@
+menu "espFoC Settings"
+
+    config ESP_FOC_ALIGN_STEP_DELAY_MS
+        int "Delay between rotor alignment step in ms"
+        default 5
+        help
+            Keeps the bridge active with step calculated 
+            voltages to ensure the Q and D vectors to
+            align, higher values increase better alignment
+            in excheange of rotor core saturation.
+
+    config NOOF_AXIS
+        int "Number of motor outputs"
+        range 1 4
+        default 1
+        help
+            The number of motor outputs available, this option
+            is the number of motor sets, each set is composed 
+            by total PWM outputs and sensor inputs.
+
+    config FOC_TASK_PRIORITY
+        int "Priority task of foc controller"
+        range 16 25
+        default 25
+
+    config FOC_TASK_STACK_SIZE
+        int "Task stack size of foc controller"
+        default 3072
+    
+    config ESP_FOC_CUSTOM_MATH
+        bool "Use custom espFoC fast math"
+        default y
+
+endmenu
+    
+    
+    

--- a/esp_foc/LICENSE
+++ b/esp_foc/LICENSE
@@ -1,0 +1,25 @@
+The MIT License (MIT)
+=====================
+
+Copyright © `2021` `Felipe Neves`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/esp_foc/README.md
+++ b/esp_foc/README.md
@@ -1,0 +1,28 @@
+# espFoC: Vector FoC controller for PMSM motors for ESP-IDF
+
+![Build](https://github.com/uLipe/espFoC/workflows/Build/badge.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+espFoC is a simple implementation of voltage mode, vector controller intended to be used with permanent-magnet synchronous motors (PMSM), and general brushless motors. This component was developed to be used with the ESP-IDF 
+espressif framework.
+
+## Getting started:
+* Just clone this project on most convenient folder;
+* Inside of your IDF project CMakeLists.txt set or add the path of this component to EXTRA_COMPONENT_DIRS for example: `set(EXTRA_COMPONENT_DIRS "path/to/this/component/")`
+* For batteries included getting started, refer the examples folder.
+
+## Features:
+* Voltage mode control, control a PMSM like a DC motor!;
+* Position and Speed closed-loop control;
+* Single-precision Floating point implementation;
+* Sample inverter driver based on esp32 LEDC PWM (easy to wire!);
+* Sample rotor position driver based on as5600 encoder (very popular!);
+* FoC engine runs sychronized at inverter PWM rate;
+
+## Limitations:
+* Support for esp32 and esp32s3 only;
+* Requires and rotor position sensor, for example, incremental encoder.
+
+## Support:
+If you find some trouble, open an issue, and if you are enjoying the project
+give it a star. Also, you can try reaching me at ryukokki.felipe@gmail.com

--- a/esp_foc/drivers/current_sensor_adc.c
+++ b/esp_foc/drivers/current_sensor_adc.c
@@ -1,0 +1,133 @@
+#include <sys/cdefs.h>
+#include <stdbool.h>
+#include "espFoC/current_sensor_adc.h"
+#include "hal/adc_hal.h"
+#include "esp_attr.h"
+#include "esp_log.h"
+
+#if CONFIG_IDF_TARGET_ESP32S3
+
+#define ADC_RESULT_BYTE     4
+#define ADC_CONV_LIMIT_EN   0
+#define ADC_CONV_MODE       ADC_CONV_BOTH_UNIT
+#define ADC_OUTPUT_TYPE     ADC_DIGI_OUTPUT_FORMAT_TYPE2
+
+#define ISENSOR_ADC_BUFFER_SIZE      1024
+#define GET_UNIT(x)        ((x>>3) & 0x1)
+
+static const char *TAG = "ESP_FOC_ISENSOR";
+
+typedef struct {
+    float adc_to_current_scale;
+    isensor_values_t currents;
+    esp_foc_isensor_t interface;
+    uint8_t noof_channels;
+}isensor_adc_t;
+
+DRAM_ATTR static isensor_adc_t isensor_adc;
+static bool adc_initialized = false;
+
+static void continuous_adc_init(uint16_t adc1_chan_mask, uint16_t adc2_chan_mask, adc_channel_t *channel, uint8_t channel_num)
+{
+    adc_digi_init_config_t adc_dma_config = {
+        .max_store_buf_size = ISENSOR_ADC_BUFFER_SIZE,
+        .conv_num_each_intr = channel_num,
+        .adc1_chan_mask = adc1_chan_mask,
+        .adc2_chan_mask = adc2_chan_mask,
+    };
+   adc_digi_initialize(&adc_dma_config);
+
+    adc_digi_configuration_t dig_cfg = {
+        .conv_limit_en = ADC_CONV_LIMIT_EN,
+        .conv_limit_num = 250,
+        .sample_freq_hz = SOC_ADC_SAMPLE_FREQ_THRES_HIGH,
+        .conv_mode = ADC_CONV_MODE,
+        .format = ADC_OUTPUT_TYPE,
+    };
+
+    adc_digi_pattern_config_t adc_pattern[SOC_ADC_PATT_LEN_MAX] = {0};
+    dig_cfg.pattern_num = channel_num;
+    for (int i = 0; i < channel_num; i++) {
+        uint8_t unit = GET_UNIT(channel[i]);
+        uint8_t ch = channel[i] & 0x7;
+        adc_pattern[i].atten = ADC_ATTEN_DB_0;
+        adc_pattern[i].channel = ch;
+        adc_pattern[i].unit = unit;
+        adc_pattern[i].bit_width = SOC_ADC_DIGI_MAX_BITWIDTH;
+
+        ESP_LOGI(TAG, "adc_pattern[%d].atten is :%x", i, adc_pattern[i].atten);
+        ESP_LOGI(TAG, "adc_pattern[%d].channel is :%x", i, adc_pattern[i].channel);
+        ESP_LOGI(TAG, "adc_pattern[%d].unit is :%x", i, adc_pattern[i].unit);
+    }
+    dig_cfg.adc_pattern = adc_pattern;
+    adc_digi_controller_configure(&dig_cfg);
+}
+
+
+IRAM_ATTR static void fetch_isensors(esp_foc_isensor_t *self, isensor_values_t *values)
+{
+    isensor_adc_t *obj = 
+        __containerof(self, isensor_adc_t, interface);
+
+    uint32_t ret_num;
+    adc_digi_output_data_t result[obj->noof_channels];
+ 
+    esp_err_t err = adc_digi_read_bytes((uint8_t *)&result, 
+                                    obj->noof_channels * sizeof(adc_digi_output_data_t),
+                                    &ret_num,
+                                    0);
+
+    if(err == ESP_OK) {
+
+        obj->currents.iu_axis_0 = (float)result[0].type2.data * obj->adc_to_current_scale;
+        obj->currents.iv_axis_0 = (float)result[1].type2.data * obj->adc_to_current_scale;
+        obj->currents.iw_axis_0 = obj->currents.iu_axis_0 + obj->currents.iv_axis_0;
+
+        if(obj->noof_channels > 2) {
+            obj->currents.iu_axis_1 = (float)result[2].type2.data * obj->adc_to_current_scale;
+            obj->currents.iv_axis_1 = (float)result[3].type2.data * obj->adc_to_current_scale;
+            obj->currents.iw_axis_1 = obj->currents.iu_axis_1 + obj->currents.iv_axis_1;
+        } 
+    }
+}
+
+IRAM_ATTR static void sample_isensors(esp_foc_isensor_t *self)
+{
+    (void)self;    
+    adc_digi_start();
+}
+
+
+esp_foc_isensor_t *isensor_adc_new(esp_foc_isensor_adc_config_t *config,
+                                float adc_to_current_scale)
+
+{
+    uint16_t adc1_chan_mask = 0;
+    uint16_t adc2_chan_mask = 0;
+    uint8_t noof_channels = config->noof_axis * 2;
+
+    if(adc_initialized == true) {
+        return &isensor_adc.interface;
+    }
+
+    adc_initialized = true;
+
+    adc_digi_stop();
+
+    for(uint8_t i = 0; i < noof_channels; i++) {
+        if(config->axis_channels[i] != 0xFF) {
+            adc1_chan_mask |= (1 << config->axis_channels[i]);
+        }
+    } 
+
+    continuous_adc_init(adc1_chan_mask, adc2_chan_mask, config->axis_channels, noof_channels);
+
+    isensor_adc.adc_to_current_scale = adc_to_current_scale;
+    isensor_adc.interface.fetch_isensors = fetch_isensors;
+    isensor_adc.interface.sample_isensors = sample_isensors;
+    isensor_adc.noof_channels = noof_channels;
+
+    return &isensor_adc.interface;
+}
+
+#endif

--- a/esp_foc/drivers/espFoC/current_sensor_adc.h
+++ b/esp_foc/drivers/espFoC/current_sensor_adc.h
@@ -1,0 +1,15 @@
+#pragma once 
+
+#include "espFoC/esp_foc.h"
+#include "driver/adc.h"
+#include "esp_err.h"
+
+typedef struct {
+    adc_bits_width_t width;
+    adc_channel_t axis_channels[4];
+    int noof_axis;
+}esp_foc_isensor_adc_config_t;
+
+
+esp_foc_isensor_t *isensor_adc_new(esp_foc_isensor_adc_config_t *config,
+                                float adc_to_current_scale);

--- a/esp_foc/drivers/espFoC/inverter_3pwm_ledc.h
+++ b/esp_foc/drivers/espFoC/inverter_3pwm_ledc.h
@@ -1,0 +1,14 @@
+#pragma once 
+
+#include "espFoC/esp_foc.h"
+#include "driver/ledc.h"
+#include "esp_err.h"
+
+esp_foc_inverter_t *inverter_3pwm_ledc_new(ledc_channel_t ch_u,
+                                        ledc_channel_t ch_v,
+                                        ledc_channel_t ch_w,
+                                        int gpio_u,
+                                        int gpio_v,
+                                        int gpio_w,
+                                        float dc_link_voltage,
+                                        int port);

--- a/esp_foc/drivers/espFoC/rotor_sensor_as5600.h
+++ b/esp_foc/drivers/espFoC/rotor_sensor_as5600.h
@@ -1,0 +1,7 @@
+#pragma once 
+
+#include "espFoC/esp_foc.h"
+
+esp_foc_rotor_sensor_t *rotor_sensor_as5600_new(int pin_sda,
+                                                int pin_scl,
+                                                int port);

--- a/esp_foc/drivers/espFoC/rotor_sensor_dummy.h
+++ b/esp_foc/drivers/espFoC/rotor_sensor_dummy.h
@@ -1,0 +1,5 @@
+#pragma once 
+
+#include "espFoC/esp_foc.h"
+
+esp_foc_rotor_sensor_t *rotor_sensor_dummy_new(int port);

--- a/esp_foc/drivers/inverter_3pwm_ledc.c
+++ b/esp_foc/drivers/inverter_3pwm_ledc.c
@@ -1,0 +1,215 @@
+#include <sys/cdefs.h>
+#include "espFoC/inverter_3pwm_ledc.h"
+#include "hal/ledc_hal.h"
+#include "esp_attr.h"
+
+#define LEDC_FREQUENCY_HZ       20000
+#define LEDC_RESOLUTION_STEPS   255.0
+
+typedef struct {
+    ledc_dev_t *hw;
+    float voltage_to_duty_ratio;
+    float dc_link_voltage;
+    ledc_channel_t ledc_channel[3];
+    esp_foc_inverter_callback_t notifier;
+    void *arg;
+    esp_foc_inverter_t interface;
+}esp_foc_ledc_inverter;
+
+static const ledc_timer_t ledc_timers[4] = {LEDC_TIMER_0,LEDC_TIMER_1,LEDC_TIMER_2,LEDC_TIMER_3};
+
+static bool ledc_driver_configured = false;
+
+DRAM_ATTR static esp_foc_ledc_inverter ledc[CONFIG_NOOF_AXIS];
+
+IRAM_ATTR static void ledc_isr(void *arg) 
+{
+    esp_foc_fpu_isr_enter();
+
+    esp_foc_ledc_inverter *obj = (esp_foc_ledc_inverter *)arg;
+
+    obj->hw->int_clr.val = (LEDC_LSTIMER0_OVF_INT_ENA |
+                        LEDC_LSTIMER1_OVF_INT_ENA |
+                        LEDC_LSTIMER2_OVF_INT_ENA |
+                        LEDC_LSTIMER3_OVF_INT_ENA );
+
+    if(obj->notifier) {
+        obj->notifier(obj->arg);
+    }
+
+    esp_foc_fpu_isr_leave();
+}
+
+/* This function is required because the ledc driver does not support update from 
+ * ISR
+ */
+IRAM_ATTR static void ledc_update(esp_foc_ledc_inverter *obj, ledc_channel_t channel, float duty)
+{
+    /* set duty parameters */
+    ledc_ll_set_hpoint(obj->hw, LEDC_LOW_SPEED_MODE, channel, 0);
+    ledc_ll_set_duty_int_part(obj->hw, LEDC_LOW_SPEED_MODE, channel, duty);
+    ledc_ll_set_duty_direction(obj->hw, LEDC_LOW_SPEED_MODE, channel, LEDC_DUTY_DIR_INCREASE);    
+    ledc_ll_set_duty_num(obj->hw, LEDC_LOW_SPEED_MODE, channel, 1);
+    ledc_ll_set_duty_cycle(obj->hw, LEDC_LOW_SPEED_MODE, channel, 1);    
+    ledc_ll_set_duty_scale(obj->hw, LEDC_LOW_SPEED_MODE, channel, 0);
+    ledc_ll_ls_channel_update(obj->hw, LEDC_LOW_SPEED_MODE, channel);
+    
+    /* trigger the duty update */
+    ledc_ll_set_sig_out_en(obj->hw, LEDC_LOW_SPEED_MODE, channel, true);
+    ledc_ll_set_duty_start(obj->hw, LEDC_LOW_SPEED_MODE, channel, true);
+}
+
+
+IRAM_ATTR static float get_dc_link_voltage (esp_foc_inverter_t *self)
+{
+    esp_foc_ledc_inverter *obj = 
+        __containerof(self, esp_foc_ledc_inverter, interface);
+
+    return obj->dc_link_voltage;
+}
+
+IRAM_ATTR static void set_voltages(esp_foc_inverter_t *self,
+                    float v_u,
+                    float v_v,
+                    float v_w)
+{
+    esp_foc_ledc_inverter *obj = 
+        __containerof(self, esp_foc_ledc_inverter, interface);
+
+    if(v_u > obj->dc_link_voltage) {
+        v_u = obj->dc_link_voltage;
+    } else if (v_u < 0.0f) {
+        v_u = 0.0f;
+    }
+
+    if(v_v > obj->dc_link_voltage) {
+        v_v = obj->dc_link_voltage;
+    } else if (v_v < 0.0f) {
+        v_v = 0.0f;
+    }
+
+    if(v_w > obj->dc_link_voltage) {
+        v_w = obj->dc_link_voltage;
+    } else if (v_w < 0.0f) {
+        v_w = 0.0f;
+    }
+
+    ledc_update(obj, obj->ledc_channel[0], obj->voltage_to_duty_ratio * v_u);
+    ledc_update(obj, obj->ledc_channel[1], obj->voltage_to_duty_ratio * v_v);
+    ledc_update(obj, obj->ledc_channel[2], obj->voltage_to_duty_ratio * v_w);
+}
+
+IRAM_ATTR static void set_inverter_callback(esp_foc_inverter_t *self,
+                        esp_foc_inverter_callback_t callback,
+                        void *argument)
+{
+    esp_foc_ledc_inverter *obj = 
+    __containerof(self, esp_foc_ledc_inverter, interface);
+
+    obj->notifier = callback;
+    obj->arg = argument;
+
+    ledc_isr_register(ledc_isr, obj, ESP_INTR_FLAG_IRAM, NULL);
+    obj->hw->int_ena.val |= (LEDC_LSTIMER0_OVF_INT_ENA |
+                        LEDC_LSTIMER1_OVF_INT_ENA |
+                        LEDC_LSTIMER2_OVF_INT_ENA |
+                        LEDC_LSTIMER3_OVF_INT_ENA );
+}
+
+IRAM_ATTR static void phase_remap(esp_foc_inverter_t *self)
+{
+    (void)self;
+}
+
+IRAM_ATTR static float get_inverter_pwm_rate (esp_foc_inverter_t *self)
+{
+    (void)self;
+    return (float)LEDC_FREQUENCY_HZ;
+}
+
+static esp_err_t inverter_3pwm_ledc_init()
+{
+    for (int i = 0; i < CONFIG_NOOF_AXIS; i++) {
+        ledc_timer_config_t ledc_timer = {
+            .duty_resolution = LEDC_TIMER_8_BIT,
+            .freq_hz = LEDC_FREQUENCY_HZ,
+            .speed_mode = LEDC_LOW_SPEED_MODE,
+            .timer_num = ledc_timers[i],
+            .clk_cfg = LEDC_AUTO_CLK,
+        };
+
+        ledc_timer_config(&ledc_timer);
+    }
+
+    return ESP_OK;
+}
+
+esp_foc_inverter_t *inverter_3pwm_ledc_new(ledc_channel_t ch_u,
+                                        ledc_channel_t ch_v,
+                                        ledc_channel_t ch_w,
+                                        int gpio_u,
+                                        int gpio_v,
+                                        int gpio_w,
+                                        float dc_link_voltage,
+                                        int port)
+{
+    if(port > CONFIG_NOOF_AXIS - 1) {
+        return NULL;
+    }
+
+    if(!ledc_driver_configured) {
+        inverter_3pwm_ledc_init();
+        ledc_driver_configured = true;
+    }
+
+    ledc[port].dc_link_voltage = dc_link_voltage;
+    ledc[port].interface.get_dc_link_voltage = get_dc_link_voltage;
+    ledc[port].interface.set_voltages = set_voltages;
+    ledc[port].interface.set_inverter_callback = set_inverter_callback;
+    ledc[port].interface.phase_remap = phase_remap;
+    ledc[port].interface.get_inverter_pwm_rate = get_inverter_pwm_rate;
+    ledc[port].ledc_channel[0] = ch_u;
+    ledc[port].ledc_channel[1] = ch_v;
+    ledc[port].ledc_channel[2] = ch_w;
+
+    ledc_channel_config_t ledc_channel[3] =  {
+        {
+            .channel    = ch_u,
+            .duty       = 0,
+            .gpio_num   = gpio_u,
+            .speed_mode = LEDC_LOW_SPEED_MODE,
+            .hpoint     = 0,
+            .timer_sel  = ledc_timers[port]
+        },
+
+        {
+            .channel    = ch_v,
+            .duty       = 0,
+            .gpio_num   = gpio_v,
+            .speed_mode = LEDC_LOW_SPEED_MODE,
+            .hpoint     = 0,
+            .timer_sel  = ledc_timers[port]
+        },
+
+        {
+            .channel    = ch_w,
+            .duty       = 0,
+            .gpio_num   = gpio_w,
+            .speed_mode = LEDC_LOW_SPEED_MODE,
+            .hpoint     = 0,
+            .timer_sel  = ledc_timers[port]
+        },
+    };
+
+    for (int ch = 0; ch < 3; ch++) {
+        esp_err_t err = ledc_channel_config(&ledc_channel[ch]);
+        if(err != ESP_OK) {
+            return NULL;
+        }
+    }
+
+    ledc[port].hw = LEDC_LL_GET_HW();
+    ledc[port].voltage_to_duty_ratio = LEDC_RESOLUTION_STEPS / ledc[port].dc_link_voltage;
+
+    return &ledc[port].interface;
+}

--- a/esp_foc/drivers/os_interface.c
+++ b/esp_foc/drivers/os_interface.c
@@ -1,0 +1,91 @@
+#include <sys/cdefs.h>
+#include <unistd.h>
+#include "espFoC/esp_foc.h"
+#include "esp_attr.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "xtensa/hal.h"
+
+static const float scale = 0.000001f;
+static uint32_t cp0_regs[18];
+static uint32_t cp_state;
+static portMUX_TYPE spinlock =  portMUX_INITIALIZER_UNLOCKED;
+
+int esp_foc_create_runner(foc_loop_runner runner, void *argument, int priority)
+{
+    int ret = xTaskCreatePinnedToCore(runner,"", CONFIG_FOC_TASK_STACK_SIZE, argument, priority, NULL, APP_CPU_NUM);
+
+    if (ret != pdPASS) {
+        return -ESP_ERR_NO_MEM;
+    }
+
+    return 0;
+}
+
+void esp_foc_sleep_ms(int sleep_ms)
+{
+    usleep(sleep_ms * 1000);
+}
+
+void esp_foc_runner_yield(void)
+{
+    taskYIELD();
+}
+
+float esp_foc_now_seconds(void)
+{
+    float now = (float)esp_timer_get_time();
+    return(now * scale);
+}
+
+/* the fpu in isr tricks below are required for xtensa based archs: */
+void esp_foc_fpu_isr_enter(void)
+{
+    cp_state = xthal_get_cpenable();
+
+    if(cp_state) {
+        xthal_save_cp0(cp0_regs);   
+    } else {
+        xthal_set_cpenable(1);
+    }
+}
+
+void esp_foc_fpu_isr_leave(void)
+{
+    if(cp_state) {
+        xthal_restore_cp0(cp0_regs);
+    } else {
+        xthal_set_cpenable(0);
+    }
+
+}
+
+void esp_foc_critical_enter(void)
+{
+    portENTER_CRITICAL(&spinlock);
+}
+
+void esp_foc_critical_leave(void)
+{
+    portEXIT_CRITICAL(&spinlock);
+}
+
+esp_foc_event_handle_t esp_foc_get_event_handle(void)
+{
+    return ((esp_foc_event_handle_t) xTaskGetCurrentTaskHandle());
+}
+
+void esp_foc_wait_notifier(void)
+{
+    ulTaskNotifyTake(pdFALSE ,portMAX_DELAY);
+}
+
+void esp_foc_send_notification(esp_foc_event_handle_t handle)
+{
+    BaseType_t wake;
+    vTaskNotifyGiveFromISR((TaskHandle_t)handle, &wake);
+    if (wake == pdTRUE) {
+        portYIELD_FROM_ISR();
+    }
+}

--- a/esp_foc/drivers/rotor_sensor_as5600.c
+++ b/esp_foc/drivers/rotor_sensor_as5600.c
@@ -1,0 +1,140 @@
+#include <math.h>
+#include "espFoC/rotor_sensor_as5600.h"
+#include "driver/gpio.h"
+#include "driver/i2c.h"
+#include "esp_err.h"
+#include "esp_attr.h"
+#include "esp_log.h"
+
+#define AS5600_SLAVE_ADDR 0x36
+#define AS5600_ANGLE_REGISTER_H 0x0E
+#define AS5600_PULSES_PER_REVOLUTION 4096.0f
+#define AS5600_READING_MASK 0xFFF 
+
+const char *tag = "ROTOR_SENSOR_AS5600";
+
+typedef struct {
+    float accumulated;
+    float previous;
+    uint16_t zero_offset;
+    int i2c_port;
+    esp_foc_rotor_sensor_t interface;
+}esp_foc_as5600_t;
+
+static bool i2c_bus_configured = false;
+
+DRAM_ATTR static esp_foc_as5600_t rotor_sensors[CONFIG_NOOF_AXIS];
+static const float encoder_wrap_value = AS5600_PULSES_PER_REVOLUTION * 0.95f;
+
+IRAM_ATTR static uint16_t read_angle_sensor(int i2c_port) 
+{
+    uint8_t write_buffer = AS5600_ANGLE_REGISTER_H;
+    uint8_t read_buffer[2] = {0,0};
+    uint16_t raw;
+    esp_err_t err;
+
+    do {
+        err =  i2c_master_write_read_device(i2c_port,
+                                        AS5600_SLAVE_ADDR,
+                                        &write_buffer,
+                                        1,
+                                        read_buffer,
+                                        2,
+                                        portMAX_DELAY);
+ 
+    } while (err != ESP_OK);
+
+    raw = read_buffer[0];
+    raw <<= 8;
+    raw |= read_buffer[1];
+
+    if(raw > AS5600_PULSES_PER_REVOLUTION - 1) {
+        raw = AS5600_PULSES_PER_REVOLUTION - 1 ;
+    }
+
+    return raw;
+}
+
+IRAM_ATTR float read_accumulated_counts (esp_foc_rotor_sensor_t *self)
+{
+    esp_foc_as5600_t *obj =
+        __containerof(self,esp_foc_as5600_t, interface);
+
+    return obj->accumulated + obj->previous;
+}
+
+IRAM_ATTR  static void set_to_zero(esp_foc_rotor_sensor_t *self)
+{
+    esp_foc_as5600_t *obj =
+        __containerof(self,esp_foc_as5600_t, interface);
+
+    obj->zero_offset = read_angle_sensor(obj->i2c_port);
+    ESP_LOGI(tag, "Setting %d [ticks] as offset.", obj->zero_offset);
+}
+
+IRAM_ATTR static float get_counts_per_revolution(esp_foc_rotor_sensor_t *self)
+{
+    (void)self;
+    return AS5600_PULSES_PER_REVOLUTION;
+}
+
+IRAM_ATTR static float read_counts(esp_foc_rotor_sensor_t *self)
+{
+    esp_foc_as5600_t *obj =
+        __containerof(self,esp_foc_as5600_t, interface);
+
+    uint16_t raw = read_angle_sensor(obj->i2c_port) & AS5600_READING_MASK;
+
+    esp_foc_critical_enter();
+
+    float delta = (float)raw - obj->previous;
+
+    if(fabs(delta) >= encoder_wrap_value) {
+        obj->accumulated = (delta < 0.0f) ? 
+            obj->accumulated + AS5600_PULSES_PER_REVOLUTION :
+                obj->accumulated - AS5600_PULSES_PER_REVOLUTION;
+    }
+
+    obj->previous = (float)raw;
+
+    esp_foc_critical_leave();
+
+    return((float)((raw - obj->zero_offset) & AS5600_READING_MASK));
+}
+
+esp_foc_rotor_sensor_t *rotor_sensor_as5600_new(int pin_sda,
+                                                int pin_scl,
+                                                int port)
+{
+    if(port > CONFIG_NOOF_AXIS - 1) {
+        return NULL;
+    }
+
+    rotor_sensors[port].interface.get_counts_per_revolution = get_counts_per_revolution;
+    rotor_sensors[port].interface.read_counts = read_counts;
+    rotor_sensors[port].interface.set_to_zero = set_to_zero;
+    rotor_sensors[port].interface.read_accumulated_counts = read_accumulated_counts;
+    rotor_sensors[port].i2c_port = I2C_NUM_0;
+    rotor_sensors[port].zero_offset = 0;
+    rotor_sensors[port].previous = 0;
+    rotor_sensors[port].accumulated = 0;
+
+    if(!i2c_bus_configured) {
+        i2c_config_t conf = {
+            .mode = I2C_MODE_MASTER,
+            .sda_io_num = pin_sda,
+            .scl_io_num = pin_scl,
+            .sda_pullup_en = GPIO_PULLUP_ENABLE,
+            .scl_pullup_en = GPIO_PULLUP_ENABLE,
+            .master.clk_speed = 1000000,
+        };
+
+        i2c_param_config(I2C_NUM_0, &conf);
+        i2c_driver_install(I2C_NUM_0, conf.mode, 0, 0, 0);
+        i2c_filter_enable(I2C_NUM_0, 7);
+
+        i2c_bus_configured = true;
+    }
+
+    return &rotor_sensors[port].interface;
+}

--- a/esp_foc/drivers/rotor_sensor_dummy.c
+++ b/esp_foc/drivers/rotor_sensor_dummy.c
@@ -1,0 +1,90 @@
+#include <math.h>
+#include "espFoC/rotor_sensor_dummy.h"
+#include "esp_err.h"
+#include "esp_attr.h"
+#include "esp_log.h"
+
+#define AS5600_SLAVE_ADDR 0x36
+#define AS5600_ANGLE_REGISTER_H 0x0E
+#define AS5600_PULSES_PER_REVOLUTION 4096.0f
+#define AS5600_READING_MASK 0xFFF 
+
+const char *tag = "ROTOR_SENSOR_AS5600";
+
+typedef struct {
+    float accumulated;
+    float raw;
+    float previous;
+    esp_foc_rotor_sensor_t interface;
+}esp_foc_dummy_t;
+
+DRAM_ATTR static esp_foc_dummy_t rotor_sensors[CONFIG_NOOF_AXIS];
+
+IRAM_ATTR float read_accumulated_counts (esp_foc_rotor_sensor_t *self)
+{
+    esp_foc_dummy_t *obj =
+        __containerof(self,esp_foc_dummy_t, interface);
+
+    return obj->accumulated + obj->previous;
+}
+
+IRAM_ATTR  static void set_to_zero(esp_foc_rotor_sensor_t *self)
+{
+    esp_foc_dummy_t *obj =
+        __containerof(self,esp_foc_dummy_t, interface);
+
+    obj->raw = 0;
+}
+
+IRAM_ATTR static float get_counts_per_revolution(esp_foc_rotor_sensor_t *self)
+{
+    (void)self;
+    return 4096.0f;
+}
+
+IRAM_ATTR static float read_counts(esp_foc_rotor_sensor_t *self)
+{
+    esp_foc_dummy_t *obj =
+        __containerof(self,esp_foc_dummy_t, interface);
+
+ 
+    esp_foc_critical_enter();
+
+    obj->raw += 40.96f;
+
+    if(obj->raw > 4096.0f) {
+        obj->raw -= 4096.0f;
+    } else if (obj->raw < 0.0f) {
+        obj->raw += 4096.0f;
+    }
+
+    float delta = (float)obj->raw - obj->previous;
+
+    if(fabs(delta) >= 3600.0f) {
+        obj->accumulated = (delta < 0.0f) ? 
+            obj->accumulated + 4096.0f :
+                obj->accumulated - 4096.0f;
+    }
+
+    obj->previous = (float)obj->raw;
+
+    esp_foc_critical_leave();
+
+    return(obj->raw);
+}
+
+esp_foc_rotor_sensor_t *rotor_sensor_dummy_new(int port)
+{
+    if(port > CONFIG_NOOF_AXIS - 1) {
+        return NULL;
+    }
+
+    rotor_sensors[port].interface.get_counts_per_revolution = get_counts_per_revolution;
+    rotor_sensors[port].interface.read_counts = read_counts;
+    rotor_sensors[port].interface.set_to_zero = set_to_zero;
+    rotor_sensors[port].interface.read_accumulated_counts = read_accumulated_counts;
+    rotor_sensors[port].raw = 0;
+    rotor_sensors[port].accumulated = 0;
+
+    return &rotor_sensors[port].interface;
+}

--- a/esp_foc/esp_foc.c
+++ b/esp_foc/esp_foc.c
@@ -1,0 +1,485 @@
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include "espFoC/esp_foc.h"
+#include "esp_attr.h"
+#include "esp_log.h"
+
+static const char * tag = "ESP_FOC";
+
+static inline float esp_foc_ticks_to_radians_normalized(esp_foc_axis_t *axis)
+{
+    axis->rotor_shaft_ticks = 
+        axis->rotor_sensor_driver->read_counts(axis->rotor_sensor_driver);
+    
+    esp_foc_critical_enter();
+
+    axis->rotor_position = 
+        axis->rotor_shaft_ticks * axis->shaft_ticks_to_radians_ratio * axis->natural_direction;
+
+    esp_foc_critical_leave();
+
+    return esp_foc_normalize_angle(
+        esp_foc_mechanical_to_elec_angle(
+            axis->rotor_position, axis->motor_pole_pairs
+        )
+    );
+}
+
+static inline void esp_foc_motor_speed_estimator(esp_foc_axis_t * axis)
+{
+    axis->accumulated_rotor_position = axis->rotor_sensor_driver->read_accumulated_counts(axis->rotor_sensor_driver) *
+        axis->shaft_ticks_to_radians_ratio;
+
+    axis->current_speed =  (axis->accumulated_rotor_position - axis->rotor_position_prev) * 
+                        axis->estimators_sample_rate;
+                        
+    axis->rotor_position_prev = axis->accumulated_rotor_position;        
+}
+
+static inline void esp_foc_position_control_loop(esp_foc_axis_t *axis)
+{
+    /* position control is disabled */
+    if(!axis->downsampling_position_reload_value) return;
+
+    axis->downsampling_position--;
+
+    if(axis->downsampling_position == 0) {
+        axis->downsampling_position = axis->downsampling_position_reload_value;
+
+        axis->target_speed = esp_foc_pid_update( &axis->position_controller,
+                                            axis->target_position,
+                                            axis->accumulated_rotor_position);
+    }
+}
+
+static inline void esp_foc_velocity_control_loop(esp_foc_axis_t *axis)
+{
+    /* speed control is disabled */
+    if(!axis->downsampling_speed_reload_value) return;
+
+    axis->downsampling_speed--;
+
+    if(axis->downsampling_speed == 0) {
+        esp_foc_motor_speed_estimator(axis);
+
+        axis->downsampling_speed = axis->downsampling_speed_reload_value;
+
+        axis->target_i_q.raw = esp_foc_pid_update( &axis->velocity_controller,
+                                            axis->target_speed,
+                                            esp_foc_low_pass_filter_update(
+                                            &axis->velocity_filter,
+                                            axis->current_speed)) ;
+        axis->target_i_d.raw = 0.0f;
+    }
+}
+
+
+static inline void esp_foc_torque_control_loop(esp_foc_axis_t *axis)
+{
+
+    axis->u_q.raw = esp_foc_pid_update( &axis->torque_controller[0],
+                                        axis->target_i_q.raw,
+                                        esp_foc_low_pass_filter_update(
+                                            &axis->current_filters[0], axis->i_q.raw)) +
+                                            axis->target_u_q.raw;
+   
+    axis->u_d.raw = esp_foc_pid_update( &axis->torque_controller[1],
+                                        axis->target_i_d.raw,
+                                        esp_foc_low_pass_filter_update(
+                                            &axis->current_filters[1], axis->i_d.raw)) +
+                                            axis->target_u_d.raw;
+
+}
+
+IRAM_ATTR static void esp_foc_control_loop(void *arg)
+{
+    esp_foc_axis_t *axis = (esp_foc_axis_t *)arg;
+    
+    esp_foc_position_control_loop(axis);
+    esp_foc_velocity_control_loop(axis);
+    esp_foc_torque_control_loop(axis);
+
+    esp_foc_modulate_dq_voltage(axis->biased_dc_link_voltage, 
+                    axis->rotor_elec_angle, 
+                    axis->u_d.raw, 
+                    axis->u_q.raw, 
+                    &axis->u_u.raw, 
+                    &axis->u_v.raw, 
+                    &axis->u_w.raw);
+
+    axis->inverter_driver->set_voltages(axis->inverter_driver,
+                                        axis->u_u.raw, 
+                                        axis->u_v.raw, 
+                                        axis->u_w.raw);
+
+    if(axis->downsampling_estimators > 0) {
+        axis->downsampling_estimators--;
+        if(axis->downsampling_estimators == 0) {
+            axis->downsampling_estimators = axis->downsampling_estimators_reload_val;
+            esp_foc_send_notification(axis->ev_handle);
+        }
+    }
+}
+
+IRAM_ATTR static void esp_foc_sensors_loop(void *arg)
+{
+    esp_foc_axis_t *axis = (esp_foc_axis_t *)arg;
+    float now;
+    axis->ev_handle = esp_foc_get_event_handle();
+    axis->inverter_driver->set_inverter_callback(axis->inverter_driver,
+                                    esp_foc_control_loop,
+                                    axis);
+
+    ESP_LOGI(tag, "Starting foc loop task for axis: %p", axis);
+    ESP_LOGI(tag, "Control loop rate [Samples/S]: %f", axis->inverter_driver->get_inverter_pwm_rate(axis->inverter_driver));
+    ESP_LOGI(tag, "Speed control loop rate [Samples/S]: %f", axis->estimators_sample_rate);
+
+    for(;;) {
+        esp_foc_wait_notifier();
+        now = esp_foc_now_seconds();
+        axis->dt = now - axis->last_timestamp;
+        axis->last_timestamp = now;
+        axis->rotor_elec_angle = esp_foc_ticks_to_radians_normalized(axis); 
+    }
+}
+
+esp_foc_err_t esp_foc_initialize_axis(esp_foc_axis_t *axis,
+                                    esp_foc_inverter_t *inverter,
+                                    esp_foc_rotor_sensor_t *rotor,
+                                    esp_foc_isensor_t *isensor,
+                                    esp_foc_motor_control_settings_t settings)
+{
+    if(axis == NULL) {
+        ESP_LOGE(tag, "invalid axis object!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+
+    if(inverter == NULL) {
+        ESP_LOGE(tag, "invalid inverter driver!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+
+    if(rotor == NULL) {
+        ESP_LOGE(tag, "invalid rotor sensor driver!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+
+    axis->inverter_driver = inverter;
+    axis->rotor_sensor_driver = rotor;
+    axis->isensor_driver = isensor;
+
+    axis->dc_link_voltage = 
+        axis->inverter_driver->get_dc_link_voltage(axis->inverter_driver);
+    axis->biased_dc_link_voltage = axis->dc_link_voltage * 0.5;
+    axis->inverter_driver->set_voltages(axis->inverter_driver, 0.0, 0.0, 0.0);
+    ESP_LOGI(tag,"inverter dc-link voltage: %f[V]", axis->dc_link_voltage);
+
+    axis->dt = 0.0;
+    axis->last_timestamp = 0.0;
+    axis->target_speed = 0.0;
+    axis->target_position = 0.0f;
+    axis->accumulated_rotor_position = 0.0f;
+
+    axis->downsampling_speed_reload_value = 0;
+    axis->downsampling_position_reload_value = 0;
+
+    axis->i_d.raw = 0.0f;
+    axis->i_q.raw = 0.0f;
+    axis->u_d.raw = 0.0f;
+    axis->u_q.raw = 0.0f;
+    axis->target_u_d.raw = 0.0f;
+    axis->target_u_q.raw = 0.0f;
+    axis->target_i_d.raw = 0.0f;
+    axis->target_i_q.raw = 0.0f;
+
+    axis->position_controller.kp = settings.position_control_settings.kp;
+    axis->position_controller.ki = settings.position_control_settings.ki;
+    axis->position_controller.kd = settings.position_control_settings.kd;
+    axis->position_controller.integrator_limit = settings.position_control_settings.integrator_limit;
+    axis->position_controller.max_output_value = settings.position_control_settings.max_output_value;
+    esp_foc_pid_reset(&axis->position_controller);
+    axis->downsampling_position = settings.downsampling_position_rate;
+    axis->downsampling_position_reload_value = settings.downsampling_position_rate;;
+
+    axis->velocity_controller.kp = settings.velocity_control_settings.kp;
+    axis->velocity_controller.ki = settings.velocity_control_settings.ki;
+    axis->velocity_controller.kd = settings.velocity_control_settings.kd;
+    axis->velocity_controller.integrator_limit = settings.velocity_control_settings.integrator_limit;
+    axis->velocity_controller.max_output_value = settings.velocity_control_settings.max_output_value;
+    esp_foc_pid_reset(&axis->velocity_controller);
+    esp_foc_low_pass_filter_init(&axis->velocity_filter, 0.99f);
+    axis->downsampling_speed = settings.downsampling_speed_rate;
+    axis->downsampling_speed_reload_value = settings.downsampling_speed_rate;
+
+    axis->estimators_sample_rate = axis->inverter_driver->get_inverter_pwm_rate(axis->inverter_driver) / 
+        axis->downsampling_speed_reload_value;
+
+    axis->downsampling_estimators_reload_val = 4;
+    axis->downsampling_estimators = 4;
+
+    axis->torque_controller[0].kp = 1.0f;
+    axis->torque_controller[0].ki = 0.0f;
+    axis->torque_controller[0].kd = 0.0f;
+    axis->torque_controller[0].integrator_limit = 0.0f;
+    axis->torque_controller[0].max_output_value = settings.torque_control_settings[0].max_output_value;
+    esp_foc_pid_reset(&axis->torque_controller[0]);
+    esp_foc_low_pass_filter_init(&axis->current_filters[0], 0.9);
+
+    axis->torque_controller[1].kp = 1.0f;
+    axis->torque_controller[1].ki = 0.0f;
+    axis->torque_controller[1].kd = 0.0f;
+    axis->torque_controller[1].integrator_limit = 0.0f;
+    axis->torque_controller[1].max_output_value = settings.torque_control_settings[1].max_output_value;
+    esp_foc_pid_reset(&axis->torque_controller[1]);
+    esp_foc_low_pass_filter_init(&axis->current_filters[1], 0.9);
+
+    axis->motor_pole_pairs = (float)settings.motor_pole_pairs;
+    ESP_LOGI(tag, "Motor poler pairs: %f",  axis->motor_pole_pairs);
+
+    axis->shaft_ticks_to_radians_ratio = ((2.0 * M_PI)) /
+        axis->rotor_sensor_driver->get_counts_per_revolution(axis->rotor_sensor_driver);
+    ESP_LOGI(tag, "Shaft to ticks ratio: %f", axis->shaft_ticks_to_radians_ratio);
+
+    esp_foc_sleep_ms(250);
+    axis->rotor_aligned = ESP_FOC_ERR_NOT_ALIGNED;
+    axis->natural_direction = (settings.natural_direction == ESP_FOC_MOTOR_NATURAL_DIRECTION_CW) ? 
+                                1.0f : -1.0f;
+
+    return ESP_FOC_OK;
+}
+
+esp_foc_err_t esp_foc_align_axis(esp_foc_axis_t *axis)
+{
+    if(axis == NULL) {
+        ESP_LOGE(tag, "Invalid axis object!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+    if(axis->rotor_aligned != ESP_FOC_ERR_NOT_ALIGNED) {
+        ESP_LOGE(tag, "This rotor was aligned already!");
+        return ESP_FOC_ERR_AXIS_INVALID_STATE;
+    }
+    float current_ticks;
+    axis->rotor_aligned = ESP_FOC_ERR_ALIGNMENT_IN_PROGRESS;
+    
+    ESP_LOGI(tag, "Starting to align the rotor");
+
+    axis->inverter_driver->set_voltages(axis->inverter_driver,
+                                        0.0f,
+                                        0.0f,
+                                        0.0f);
+    esp_foc_sleep_ms(500);
+
+    axis->inverter_driver->set_voltages(axis->inverter_driver,
+                                        0.4 * axis->biased_dc_link_voltage,
+                                        0.0f,
+                                        0.0f);
+    esp_foc_sleep_ms(500);
+    current_ticks = axis->rotor_sensor_driver->read_counts(axis->rotor_sensor_driver);
+    ESP_LOGI(tag, "rotor ticks offset: %f [ticks] for Coil U", current_ticks);
+
+    axis->rotor_sensor_driver->set_to_zero(axis->rotor_sensor_driver);
+    axis->rotor_aligned = ESP_FOC_OK;
+    ESP_LOGI(tag, "Done, rotor aligned!");
+    return ESP_FOC_OK;
+}
+
+IRAM_ATTR esp_foc_err_t esp_foc_set_target_voltage(esp_foc_axis_t *axis,
+                                        esp_foc_q_voltage uq,
+                                        esp_foc_d_voltage ud)
+{
+    if(axis == NULL) {
+        ESP_LOGE(tag, "invalid axis object!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+    if(axis->rotor_aligned != ESP_FOC_OK) {
+        ESP_LOGE(tag, "align rotor first!");
+        return ESP_FOC_ERR_AXIS_INVALID_STATE;
+    }
+    esp_foc_critical_enter();
+
+    axis->target_u_q = uq;
+    axis->target_u_d = ud;
+
+    esp_foc_critical_leave();
+    
+    return ESP_FOC_OK;
+}
+
+IRAM_ATTR esp_foc_err_t esp_foc_set_target_speed(esp_foc_axis_t *axis, 
+                                                esp_foc_radians_per_second speed)
+{
+    if(axis == NULL) {
+        ESP_LOGE(tag, "invalid axis object!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+    if(axis->rotor_aligned != ESP_FOC_OK) {
+        ESP_LOGE(tag, "align rotor first!");
+        return ESP_FOC_ERR_AXIS_INVALID_STATE;
+    }
+
+    esp_foc_critical_enter();
+    axis->target_speed = speed.raw;
+    esp_foc_critical_leave();
+    
+    return ESP_FOC_OK;
+}
+
+IRAM_ATTR esp_foc_err_t esp_foc_set_target_position(esp_foc_axis_t *axis, 
+                                                    esp_foc_radians position)
+{
+    if(axis == NULL) {
+        ESP_LOGE(tag, "invalid axis object!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+    if(axis->rotor_aligned != ESP_FOC_OK) {
+        ESP_LOGE(tag, "align rotor first!");
+        return ESP_FOC_ERR_AXIS_INVALID_STATE;
+    }
+
+    esp_foc_critical_enter();
+    axis->target_position = position.raw;
+    esp_foc_critical_leave();
+
+    return ESP_FOC_OK;
+}
+
+esp_foc_err_t esp_foc_run(esp_foc_axis_t *axis)
+{
+    if(axis == NULL) {
+        ESP_LOGE(tag, "invalid axis object!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+    if(axis->rotor_aligned != ESP_FOC_OK) {
+        ESP_LOGE(tag, "align rotor first!");
+        return ESP_FOC_ERR_AXIS_INVALID_STATE;
+    }
+
+    int ret = esp_foc_create_runner(esp_foc_sensors_loop, axis, CONFIG_FOC_TASK_PRIORITY);
+
+    if (ret < 0) {
+        ESP_LOGE(tag, "Check os interface, the runner creation has failed!");
+        return ESP_FOC_ERR_UNKNOWN;
+    }
+
+    return ESP_FOC_OK;
+}
+
+esp_foc_err_t esp_foc_test_motor(esp_foc_inverter_t *inverter,
+                                esp_foc_rotor_sensor_t *rotor,
+                                esp_foc_motor_control_settings_t settings)
+{
+    if(inverter == NULL) {
+        ESP_LOGE(tag, "invalid inverter driver!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+
+    if(rotor == NULL) {
+        ESP_LOGE(tag, "invalid rotor sensor driver!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+
+    ESP_LOGI(tag, "Starting motor test, check the spinning direction !");
+
+    inverter->set_voltages(inverter,
+                            0.2 * (inverter->get_dc_link_voltage(inverter) / 2) , 
+                            0.0f, 
+                            0.0f);
+    esp_foc_sleep_ms(250);
+
+    inverter->set_voltages(inverter,
+                            0.0f,
+                            0.2 * (inverter->get_dc_link_voltage(inverter) / 2) ,  
+                            0.0f);
+    esp_foc_sleep_ms(250);
+
+    /* Turn motor in one direction */
+    for(float i = 0.0f; i < 2 * M_PI * settings.motor_pole_pairs; i += 0.05) {
+        esp_foc_u_voltage u;
+        esp_foc_v_voltage v;
+        esp_foc_w_voltage w;
+        float electrical_angle = settings.motor_pole_pairs * rotor->read_counts(rotor) * 
+                                (((2.0 * M_PI)) / rotor->get_counts_per_revolution(rotor));
+
+        ESP_LOGI(tag, "SVM calculated angle: %f [rad] Caculated electrical angle: %f [rad]", i, electrical_angle);
+
+        esp_foc_modulate_dq_voltage(inverter->get_dc_link_voltage(inverter) / 2, 
+                i, 
+                0.2 * (inverter->get_dc_link_voltage(inverter) / 2), 
+                0.0, 
+                &u.raw, 
+                &v.raw, 
+                &w.raw);
+
+        inverter->set_voltages(inverter,
+                                u.raw, 
+                                v.raw, 
+                                w.raw);
+
+        esp_foc_sleep_ms(10);
+    }
+
+    /* Now in another: */
+    for(float i =  2 * M_PI * settings.motor_pole_pairs; i > 0.0f; i -= 0.05) {
+        esp_foc_u_voltage u;
+        esp_foc_v_voltage v;
+        esp_foc_w_voltage w;
+        float electrical_angle = settings.motor_pole_pairs * rotor->read_counts(rotor) * 
+                                (((2.0 * M_PI)) / rotor->get_counts_per_revolution(rotor));
+
+        ESP_LOGI(tag, "SVM calculated angle: %f [rad] Caculated electrical angle: %f [rad]", i, electrical_angle);
+
+        esp_foc_modulate_dq_voltage(inverter->get_dc_link_voltage(inverter) / 2, 
+                i, 
+                0.2 * (inverter->get_dc_link_voltage(inverter) / 2), 
+                0.0, 
+                &u.raw, 
+                &v.raw, 
+                &w.raw);
+
+        inverter->set_voltages(inverter,
+                                u.raw, 
+                                v.raw, 
+                                w.raw);
+
+        esp_foc_sleep_ms(10);
+    }
+
+    inverter->set_voltages(inverter,
+                            0.0f,
+                            0.0f,  
+                            0.0f);
+
+    ESP_LOGI(tag, "Test finished keep or switch motor phases depending on resultant motion");
+    return ESP_FOC_OK;
+}
+
+esp_foc_err_t esp_foc_get_control_data(esp_foc_axis_t *axis, esp_foc_control_data_t *control_data)
+{
+    if(axis == NULL) {
+        ESP_LOGE(tag, "invalid axis object!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+
+    if(control_data == NULL) {
+        ESP_LOGE(tag, "invalid control data object!");
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+
+    esp_foc_critical_enter();
+
+    control_data->u = axis->u_u;
+    control_data->v = axis->u_v;
+    control_data->w = axis->u_w;
+
+    control_data->out_q = axis->u_q;
+    control_data->out_d = axis->u_d;
+    control_data->dt.raw = axis->dt;
+
+    control_data->position.raw = axis->accumulated_rotor_position;
+    control_data->speed.raw = axis->current_speed;
+
+    esp_foc_critical_leave();
+
+    return ESP_FOC_OK;
+}

--- a/esp_foc/esp_foc_consts.c
+++ b/esp_foc/esp_foc_consts.c
@@ -1,0 +1,15 @@
+#include <math.h>
+
+#ifdef CONFIG_ESP_FOC_CUSTOM_MATH
+const float ESP_FOC_FAST_PI = 3.14159265358f;
+const float ESP_FOC_FAST_2PI = ESP_FOC_FAST_PI * 2.0f;
+const float ESP_FOC_SIN_COS_APPROX_B = 4.0f / ESP_FOC_FAST_PI;
+const float ESP_FOC_SIN_COS_APPROX_C = -4.0f / (ESP_FOC_FAST_PI * ESP_FOC_FAST_PI);
+const float ESP_FOC_SIN_COS_APPROX_P = 0.225f;
+const float ESP_FOC_SIN_COS_APPROX_D = ESP_FOC_FAST_PI/2.0f; 
+#endif
+
+const float ESP_FOC_CLARKE_K1 = 2.0/3.0f;
+const float ESP_FOC_CLARKE_K2 = 1.0/3.0f;
+const float ESP_FOC_CLARKE_PARK_SQRT3 = 1.73205080757f;
+const float ESP_FOC_CLARKE_K3 = 2.0f / ESP_FOC_CLARKE_PARK_SQRT3;

--- a/esp_foc/idf_component.yml
+++ b/esp_foc/idf_component.yml
@@ -1,0 +1,5 @@
+version: "0.0.1"
+description: Vector FoC controller for PMSM motors for ESP-IDF
+url: https://github.com/espressif/idf-extra-components/tree/master/esp_foc
+dependencies:
+  idf: ">=4.4"

--- a/esp_foc/include/espFoC/current_sensor_interface.h
+++ b/esp_foc/include/espFoC/current_sensor_interface.h
@@ -1,0 +1,18 @@
+#pragma once
+
+typedef struct {
+    float iu_axis_0;
+    float iv_axis_0;
+    float iw_axis_0;
+
+    float iu_axis_1;
+    float iv_axis_1;
+    float iw_axis_1;
+} isensor_values_t;
+
+typedef struct esp_foc_isensor_s esp_foc_isensor_t;
+
+struct esp_foc_isensor_s {
+    void (*fetch_isensors)(esp_foc_isensor_t *self, isensor_values_t *values);
+    void (*sample_isensors)(esp_foc_isensor_t *self);
+};

--- a/esp_foc/include/espFoC/ema_low_pass_filter.h
+++ b/esp_foc/include/espFoC/ema_low_pass_filter.h
@@ -1,0 +1,30 @@
+#pragma once
+
+typedef struct {
+    float alpha;
+    float beta;
+    float y_n_prev;
+} esp_foc_lp_filter_t;
+
+static inline void esp_foc_low_pass_filter_init(esp_foc_lp_filter_t *filter,
+                                                float alpha)
+{
+    if(alpha > 1.0f) {
+        alpha = 1.0f;
+    } else if (alpha < 0.0f) {
+        alpha = 0.0f;
+    } 
+
+    filter->y_n_prev = 0.0f;
+    filter->alpha = alpha;
+    filter->beta = 1.0f - alpha;
+
+}
+
+static inline float esp_foc_low_pass_filter_update(esp_foc_lp_filter_t *filter,
+                                                  float x_n)
+{
+    float y_n = filter->alpha * x_n + filter->beta * filter->y_n_prev;
+    filter->y_n_prev = y_n;
+    return y_n;
+}

--- a/esp_foc/include/espFoC/esp_foc.h
+++ b/esp_foc/include/espFoC/esp_foc.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <math.h>
+#include "espFoC/ema_low_pass_filter.h"
+#include "espFoC/foc_math.h"
+#include "espFoC/modulator.h"
+#include "espFoC/pid_controller.h"
+#include "espFoC/inverter_interface.h"
+#include "espFoC/current_sensor_interface.h"
+#include "espFoC/rotor_sensor_interface.h"
+#include "espFoC/os_interface.h"
+#include "espFoC/esp_foc_units.h"
+
+typedef enum {
+    ESP_FOC_OK = 0,
+    ESP_FOC_ERR_NOT_ALIGNED = -1,
+    ESP_FOC_ERR_INVALID_ARG = -2,
+    ESP_FOC_ERR_AXIS_INVALID_STATE = -3,
+    ESP_FOC_ERR_ALIGNMENT_IN_PROGRESS = -4,
+    ESP_FOC_ERR_TIMESTEP_TOO_SMALL = -5,
+    ESP_FOC_ERR_UNKNOWN = -128
+} esp_foc_err_t;
+
+#include "espFoC/esp_foc_axis.h"
+
+typedef enum {
+    ESP_FOC_MOTOR_NATURAL_DIRECTION_CW,
+    ESP_FOC_MOTOR_NATURAL_DIRECTION_CCW,
+} esp_foc_motor_direction_t;
+
+typedef struct {
+    float kp;
+    float ki;
+    float kd;
+    float integrator_limit;
+    float max_output_value;
+} esp_foc_control_settings_t;
+
+typedef struct {
+    esp_foc_control_settings_t torque_control_settings[2];
+    esp_foc_control_settings_t velocity_control_settings;
+    esp_foc_control_settings_t position_control_settings;
+    int downsampling_speed_rate;
+    int downsampling_position_rate;
+    int motor_pole_pairs;
+    int estimators_rate;
+    esp_foc_motor_direction_t natural_direction;
+} esp_foc_motor_control_settings_t;
+
+typedef struct {
+    esp_foc_seconds dt;
+    esp_foc_u_voltage u;
+    esp_foc_v_voltage v;
+    esp_foc_w_voltage w;
+
+    esp_foc_q_voltage out_q;
+    esp_foc_d_voltage out_d;
+
+    esp_foc_radians position;
+    esp_foc_radians_per_second speed;
+} esp_foc_control_data_t;
+
+
+esp_foc_err_t esp_foc_initialize_axis(esp_foc_axis_t *axis,
+                                    esp_foc_inverter_t *inverter,
+                                    esp_foc_rotor_sensor_t *rotor,
+                                    esp_foc_isensor_t *isensor,
+                                    esp_foc_motor_control_settings_t settings);
+
+esp_foc_err_t esp_foc_align_axis(esp_foc_axis_t *axis);
+
+esp_foc_seconds esp_foc_get_runner_dt(esp_foc_axis_t *axis);
+
+esp_foc_err_t esp_foc_set_target_voltage(esp_foc_axis_t *axis,
+                                        esp_foc_q_voltage uq,
+                                        esp_foc_d_voltage ud);                                        
+
+esp_foc_err_t esp_foc_set_target_speed(esp_foc_axis_t *axis, esp_foc_radians_per_second speed);
+
+esp_foc_err_t esp_foc_set_target_position(esp_foc_axis_t *axis, esp_foc_radians position);
+
+esp_foc_err_t esp_foc_get_control_data(esp_foc_axis_t *axis, esp_foc_control_data_t *control_data);
+
+esp_foc_err_t esp_foc_run(esp_foc_axis_t *axis);
+
+esp_foc_err_t esp_foc_test_motor(esp_foc_inverter_t *inverter,
+                                esp_foc_rotor_sensor_t *rotor,
+                                esp_foc_motor_control_settings_t settings);

--- a/esp_foc/include/espFoC/esp_foc_axis.h
+++ b/esp_foc/include/espFoC/esp_foc_axis.h
@@ -1,0 +1,69 @@
+#pragma once
+
+typedef struct {
+    esp_foc_q_current target_i_q;
+    esp_foc_d_current target_i_d;
+
+    esp_foc_q_current i_q;
+    esp_foc_d_current i_d;
+
+    esp_foc_q_voltage u_q;
+    esp_foc_d_voltage u_d;
+
+    esp_foc_q_voltage target_u_q;
+    esp_foc_d_voltage target_u_d;
+
+    esp_foc_alpha_voltage u_alpha;
+    esp_foc_beta_voltage u_beta;
+
+    esp_foc_u_voltage u_u;
+    esp_foc_v_voltage u_v;
+    esp_foc_w_voltage u_w;
+
+    esp_foc_alpha_current i_alpha;
+    esp_foc_beta_current i_beta;
+
+    esp_foc_u_current i_u;
+    esp_foc_v_current i_v;
+    esp_foc_w_current i_w;
+
+    float target_speed;
+    float current_speed;
+    float shaft_ticks_to_radians_ratio;
+    float dt;
+    float last_timestamp;
+    int downsampling_speed_reload_value;
+    int downsampling_speed;
+
+    float target_position;
+    float rotor_position;
+    float accumulated_rotor_position;
+    float rotor_position_prev;
+    float rotor_shaft_ticks;
+    float rotor_elec_angle;
+    int downsampling_position_reload_value;
+    int downsampling_position;
+
+    float dc_link_voltage;
+    float biased_dc_link_voltage;
+    float motor_pole_pairs;
+    float natural_direction;
+    
+    float estimators_sample_rate;
+    int downsampling_estimators;
+    int downsampling_estimators_reload_val;
+
+    esp_foc_err_t rotor_aligned;
+    esp_foc_pid_controller_t velocity_controller;
+    esp_foc_pid_controller_t torque_controller[2];
+    esp_foc_pid_controller_t position_controller;
+    esp_foc_lp_filter_t velocity_filter;
+    esp_foc_lp_filter_t current_filters[2];
+
+    esp_foc_inverter_t * inverter_driver;
+    esp_foc_rotor_sensor_t *rotor_sensor_driver;
+    esp_foc_isensor_t *isensor_driver;
+    esp_foc_event_handle_t ev_handle;
+    esp_foc_event_handle_t control_handle;
+
+} esp_foc_axis_t;

--- a/esp_foc/include/espFoC/esp_foc_units.h
+++ b/esp_foc/include/espFoC/esp_foc_units.h
@@ -1,0 +1,69 @@
+#pragma once
+
+typedef struct {
+    float raw;
+} esp_foc_q_voltage;
+
+typedef struct {
+    float raw;
+} esp_foc_d_voltage;
+
+typedef struct {
+    float raw;
+} esp_foc_alpha_voltage;
+
+typedef struct {
+    float raw;
+} esp_foc_beta_voltage;
+
+typedef struct {
+    float raw;
+} esp_foc_u_voltage;
+
+typedef struct {
+    float raw;
+} esp_foc_v_voltage;
+
+typedef struct {
+    float raw;
+} esp_foc_w_voltage;
+
+typedef struct {
+    float raw;
+} esp_foc_q_current;
+
+typedef struct {
+    float raw;
+} esp_foc_d_current;
+
+typedef struct {
+    float raw;
+} esp_foc_alpha_current;
+
+typedef struct {
+    float raw;
+} esp_foc_beta_current;
+
+typedef struct {
+    float raw;
+} esp_foc_u_current;
+
+typedef struct {
+    float raw;
+} esp_foc_v_current;
+
+typedef struct {
+    float raw;
+} esp_foc_w_current;
+
+typedef struct {
+    float raw;
+} esp_foc_radians_per_second;
+
+typedef struct {
+    float raw;
+} esp_foc_radians;
+
+typedef struct {
+    float raw;
+} esp_foc_seconds;

--- a/esp_foc/include/espFoC/foc_math.h
+++ b/esp_foc/include/espFoC/foc_math.h
@@ -1,0 +1,113 @@
+#pragma once 
+
+#ifdef CONFIG_ESP_FOC_CUSTOM_MATH
+extern const float ESP_FOC_FAST_PI;
+extern const float ESP_FOC_FAST_2PI;
+extern const float ESP_FOC_SIN_COS_APPROX_B;
+extern const float ESP_FOC_SIN_COS_APPROX_C;
+extern const float ESP_FOC_SIN_COS_APPROX_P;
+extern const float ESP_FOC_SIN_COS_APPROX_D;
+#endif
+ 
+extern const float ESP_FOC_CLARKE_K1;
+extern const float ESP_FOC_CLARKE_K2;
+extern const float ESP_FOC_CLARKE_PARK_SQRT3;
+extern const float ESP_FOC_CLARKE_K3;
+
+static inline float esp_foc_sine(float x) 
+{
+#ifdef CONFIG_ESP_FOC_CUSTOM_MATH
+    float y = ESP_FOC_SIN_COS_APPROX_B * x + 
+        ESP_FOC_SIN_COS_APPROX_C * x * (x < 0 ? -x : x);
+    return ESP_FOC_SIN_COS_APPROX_P * (y * (y < 0 ? -y : y) - y) + y;
+#else
+    return sinf(x);
+#endif
+}
+
+static inline float esp_foc_cosine(float x)
+{
+#ifdef CONFIG_ESP_FOC_CUSTOM_MATH
+    x = (x > 0) ? -x : x;
+    x += ESP_FOC_SIN_COS_APPROX_D;
+
+    return esp_foc_sine(x);
+#else
+    return cosf(x);
+#endif
+}
+
+static inline float esp_foc_mechanical_to_elec_angle(float mech_angle, 
+                                                    float pole_pairs)
+{
+    return(mech_angle * pole_pairs);
+}
+
+static inline float esp_foc_normalize_angle(float angle)
+{
+#ifdef CONFIG_ESP_FOC_CUSTOM_MATH
+    float result =  fmod(angle, ESP_FOC_FAST_2PI);
+    if(result > ESP_FOC_FAST_PI) {
+        result -= ESP_FOC_FAST_2PI;  
+    }
+#else 
+    const float full2pi = M_PI * 2.0f;
+    float result =  fmod(angle, full2pi);
+
+    if(result > M_PI) {
+        result -= full2pi;  
+    }
+#endif
+
+    return result;
+}
+
+static inline void esp_foc_clarke_transform (float v_uvw[3], 
+                                            float * v_aplha, 
+                                            float *v_beta)
+{
+    *v_aplha = ESP_FOC_CLARKE_K1 * v_uvw[0] - 
+        ESP_FOC_CLARKE_K2 * (v_uvw[1] - v_uvw[2]);
+
+    *v_beta = ESP_FOC_CLARKE_K3  * (v_uvw[1] - v_uvw[2]);
+}
+
+static inline void esp_foc_park_transform (float theta,
+                                        float v_ab[2],
+                                        float *v_d,
+                                        float *v_q)
+{
+    float sin = esp_foc_sine(theta);
+    float cos = esp_foc_cosine(theta);
+
+    *v_d = v_ab[0] * cos +
+        v_ab[1] * sin;
+    
+    *v_q = v_ab[1] * cos -
+        v_ab[0] * sin;    
+}
+
+static inline void esp_foc_inverse_clarke_transform (float v_ab[2],
+                                                    float *v_u,
+                                                    float *v_v,
+                                                    float *v_w)
+{
+    *v_u = v_ab[0];
+    *v_v = (-v_ab[0] + ESP_FOC_CLARKE_PARK_SQRT3 * v_ab[1]) * 0.5f;
+    *v_w = (-v_ab[0] - ESP_FOC_CLARKE_PARK_SQRT3 * v_ab[1]) * 0.5f;  
+}
+
+static inline void esp_foc_inverse_park_transform (float theta,
+                                                float v_dq[2],
+                                                float *v_alpha,
+                                                float *v_beta)
+{
+    float sin = esp_foc_sine(theta);
+    float cos = esp_foc_cosine(theta);
+
+    *v_alpha = v_dq[0] * cos -
+        v_dq[1] * sin;
+    
+    *v_beta = v_dq[1] * cos +
+        v_dq[0] * sin;    
+}

--- a/esp_foc/include/espFoC/inverter_interface.h
+++ b/esp_foc/include/espFoC/inverter_interface.h
@@ -1,0 +1,18 @@
+#pragma once
+
+typedef void (*esp_foc_inverter_callback_t) (void *argument);
+
+typedef struct esp_foc_inverter_s esp_foc_inverter_t;
+
+struct esp_foc_inverter_s {
+    void (*set_inverter_callback)(esp_foc_inverter_t *self,
+                        esp_foc_inverter_callback_t callback,
+                        void *argument);
+    float (*get_dc_link_voltage)(esp_foc_inverter_t *self);
+    void (*set_voltages)(esp_foc_inverter_t *self,
+                        float v_u,
+                        float v_v,
+                        float v_w);
+    void (*phase_remap)(esp_foc_inverter_t *self);
+    float (*get_inverter_pwm_rate)(esp_foc_inverter_t *self);
+};

--- a/esp_foc/include/espFoC/modulator.h
+++ b/esp_foc/include/espFoC/modulator.h
@@ -1,0 +1,33 @@
+#pragma once
+
+static inline void esp_foc_modulate_dq_voltage (float vbus_bias,
+                                            float theta,
+                                            float v_d,
+                                            float v_q,
+                                            float *v_u,
+                                            float *v_v,
+                                            float *v_w)
+{
+    float dq_frame[2] = {v_d, v_q};
+    float ab_frame[2];
+
+    esp_foc_inverse_park_transform(theta, dq_frame, &ab_frame[0], &ab_frame[1]);
+    esp_foc_inverse_clarke_transform(ab_frame, v_u,v_v,v_w);
+
+    *v_u += vbus_bias;
+    *v_v += vbus_bias;
+    *v_w += vbus_bias;   
+}
+
+static inline void esp_foc_get_dq_currents(float theta,
+                                        float i_u, 
+                                        float i_v, 
+                                        float i_w, 
+                                        float *i_q, 
+                                        float *i_d) {
+    
+    float phase_current_frame[3] = {i_u, i_v, i_w};
+    float ab_frame[2];
+    esp_foc_clarke_transform(phase_current_frame,&ab_frame[0], &ab_frame[1]);
+    esp_foc_park_transform(theta, ab_frame, i_d, i_q);
+}

--- a/esp_foc/include/espFoC/os_interface.h
+++ b/esp_foc/include/espFoC/os_interface.h
@@ -1,0 +1,16 @@
+#pragma once
+
+typedef void (*foc_loop_runner) (void *arg);
+typedef void*  esp_foc_event_handle_t;
+
+int esp_foc_create_runner(foc_loop_runner runner, void *argument, int priority);
+void esp_foc_sleep_ms(int sleep_ms);
+void esp_foc_runner_yield(void);
+float esp_foc_now_seconds(void);
+void esp_foc_fpu_isr_enter(void);
+void esp_foc_fpu_isr_leave(void);
+void esp_foc_critical_enter(void);
+void esp_foc_critical_leave(void);
+esp_foc_event_handle_t esp_foc_get_event_handle(void);
+void esp_foc_wait_notifier(void);
+void esp_foc_send_notification(esp_foc_event_handle_t handle);

--- a/esp_foc/include/espFoC/pid_controller.h
+++ b/esp_foc/include/espFoC/pid_controller.h
@@ -1,0 +1,54 @@
+#pragma once
+
+typedef struct {
+    float kp;
+    float ki; /** ki = kp ( 1 / n * Ts) */
+    float kd; /** kd = kp * n * Ts */
+
+    float integrator_limit;
+    float accumulated_error;
+    float previous_error;
+    float max_output_value;
+
+}esp_foc_pid_controller_t;
+
+static inline float esp_foc_saturate(float value, float limit) 
+{
+    float result = value;
+    if (value > limit) {
+        result = limit;
+    } else if (value < -limit) {
+        result = -limit;
+    }
+
+    return result;
+}
+
+static inline void esp_foc_pid_reset(esp_foc_pid_controller_t *self)
+{
+    self->accumulated_error = 0.0f;
+    self->previous_error = 0.0f;
+}
+
+static inline float  esp_foc_pid_update(esp_foc_pid_controller_t *self,
+                                        float reference,
+                                        float measure)
+{
+    float error = reference - measure;
+    float error_diff = error - self->previous_error;
+    self->accumulated_error += error;
+
+    self->previous_error = error;
+
+    if(self->accumulated_error > self->integrator_limit) {
+        self->accumulated_error = self->integrator_limit;
+    } else if (self->accumulated_error < -self->integrator_limit) {
+        self->accumulated_error = -self->integrator_limit;
+    }
+
+    float mv = (self->kp * error) + 
+            (self->ki * self->accumulated_error) + 
+            (self->kd * error_diff);
+
+    return esp_foc_saturate(mv, self->max_output_value);
+}

--- a/esp_foc/include/espFoC/rotor_sensor_interface.h
+++ b/esp_foc/include/espFoC/rotor_sensor_interface.h
@@ -1,0 +1,11 @@
+#pragma once 
+
+typedef struct esp_foc_rotor_sensor_s esp_foc_rotor_sensor_t;
+
+struct esp_foc_rotor_sensor_s{
+    void  (*set_to_zero) (esp_foc_rotor_sensor_t *self);
+    float (*get_counts_per_revolution) (esp_foc_rotor_sensor_t *self);
+    float (*read_counts) (esp_foc_rotor_sensor_t *self);
+    float (*read_accumulated_counts) (esp_foc_rotor_sensor_t *self);
+    void  (*set_simulation_count)(esp_foc_rotor_sensor_t *self, float increment);
+};

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -9,7 +9,7 @@ set(EXTRA_COMPONENT_DIRS ../libsodium ../expat ../cbor ../jsmn ../qrcode ../coap
 
 # 2. Add here if the component is compatible with IDF >= v4.4
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "4.4")
-    list(APPEND EXTRA_COMPONENT_DIRS ../pid_ctrl ../esp_encrypted_img ../pcap)
+    list(APPEND EXTRA_COMPONENT_DIRS ../pid_ctrl ../esp_encrypted_img ../pcap ../esp_foc)
 endif()
 
 # 3. Add here if the component is compatible with IDF >= v5.0


### PR DESCRIPTION
component to the extra component list.

Signed-off-by: Felipe Neves <felipe.neves@linaro.org>

# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Adds esp FoC vector controller for permanent magnet sychronous motors aka PMSM.
