### PR TITLE
Added badges with version to the README files of components

### DIFF
--- a/bdc_motor/README.md
+++ b/bdc_motor/README.md
@@ -1,5 +1,7 @@
 # Brushed DC Motor Control
 
+[![Component Registry](https://components.espressif.com/components/espressif/bdc_motor/badge.svg)](https://components.espressif.com/components/espressif/bdc_motor)
+
 This directory contains an implementation for Brushed DC Motor by different peripherals. Currently only MCPWM is supported as the BDC motor backend.
 
 To learn more about how to use this component, please check API Documentation from header file [bdc_motor.h](./include/bdc_motor.h).

--- a/eigen/README.md
+++ b/eigen/README.md
@@ -1,5 +1,7 @@
 # Eigen for ESP-IDF
 
+[![Component Registry](https://components.espressif.com/components/espressif/eigen/badge.svg)](https://components.espressif.com/components/espressif/eigen)
+
 This component ports Eigen library into the esp-idf.
 
 **Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.**

--- a/esp_encrypted_img/README.md
+++ b/esp_encrypted_img/README.md
@@ -1,5 +1,7 @@
 # ESP Encrypted Image Abstraction Layer
 
+[![Component Registry](https://components.espressif.com/components/espressif/esp_encrypted_img/badge.svg)](https://components.espressif.com/components/espressif/esp_encrypted_img)
+
 This component provides an API interface to decrypt data defined in "ESP Encrypted Image" format. This format is as specified at [Image Format](#image-format)
 
 This component can help in integrating pre encrypted firmware in over-the-air updates. Additionally, this component can also be used for other use-cases which requires addition of encryption layer for custom data.

--- a/esp_jpeg/README.md
+++ b/esp_jpeg/README.md
@@ -1,5 +1,7 @@
 # JPEG Decoder: TJpgDec - Tiny JPEG Decompressor
 
+[![Component Registry](https://components.espressif.com/components/espressif/esp_jpeg/badge.svg)](https://components.espressif.com/components/espressif/esp_jpeg)
+
 TJpgDec is a generic JPEG image decompressor that is highly optimized for small embedded systems. It works with very low memory consumption.
 
 Some microcontrollers have TJpg decoder in ROM, it is used, if there is. [^1] Using ROM code can be disabled in menuconfig.

--- a/esp_serial_slave_link/README.md
+++ b/esp_serial_slave_link/README.md
@@ -1,5 +1,7 @@
 # Espressif Serial Slave Link (ESSL) component
 
+[![Component Registry](https://components.espressif.com/components/espressif/esp_serial_slave_link/badge.svg)](https://components.espressif.com/components/espressif/esp_serial_slave_link)
+
 This component used to reside in [esp-idf](https://github.com/espressif/esp-idf) project as its component.
 
 It's used on the HOST, to communicate with ESP chips as SLAVE via SDIO/SPI slave HD mode.

--- a/fmt/README.md
+++ b/fmt/README.md
@@ -1,5 +1,6 @@
  # FMT
  
+ [![Component Registry](https://components.espressif.com/components/espressif/fmt/badge.svg)](https://components.espressif.com/components/espressif/fmt)
  
 **fmt** is an open-source formatting library providing a fast and safe
 alternative to C stdio and C++ iostreams.

--- a/jsmn/README.md
+++ b/jsmn/README.md
@@ -1,7 +1,7 @@
 JSMN
 ====
 
-[![Build Status](https://travis-ci.org/zserge/jsmn.svg?branch=master)](https://travis-ci.org/zserge/jsmn)
+[![Build Status](https://travis-ci.org/zserge/jsmn.svg?branch=master)](https://travis-ci.org/zserge/jsmn) [![Component Registry](https://components.espressif.com/components/espressif/jsmn/badge.svg)](https://components.espressif.com/components/espressif/jsmn)
 
 jsmn (pronounced like 'jasmine') is a minimalistic JSON parser in C.  It can be
 easily integrated into resource-limited or embedded projects.

--- a/json_generator/README.md
+++ b/json_generator/README.md
@@ -1,4 +1,7 @@
 # JSON Generator
+
+[![Component Registry](https://components.espressif.com/components/espressif/json_generator/badge.svg)](https://components.espressif.com/components/espressif/json_generator)
+
 A simple JSON (JavasScript Object Notation) generator with flushing capability.
 Details of JSON can be found at [http://www.json.org/](http://www.json.org/).
 The JSON strings generated can be validated using any standard JSON validator. Eg. [https://jsonlint.com/](https://jsonlint.com/)

--- a/json_parser/README.md
+++ b/json_parser/README.md
@@ -1,5 +1,7 @@
 # JSON Parser
 
+[![Component Registry](https://components.espressif.com/components/espressif/json_parser/badge.svg)](https://components.espressif.com/components/espressif/json_parser)
+
 This is a simple, light weight JSON parser built on top of [jsmn](https://github.com/zserge/jsmn).
 
 Files

--- a/led_strip/README.md
+++ b/led_strip/README.md
@@ -1,5 +1,7 @@
 # LED Strip Component
 
+[![Component Registry](https://components.espressif.com/components/espressif/led_strip/badge.svg)](https://components.espressif.com/components/espressif/led_strip)
+
 This directory contains an implementation for addressable LEDs by different peripherals. Currently only RMT is supported as the led strip backend.
 
 The driver should be compatible with:

--- a/pcap/README.md
+++ b/pcap/README.md
@@ -1,5 +1,7 @@
 # Simple PCAP file writer
 
+[![Component Registry](https://components.espressif.com/components/espressif/pcap/badge.svg)](https://components.espressif.com/components/espressif/pcap)
+
 This component allows users to trace their captured packets in .pcap file format.
 
 More details about PCAP format can be found [here](https://wiki.wireshark.org/Development/LibpcapFileFormat).

--- a/pid_ctrl/README.md
+++ b/pid_ctrl/README.md
@@ -1,0 +1,3 @@
+# Proportional integral derivative controller
+
+[![Component Registry](https://components.espressif.com/components/espressif/pcap/badge.svg)](https://components.espressif.com/components/espressif/pcap)

--- a/qrcode/README.md
+++ b/qrcode/README.md
@@ -1,5 +1,7 @@
 # QR Code generator component
 
+[![Component Registry](https://components.espressif.com/components/espressif/qrcode/badge.svg)](https://components.espressif.com/components/espressif/qrcode)
+
 This component contains a QR code generator written in C. This component is based on [QR-Code-generator](https://github.com/nayuki/QR-Code-generator).
 This component is used as part of the following ESP-IDF examples:
 - [DPP Enrollee Example](https://github.com/espressif/esp-idf/tree/master/examples/wifi/wifi_easy_connect/dpp-enrollee).

--- a/sh2lib/README.md
+++ b/sh2lib/README.md
@@ -1,4 +1,6 @@
 # Abstraction layer for HTTP2 with TLS
 
+[![Component Registry](https://components.espressif.com/components/espressif/sh2lib/badge.svg)](https://components.espressif.com/components/espressif/sh2lib)
+
 This component contains an abstraction layer which exposes simpler set of APIs combining `nghttp2` (HTTP/2 C Library) and `esp-tls` (from ESP-IDF) components.
 

--- a/usb/esp_modem_usb_dte/README.md
+++ b/usb/esp_modem_usb_dte/README.md
@@ -1,5 +1,7 @@
 # USB DTE plugin for esp_modem
 
+[![Component Registry](https://components.espressif.com/components/espressif/esp_modem_usb_dte/badge.svg)](https://components.espressif.com/components/espressif/esp_modem_usb_dte)
+
 > :warning: **Experimental feature**: USB DTE is under development!
 
 This component extends [esp_modem](https://components.espressif.com/component/espressif/esp_modem) with USB DTE.

--- a/usb/esp_tinyusb/README.md
+++ b/usb/esp_tinyusb/README.md
@@ -1,5 +1,7 @@
 # Espressif's additions to TinyUSB
 
+[![Component Registry](https://components.espressif.com/components/espressif/esp_tinyusb/badge.svg)](https://components.espressif.com/components/espressif/esp_tinyusb)
+
 This component adds features to TinyUSB that help users with integrating TinyUSB with their ESP-IDF application.
 
 It contains:

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,4 +1,5 @@
 description: Espressif's additions to TinyUSB
+documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
 version: 1.0.0
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:

--- a/usb/usb_host_cdc_acm/README.md
+++ b/usb/usb_host_cdc_acm/README.md
@@ -1,5 +1,7 @@
 # USB Host CDC-ACM Class Driver
 
+[![Component Registry](https://components.espressif.com/components/espressif/usb_host_cdc_acm/badge.svg)](https://components.espressif.com/components/espressif/usb_host_cdc_acm)
+
 This directory contains an implementation of a USB CDC-ACM Host Class Driver that is implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
 
 ## Supported Devices

--- a/usb/usb_host_ch34x_vcp/README.md
+++ b/usb/usb_host_ch34x_vcp/README.md
@@ -1,5 +1,7 @@
 # CH34x USB-UART converter driver
 
+[![Component Registry](https://components.espressif.com/components/espressif/usb_host_ch34x_vcp/badge.svg)](https://components.espressif.com/components/espressif/usb_host_ch34x_vcp)
+
 Limited implementation only. The vendor does not provide full specification.
 
 * CH340 and CH341 supported

--- a/usb/usb_host_cp210x_vcp/README.md
+++ b/usb/usb_host_cp210x_vcp/README.md
@@ -1,4 +1,6 @@
 # Silicon Labs CP210x USB-UART converter driver
 
+[![Component Registry](https://components.espressif.com/components/espressif/usb_host_cp210x_vcp/badge.svg)](https://components.espressif.com/components/espressif/usb_host_cp210x_vcp)
+
 * [Datasheet](https://www.silabs.com/documents/public/data-sheets/CP2102-9.pdf)
 * [Application note](https://www.silabs.com/documents/public/application-notes/an197.pdf)

--- a/usb/usb_host_ftdi_vcp/README.md
+++ b/usb/usb_host_ftdi_vcp/README.md
@@ -1,5 +1,7 @@
 # FTDI UART-USB converters driver
 
+[![Component Registry](https://components.espressif.com/components/espressif/usb_host_ftdi_vcp/badge.svg)](https://components.espressif.com/components/espressif/usb_host_ftdi_vcp)
+
 Supported devices:
 * FT231
 * FT232

--- a/usb/usb_host_msc/README.md
+++ b/usb/usb_host_msc/README.md
@@ -1,5 +1,7 @@
 # USB Host MSC (Mass Storage Class) Driver
 
+[![Component Registry](https://components.espressif.com/components/espressif/usb_host_msc/badge.svg)](https://components.espressif.com/components/espressif/usb_host_msc)
+
 This directory contains an implementation of a USB Mass Storage Class Driver implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
 
 MSC driver allows access to USB flash drivers using the BOT “Bulk-Only Transport” protocol and the Transparent SCSI command set.

--- a/usb/usb_host_uvc/README.md
+++ b/usb/usb_host_uvc/README.md
@@ -1,5 +1,7 @@
 # USB Host UVC Driver
 
+[![Component Registry](https://components.espressif.com/components/espressif/usb_host_uvc/badge.svg)](https://components.espressif.com/components/espressif/usb_host_uvc)
+
 This directory contains USB host UVC driver based on [libuvc](https://github.com/libuvc/libuvc) library. Support for `libuvc` is achieved by implementing adapter between [libusb](https://github.com/libusb/libusb) (underling host library used by `libuvc`) and [usb_host](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html) library targeted for ESP SOCs.    
 
 ## Usage

--- a/usb/usb_host_vcp/README.md
+++ b/usb/usb_host_vcp/README.md
@@ -1,5 +1,7 @@
 # Virtual COM Port Service
 
+[![Component Registry](https://components.espressif.com/components/espressif/usb_host_vcp/badge.svg)](https://components.espressif.com/components/espressif/usb_host_vcp)
+
 Virtual COM Port (VCP) service manages drivers to connected VCP devices - typically USB <-> UART converters.
 In practice, you rarely care about specifics of the devices; you only want uniform interface for them all.
 


### PR DESCRIPTION
# Description
Created README.md file for pid_ctrl component.
Added badges with versions in README files to following components:
- bdc_motor
- eigen
- esp_encrypted_img
- esp_jpeg
- esp_serial_slave_link
- fmt
- jsmn
- json_generator
- json_parser
- led_strip
- pcap
- pid_ctrl
- qrcode
- sh2lib
- esp_modem_usb_dte
- esp_tiny_usb
- usb_host_cdc_acm
- usb_host_ch34x_vcp
- usb_host_cp210x_vcp
- usb_host_ftdi_vcp
- usb_host_msc
- usb_host_uvc
- usb_host_vcp

## Edit
Added 
``` yml
documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
```
to the [usb/esp_tinyusb/idf_component.yml](https://github.com/espressif/idf-extra-components/blob/master/usb/esp_tinyusb/idf_component.yml)