### PR TITLE
essl_sdio: support communicating with esp32c6 sdio slave

### DIFF
--- a/esp_serial_slave_link/CHANGELOG.md
+++ b/esp_serial_slave_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Supported communicating with ESP32C6 SDIO Slave
+
 ## 1.0.1
 
 - Fixed build failure issue on chip which doesn't support SDMMC host

--- a/esp_serial_slave_link/essl_sdio_defs.c
+++ b/esp_serial_slave_link/essl_sdio_defs.c
@@ -12,3 +12,7 @@
 essl_sdio_def_t ESSL_SDIO_DEF_ESP32 = {
     .new_packet_intr_mask = BIT(23),
 };
+
+essl_sdio_def_t ESSL_SDIO_DEF_ESP32C6 = {
+    .new_packet_intr_mask = BIT(23),
+};

--- a/esp_serial_slave_link/idf_component.yml
+++ b/esp_serial_slave_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.1.0"
 description: "Espressif Serial Slave Link Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_serial_slave_link
 dependencies:

--- a/esp_serial_slave_link/include/esp_serial_slave_link/essl_sdio.h
+++ b/esp_serial_slave_link/include/esp_serial_slave_link/essl_sdio.h
@@ -13,6 +13,7 @@
 #include "driver/sdmmc_host.h"
 
 #include "esp_serial_slave_link/essl.h"
+#include "essl_sdio_defs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,13 +25,6 @@ typedef struct {
     int recv_buffer_size;   ///< The pre-negotiated recv buffer size used by both the host and the slave.
 } essl_sdio_config_t;
 
-typedef struct {
-    //interrupts
-    uint32_t new_packet_intr_mask;
-} essl_sdio_def_t;
-
-/// Definitions of ESP32 SDIO Slave hardware
-extern essl_sdio_def_t ESSL_SDIO_DEF_ESP32;
 
 /**
  * @brief Initialize the ESSL SDIO device and get its handle.

--- a/esp_serial_slave_link/include/esp_serial_slave_link/essl_sdio_defs.h
+++ b/esp_serial_slave_link/include/esp_serial_slave_link/essl_sdio_defs.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+/**
+ * This file contains SDIO Slave hardware specific requirements
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    //interrupts
+    uint32_t new_packet_intr_mask;
+} essl_sdio_def_t;
+
+/// Definitions of ESP32 SDIO Slave hardware
+extern essl_sdio_def_t ESSL_SDIO_DEF_ESP32;
+/// Definitions of ESP32C6 SDIO Slave hardware
+extern essl_sdio_def_t ESSL_SDIO_DEF_ESP32C6;
+
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## What Happened
- Supported essl_sdio communicating with ESP32C6 SDIO Slave
- Upgrade to v1.1.0

