### PR TITLE
ci: use dl.espressif.com/pypi for wheels, install cryptography wheel

### DIFF
--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -88,8 +88,8 @@ jobs:
           path: test_app/build
       - name: Install Python packages
         env:
-          PIP_EXTRA_INDEX_URL: "https://www.piwheels.org/simple"
-        run: pip install pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf
+          PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
+        run: pip install --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf
       - name: Run Test App on target
         working-directory: test_app
         run: pytest --junit-xml=./test_app_results_${{ matrix.idf_target }}_${{ matrix.idf_ver }}.xml --target=${{ matrix.idf_target }}

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -63,8 +63,8 @@ jobs:
           path: usb/test_app/build
       - name: Install Python packages
         env:
-          PIP_EXTRA_INDEX_URL: "https://www.piwheels.org/simple"
-        run: pip install pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf
+          PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
+        run: pip install --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf
       - name: Run USB Test App on target
         working-directory: usb/test_app
         run: pytest --target=${{ matrix.idf_target }}


### PR DESCRIPTION
New version of `cryptography` was released yesterday, but piwheels.org doesn't have a wheel for it yet.
Switch to dl.espressif.com/pypi as the extra source of wheels and prefer installing a version of `cryptography` from a binary wheel.

Fixes pipeline failures such as https://github.com/espressif/idf-extra-components/runs/8252043014

Port of a fix by @mahavirj in esp-protocols repository, https://github.com/espressif/esp-protocols/commit/64e31dae4829fb700ea0c461d8dd077b6340f5d4.