### PR TITLE
usb_host_msc: Fix compatibility with IDF v4.4

### DIFF
--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.0", "latest"]
+        idf_ver: ["release-v4.4", "release-v5.0", "latest"]
         idf_target: ["esp32s2", "esp32s3"]
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}

--- a/usb/usb_host_cdc_acm/test/usb_device.c
+++ b/usb/usb_host_cdc_acm/test/usb_device.c
@@ -8,6 +8,7 @@
 #include "sdkconfig.h"
 #include "tinyusb.h"
 #include "tusb_cdc_acm.h"
+#include "esp_idf_version.h"
 
 static uint8_t buf[CONFIG_TINYUSB_CDC_RX_BUFSIZE + 1];
 void tinyusb_cdc_rx_callback(int itf, cdcacm_event_t *event)
@@ -19,6 +20,7 @@ void tinyusb_cdc_rx_callback(int itf, cdcacm_event_t *event)
     tinyusb_cdcacm_write_flush(itf, 0);
 }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 static const tusb_desc_device_t cdc_device_descriptor = {
     .bLength = sizeof(cdc_device_descriptor),
     .bDescriptorType = TUSB_DESC_DEVICE,
@@ -42,12 +44,16 @@ static const uint8_t cdc_desc_configuration[] = {
     TUD_CDC_DESCRIPTOR(0, 4, 0x81, 8, 0x02, 0x82, 64),
     TUD_CDC_DESCRIPTOR(2, 4, 0x83, 8, 0x04, 0x84, 64),
 };
+#endif
 
 void run_usb_dual_cdc_device(void)
 {
     const tinyusb_config_t tusb_cfg = {
+        .external_phy = false,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
         .device_descriptor = &cdc_device_descriptor,
         .configuration_descriptor = cdc_desc_configuration
+#endif
     };
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
 

--- a/usb/usb_host_msc/idf_component.yml
+++ b/usb/usb_host_msc/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: USB Host MSC driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_msc
 

--- a/usb/usb_host_msc/src/msc_host_vfs.c
+++ b/usb/usb_host_msc/src/msc_host_vfs.c
@@ -13,6 +13,7 @@
 #include "diskio_impl.h"
 #include "ffconf.h"
 #include "ff.h"
+#include "esp_idf_version.h"
 
 #define DRIVE_STR_LEN 3
 
@@ -33,8 +34,14 @@ static esp_err_t msc_format_storage(size_t block_size, size_t allocation_size, c
 
     // Valid value of cluster size is between sector_size and 128 * sector_size.
     size_t cluster_size = MIN(MAX(allocation_size, block_size), 128 * block_size);
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+    FRESULT err = f_mkfs(drv, FM_ANY | FM_SFD, cluster_size, workbuf, workbuf_size);
+#else
     const MKFS_PARM opt = {(BYTE)(FM_ANY | FM_SFD), 0, 0, 0, cluster_size};
     FRESULT err = f_mkfs(drv, &opt, workbuf, workbuf_size);
+#endif
+
     if (err) {
         ESP_LOGE(TAG, "Formatting failed with error: %d", err);
         free(workbuf);

--- a/usb/usb_host_msc/test/msc_device.c
+++ b/usb/usb_host_msc/test/msc_device.c
@@ -39,6 +39,7 @@
 #include "tinyusb.h"
 #include "test_common.h"
 #include "soc/soc_caps.h"
+#include "esp_idf_version.h"
 
 #if SOC_USB_OTG_SUPPORTED
 
@@ -48,7 +49,7 @@
 
 static const char *TAG = "msc_example";
 
-
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 /**** Kconfig driven Descriptor ****/
 static const tusb_desc_device_t device_descriptor = {
     .bLength = sizeof(device_descriptor),
@@ -72,15 +73,18 @@ static const uint8_t msc_desc_configuration[] = {
     TUD_CONFIG_DESCRIPTOR(1, 4, 0, msc_desc_config_len, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
     TUD_MSC_DESCRIPTOR(0, 5, 1, 0x80 | 1, 64),
 };
-
+#endif
 
 void device_app(void)
 {
     ESP_LOGI(TAG, "USB initialization");
 
     tinyusb_config_t tusb_cfg = {
+        .external_phy = false,
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
         .device_descriptor = &device_descriptor,
         .configuration_descriptor = msc_desc_configuration
+#endif
     };
 
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));

--- a/usb/usb_host_uvc/src/descriptor.c
+++ b/usb/usb_host_uvc/src/descriptor.c
@@ -14,6 +14,7 @@
 #include "usb/usb_host.h"
 #include "usb/usb_types_ch9.h"
 #include "sys/param.h"
+#include <inttypes.h>
 
 typedef struct {
     uint8_t bLength;
@@ -497,7 +498,7 @@ static void print_class_header_desc(const uint8_t *buff)
         printf("\tbDescriptorSubType %u\n", desc->bDescriptorSubType);
         printf("\tbcdUVC %x\n", desc->bcdUVC);
         printf("\twTotalLength %u\n", desc->wTotalLength);
-        printf("\tdwClockFrequency %lu\n", desc->dwClockFrequency);
+        printf("\tdwClockFrequency %"PRIu32"\n", desc->dwClockFrequency);
         printf("\tbFunctionProtocol %u\n", desc->bFunctionProtocol);
         printf("\tbInCollection %u\n", desc->bInCollection);
         printf("\tbaInterfaceNr %u\n", desc->baInterfaceNr);
@@ -643,23 +644,23 @@ static void print_vs_frame_mjpeg_desc(const uint8_t *buff)
     printf("\tbmCapabilities 0x%x\n", desc->bmCapabilities);
     printf("\twWidth %u\n", desc->wWidth);
     printf("\twHeigh %u\n", desc->wHeigh);
-    printf("\tdwMinBitRate %lu\n", desc->dwMinBitRate);
-    printf("\tdwMaxBitRate %lu\n", desc->dwMaxBitRate);
-    printf("\tdwMaxVideoFrameBufSize %lu\n", desc->dwMaxVideoFrameBufSize);
-    printf("\tdwDefaultFrameInterval %lu\n", desc->dwDefaultFrameInterval);
+    printf("\tdwMinBitRate %"PRIu32"\n", desc->dwMinBitRate);
+    printf("\tdwMaxBitRate %"PRIu32"\n", desc->dwMaxBitRate);
+    printf("\tdwMaxVideoFrameBufSize %"PRIu32"\n", desc->dwMaxVideoFrameBufSize);
+    printf("\tdwDefaultFrameInterval %"PRIu32"\n", desc->dwDefaultFrameInterval);
     printf("\tbFrameIntervalType %u\n", desc->bFrameIntervalType);
 
     if (desc->bFrameIntervalType == 0) {
         // Continuous Frame Intervals
-        printf("\tdwMinFrameInterval %lu\n",  desc->dwMinFrameInterval);
-        printf("\tdwMaxFrameInterval %lu\n",  desc->dwMaxFrameInterval);
-        printf("\tdwFrameIntervalStep %lu\n", desc->dwFrameIntervalStep);
+        printf("\tdwMinFrameInterval %"PRIu32"\n",  desc->dwMinFrameInterval);
+        printf("\tdwMaxFrameInterval %"PRIu32"\n",  desc->dwMaxFrameInterval);
+        printf("\tdwFrameIntervalStep %"PRIu32"\n", desc->dwFrameIntervalStep);
     } else {
         // Discrete Frame Intervals
         size_t max_intervals = sizeof(desc->dwFrameInterval) / sizeof(desc->dwFrameInterval[0]);
         size_t num_of_intervals = MIN((desc->bLength - 26) / 4, max_intervals);
         for (int i = 0; i < num_of_intervals; ++i) {
-            printf("\tFrameInterval[%d] %lu\n", i, desc->dwFrameInterval[i]);
+            printf("\tFrameInterval[%d] %"PRIu32"\n", i, desc->dwFrameInterval[i]);
         }
     }
 }


### PR DESCRIPTION
Since API of `fatfs` has changed between IDF versions v4.4 and 5.0, compile time condition was added in order to cover both. 
