### PR TITLE
USB: esp_tinyusb - fix memory leak in case of error, refactoring

### DIFF
--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,6 +1,6 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.0.2
+version: 1.0.3
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule

--- a/usb/esp_tinyusb/include/vfs_tinyusb.h
+++ b/usb/esp_tinyusb/include/vfs_tinyusb.h
@@ -12,6 +12,9 @@
 extern "C" {
 #endif
 
+#define VFS_TUSB_MAX_PATH 16
+#define VFS_TUSB_PATH_DEFAULT "/dev/tusb_cdc"
+
 /**
  * @brief Register TinyUSB CDC at VFS with path
  * @param cdc_intf - interface number of TinyUSB's CDC

--- a/usb/esp_tinyusb/tusb_console.c
+++ b/usb/esp_tinyusb/tusb_console.c
@@ -103,7 +103,7 @@ esp_err_t esp_tusb_init_console(int cdc_intf)
 {
     /* Registering TUSB at VFS */
     ESP_RETURN_ON_ERROR(esp_vfs_tusb_cdc_register(cdc_intf, NULL), TAG, "");
-    ESP_RETURN_ON_ERROR(redirect_std_streams_to(&con.in, &con.out, &con.err, "/dev/tusb_cdc"), TAG, "Failed to redirect STD streams");
+    ESP_RETURN_ON_ERROR(redirect_std_streams_to(&con.in, &con.out, &con.err, VFS_TUSB_PATH_DEFAULT), TAG, "Failed to redirect STD streams");
     return ESP_OK;
 }
 

--- a/usb/esp_tinyusb/vfs_tinyusb.c
+++ b/usb/esp_tinyusb/vfs_tinyusb.c
@@ -23,8 +23,6 @@
 #include "sdkconfig.h"
 
 const static char *TAG = "tusb_vfs";
-#define VFS_TUSB_MAX_PATH 16
-#define VFS_TUSB_PATH_DEFAULT "/dev/tusb_cdc"
 
 // Token signifying that no character is available
 #define NONE -1


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
1. Fix memory leak while returning in case of error. While returning in case of error, these should be called for freeing up the resources:
    a. tinyusb_cdc_deinit()
    b. free(acm->rx_tfbuf);
2. Remove unused 'initialized'
3. Remove hard coding of "/dev/tusb_cdc"
