### PR TITLE
Fix/usb/tests

### DIFF
--- a/usb/test_app/main/idf_component.yml
+++ b/usb/test_app/main/idf_component.yml
@@ -1,0 +1,6 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/esp_tinyusb:
+    version: "0.0.1"
+    rules:
+      - if: "idf_version >= 5.0"

--- a/usb/usb_host_cdc_acm/idf_component.yml
+++ b/usb/usb_host_cdc_acm/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: USB Host CDC-ACM driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_cdc_acm
 dependencies:

--- a/usb/usb_host_cdc_acm/include/usb/cdc_acm_host.h
+++ b/usb/usb_host_cdc_acm/include/usb/cdc_acm_host.h
@@ -333,7 +333,6 @@ public:
     }
 
 private:
-    CdcAcmDevice(const CdcAcmDevice &Copy);
     CdcAcmDevice &operator= (const CdcAcmDevice &Copy);
     bool operator== (const CdcAcmDevice &param) const;
     bool operator!= (const CdcAcmDevice &param) const;

--- a/usb/usb_host_cdc_acm/test/CMakeLists.txt
+++ b/usb/usb_host_cdc_acm/test/CMakeLists.txt
@@ -1,3 +1,10 @@
+include($ENV{IDF_PATH}/tools/cmake/version.cmake)
+set (TINYUSB_LIB)
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
+    set(TINYUSB_LIB "esp_tinyusb")
+else()
+    set(TINYUSB_LIB "tinyusb")
+endif()
 idf_component_register(SRCS "test_cdc_acm_host.c" "usb_device.c"
                        INCLUDE_DIRS "."
-                       REQUIRES usb_host_cdc_acm tinyusb unity)
+                       REQUIRES usb_host_cdc_acm unity ${TINYUSB_LIB})

--- a/usb/usb_host_cdc_acm/test/test_cdc_acm_host.c
+++ b/usb/usb_host_cdc_acm/test/test_cdc_acm_host.c
@@ -48,7 +48,6 @@ void usb_lib_task(void *arg)
         .target = USB_PHY_TARGET_INT,
         .otg_mode = USB_OTG_MODE_HOST,
         .otg_speed = USB_PHY_SPEED_UNDEFINED,   //In Host mode, the speed is determined by the connected device
-        .gpio_conf = NULL,
     };
     TEST_ASSERT_EQUAL(ESP_OK, usb_new_phy(&phy_config, &phy_hdl));
     // Install USB Host driver. Should only be called once in entire application

--- a/usb/usb_host_msc/idf_component.yml
+++ b/usb/usb_host_msc/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2"
+version: "1.0.3"
 description: USB Host MSC driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_msc
 

--- a/usb/usb_host_msc/test/CMakeLists.txt
+++ b/usb/usb_host_msc/test/CMakeLists.txt
@@ -1,3 +1,10 @@
+include($ENV{IDF_PATH}/tools/cmake/version.cmake)
+set (TINYUSB_LIB)
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
+    set(TINYUSB_LIB "esp_tinyusb")
+else()
+    set(TINYUSB_LIB "tinyusb")
+endif()
 idf_component_register(SRC_DIRS .
                        INCLUDE_DIRS .
-                       REQUIRES unity usb usb_host_msc tinyusb)
+                       REQUIRES unity usb usb_host_msc ${TINYUSB_LIB})

--- a/usb/usb_host_msc/test/test_msc.c
+++ b/usb/usb_host_msc/test/test_msc.c
@@ -188,7 +188,6 @@ static void msc_setup(void)
         .target = USB_PHY_TARGET_INT,
         .otg_mode = USB_OTG_MODE_HOST,
         .otg_speed = USB_PHY_SPEED_UNDEFINED,   //In Host mode, the speed is determined by the connected device
-        .gpio_conf = NULL,
     };
     ESP_OK_ASSERT(usb_new_phy(&phy_config, &phy_hdl));
     const usb_host_config_t host_config = {
@@ -220,8 +219,7 @@ static void msc_setup(void)
 
 static void msc_teardown(void)
 {
-    // Wait to finish any ongoing USB operations
-    vTaskDelay(100);
+    vTaskDelay(10); // Wait to finish any ongoing USB operations
 
     ESP_OK_ASSERT( msc_host_vfs_unregister(vfs_handle) );
     ESP_OK_ASSERT( msc_host_uninstall_device(device) );
@@ -235,6 +233,7 @@ static void msc_teardown(void)
     phy_hdl = NULL;
 
     vQueueDelete(app_queue);
+    vTaskDelay(10); // Wait for FreeRTOS to clean up deleted tasks
 }
 
 static void write_read_sectors(void)


### PR DESCRIPTION
# Change description
Update USB tests for IDFv5.0 change https://github.com/espressif/esp-idf/commit/94a00bda0f00548c8adacdd6c3fe7c9957dfcb9d

- [x] Update USB tests to IDF v5.0
- [x] Enable copy constructor for CDC-ACM
- [x] Fix MSC memory leak
