### PR TITLE
esp_jpeg: Fixed list of MCUs with TjpgDec in ROM in Readme

### DIFF
--- a/esp_jpeg/README.md
+++ b/esp_jpeg/README.md
@@ -27,9 +27,8 @@ Some microcontrollers have TJpg decoder in ROM. It is used as default, but it ca
 ### List of MCUs, which have TJpgDec in ROM
 - ESP32
 - ESP32-S3
-- ESP32-C2
 - ESP32-C3
-- ESP32-H2
+- ESP32-C6
 
 ### Fixed compilation configuration of the ROM code
 - Stream input buffer: 512

--- a/esp_jpeg/idf_component.yml
+++ b/esp_jpeg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: "JPEG Decoder: TJpgDec"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_jpeg/
 dependencies:


### PR DESCRIPTION
After notification on Mattermost, I fixing bad list of MCUs, which have TjpgDec in ROM. 
