### PR TITLE
coap: Upgrade libcoap to release v4.3.1

### DIFF
--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.1~1-rc.1"
+version: "4.3.1~1"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:

--- a/coap/port/include/coap_config_posix.h
+++ b/coap/port/include/coap_config_posix.h
@@ -47,7 +47,7 @@ struct in6_pktinfo {
 #define IPV6_PKTINFO IPV6_CHECKSUM
 
 #define PACKAGE_NAME "libcoap-posix"
-#define PACKAGE_VERSION "4.3.1-rc1"
+#define PACKAGE_VERSION "4.3.1"
 
 #ifdef CONFIG_MBEDTLS_TLS_ENABLED
 #define HAVE_MBEDTLS


### PR DESCRIPTION
Upgrade CoAP to release v4.3.1

changelog: https://github.com/obgm/libcoap/blob/v4.3.1/ChangeLog