### PR TITLE
esp_tinyusb: Allow TinyUSB updates

### DIFF
--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,11 +1,11 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.0.1
+version: 1.0.2
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
-    version: '^0.12.2' # Use fixed minor version. TinyUSB does not guarantee backward compatibility
+    version: '0.*' 
     public: true
 targets:
 - esp32s2


### PR DESCRIPTION
Semver has special handling of 0.x versions
Reference: https://devhints.io/semver
