### PR TITLE
Change minimum IDF version for `cbor` component to IDF v5.0

### DIFF
--- a/cbor/idf_component.yml
+++ b/cbor/idf_component.yml
@@ -1,5 +1,5 @@
-version: "0.6.0"
+version: "0.6.1"
 description: "CBOR: Concise Binary Object Representation Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/cbor
 dependencies:
-  idf: ">=4.3"
+  idf: ">=5.0"


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
- IDF versions below v5.0 already include the `cbor` component in source format.
- Due to this, there is a conflict if the `cbor` component is used on lower versions of IDF and the only way to fix it is by adding a rule to the `idf_component.yml`
- This commit sets the minimum version to IDF v5.0 to fix this behaviour.
