### PR TITLE
coap: Add mbedTLS and debug config for CoAP build option (IEC-19)

### DIFF
--- a/coap/CMakeLists.txt
+++ b/coap/CMakeLists.txt
@@ -14,7 +14,6 @@ set(srcs
     "libcoap/src/coap_asn1.c"
     "libcoap/src/coap_async.c"
     "libcoap/src/coap_cache.c"
-    "libcoap/src/coap_debug.c"
     "libcoap/src/coap_event.c"
     "libcoap/src/coap_hashkey.c"
     "libcoap/src/coap_io.c"
@@ -33,6 +32,15 @@ set(srcs
     "libcoap/src/str.c"
     "libcoap/src/uri.c"
     "libcoap/src/coap_mbedtls.c")
+
+
+if(CONFIG_COAP_MBEDTLS_DEBUG)
+    list(APPEND srcs
+        "libcoap/src/coap_debug.c")
+else()
+    list(APPEND srcs
+        "port/src/esp_coap_debug.c")
+endif()
 
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS "${include_dirs}"

--- a/coap/Kconfig
+++ b/coap/Kconfig
@@ -1,8 +1,18 @@
 menu "CoAP Configuration"
     visible if LWIP_IPV6
 
+    config COAP_MBEDTLS_SUPPORT
+        bool "Enable mbedTLS within CoAP"
+        depends on MBEDTLS_TLS_ENABLED
+        default y
+        help
+            Enable mbedTLS functionality for CoAP.
+
+            If this option is disabled, redundent CoAP mbedTLS code is removed.
+
     choice COAP_MBEDTLS_ENCRYPTION_MODE
         prompt "CoAP Encryption method"
+        depends on COAP_MBEDTLS_SUPPORT
         default COAP_MBEDTLS_PSK
         help
             If the CoAP information is to be encrypted, the encryption environment

--- a/coap/port/include/coap_config_posix.h
+++ b/coap/port/include/coap_config_posix.h
@@ -49,9 +49,9 @@ struct in6_pktinfo {
 #define PACKAGE_NAME "libcoap-posix"
 #define PACKAGE_VERSION "4.3.1-rc1"
 
-#ifdef CONFIG_MBEDTLS_TLS_ENABLED
+#ifdef CONFIG_COAP_MBEDTLS_SUPPORT
 #define HAVE_MBEDTLS
-#endif /* CONFIG_MBEDTLS_TLS_ENABLED */
+#endif /* CONFIG_COAP_MBEDTLS_SUPPORT */
 #define COAP_CONSTRAINED_STACK 1
 #define ESPIDF_VERSION
 

--- a/coap/port/src/esp_coap_debug.c
+++ b/coap/port/src/esp_coap_debug.c
@@ -1,0 +1,101 @@
+/* coap_debug.c -- debug utilities
+ *
+ * Copyright (C) 2010--2012,2014--2022 Olaf Bergmann <bergmann@tzi.org> and others
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * This file is part of the CoAP library libcoap. Please see
+ * README for terms of use.
+ */
+
+/**
+ * @file coap_debug.c
+ * @brief Debug utilities
+ */
+
+#include "coap3/coap_internal.h"
+
+coap_log_t coap_get_log_level(void)
+{
+    return LOG_WARNING;
+}
+
+void coap_set_log_level(coap_log_t level)
+{
+
+}
+
+
+void coap_set_log_handler(coap_log_handler_t handler)
+{
+
+}
+
+const char *coap_package_name(void)
+{
+    return PACKAGE_NAME;
+}
+
+const char *coap_package_version(void)
+{
+    return PACKAGE_STRING;
+}
+
+const char *coap_package_build(void)
+{
+#ifdef LIBCOAP_PACKAGE_BUILD
+    return LIBCOAP_PACKAGE_BUILD;
+#else /* !LIBCOAP_PACKAGE_BUILD */
+    return PACKAGE_STRING;
+#endif /* !LIBCOAP_PACKAGE_BUILD */
+}
+
+void coap_set_show_pdu_output(int use_fprintf)
+{
+
+}
+
+void coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu)
+{
+
+}
+
+void coap_show_tls_version(coap_log_t level)
+{
+
+}
+
+char *coap_string_tls_version(char *buffer, size_t bufsize)
+{
+    return buffer;
+}
+
+void coap_log_impl(coap_log_t level, const char *format, ...)
+{
+
+}
+
+char *coap_string_tls_support(char *buffer, size_t bufsize)
+{
+    return buffer;
+}
+
+size_t coap_print_addr(const coap_address_t *addr,
+                       unsigned char *buf, size_t len)
+{
+    buf[0] = '\000';
+    return 0;
+}
+
+
+int coap_debug_set_packet_loss(const char *loss_level)
+{
+    return 0;
+}
+
+int coap_debug_send_packet(void)
+{
+    return 1;
+}


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
1. Add `COAP_MBEDTLS_SUPPORT` Kconfig to make CoAP support DTLS or not. This can help save about 80 KB firmware size.
2. Depend on `COAP_MBEDTLS_DEBUG` Kconfig to make CoAP support debug or not. This can help save about 20 KB firmware size.