### PR TITLE
led_strip: support for 4 components RGBW leds (SK6812)

### DIFF
--- a/led_strip/CHANGELOG.md
+++ b/led_strip/CHANGELOG.md
@@ -12,3 +12,13 @@
 - Support various RMT clock sources
 - Acquire and release the power management lock before and after each refresh
 - New driver flag: `invert_out` which can invert the led control signal by hardware
+
+## 2.2.0
+
+- Support for 4 components RGBW leds (SK6812):
+  - new field led_type in led_strip_config_t flags; valid values are
+      LED_TYPE_WS2812
+      LED_TYPE_SK6812
+  - new API led_strip_set_pixel_rgbw
+  - new interface type set_pixel_rgbw
+  - using specific timing for SK6812

--- a/led_strip/CHANGELOG.md
+++ b/led_strip/CHANGELOG.md
@@ -16,9 +16,8 @@
 ## 2.2.0
 
 - Support for 4 components RGBW leds (SK6812):
-  - new field led_type in led_strip_config_t flags; valid values are
-      LED_TYPE_WS2812
-      LED_TYPE_SK6812
+  - in led_strip_config_t new fields
+      led_pixel_format, controlling byte format (LED_PIXEL_FORMAT_GRB, LED_PIXEL_FORMAT_GRBW)
+      led_model, used to configure bit timing (LED_MODEL_WS2812, LED_MODEL_SK6812)
   - new API led_strip_set_pixel_rgbw
   - new interface type set_pixel_rgbw
-  - using specific timing for SK6812

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.0"
+version: "2.2.0"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 dependencies:

--- a/led_strip/include/led_strip.h
+++ b/led_strip/include/led_strip.h
@@ -30,6 +30,22 @@ extern "C" {
 esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue);
 
 /**
+ * @brief Set RGBW for a specific pixel
+ *
+ * @param strip: LED strip
+ * @param index: index of pixel to set
+ * @param red: red part of color
+ * @param green: green part of color
+ * @param blue: blue part of color
+ * @param white: separate white component (sk6812rgbw leds)
+ *
+ * @return
+ *      - ESP_OK: RGBW color succesfully set for the pixel
+ *      - ESP_ERR_INVALID_ARG: Set RGB for a specific pixel failed because of an invalid argument
+ */
+esp_err_t led_strip_set_pixel_rgbw(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white);
+
+/**
  * @brief Refresh memory colors to LEDs
  *
  * @param strip: LED strip

--- a/led_strip/include/led_strip_types.h
+++ b/led_strip/include/led_strip_types.h
@@ -11,7 +11,15 @@
 extern "C" {
 #endif
 
-enum led_type_t { LED_TYPE_WS2812 = 0, LED_TYPE_SK6812 };
+typedef enum {
+    LED_PIXEL_FORMAT_GRB,
+    LED_PIXEL_FORMAT_GRBW
+} led_pixel_format_t;
+
+typedef enum {
+    LED_MODEL_WS2812,
+    LED_MODEL_SK6812
+} led_model_t;
 
 /**
  * @brief LED strip handle
@@ -24,7 +32,8 @@ typedef struct led_strip_t *led_strip_handle_t;
 typedef struct {
     uint32_t strip_gpio_num; /*!< GPIO number that used by LED strip */
     uint32_t max_leds;       /*!< Maximum LEDs in a single strip */
-    enum led_type_t led_type;
+    led_pixel_format_t led_pixel_format;
+    led_model_t led_model;
     struct {
         uint32_t invert_out: 1; /*!< Invert output signal */
     } flags;

--- a/led_strip/include/led_strip_types.h
+++ b/led_strip/include/led_strip_types.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+enum led_type_t { LED_TYPE_WS2812 = 0, LED_TYPE_SK6812 };
+
 /**
  * @brief LED strip handle
  */
@@ -22,6 +24,7 @@ typedef struct led_strip_t *led_strip_handle_t;
 typedef struct {
     uint32_t strip_gpio_num; /*!< GPIO number that used by LED strip */
     uint32_t max_leds;       /*!< Maximum LEDs in a single strip */
+    enum led_type_t led_type;
     struct {
         uint32_t invert_out: 1; /*!< Invert output signal */
     } flags;

--- a/led_strip/interface/led_strip_interface.h
+++ b/led_strip/interface/led_strip_interface.h
@@ -35,6 +35,22 @@ struct led_strip_t {
     esp_err_t (*set_pixel)(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue);
 
     /**
+     * @brief Set RGBW for a specific pixel
+     *
+     * @param strip: LED strip
+     * @param index: index of pixel to set
+     * @param red: red part of color
+     * @param green: green part of color
+     * @param blue: blue part of color
+     * @param white: separate white component (sk6812rgbw leds)
+     *
+     * @return
+     *      - ESP_OK: RGBW color succesfully set for the pixel
+     *      - ESP_ERR_INVALID_ARG: Set RGB for a specific pixel failed because of an invalid argument
+     */
+    esp_err_t (*set_pixel_rgbw)(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white);
+
+    /**
      * @brief Refresh memory colors to LEDs
      *
      * @param strip: LED strip

--- a/led_strip/src/led_strip_api.c
+++ b/led_strip/src/led_strip_api.c
@@ -16,6 +16,12 @@ esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index, uint32_t
     return strip->set_pixel(strip, index, red, green, blue);
 }
 
+esp_err_t led_strip_set_pixel_rgbw(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return strip->set_pixel_rgbw(strip, index, red, green, blue, white);
+}
+
 esp_err_t led_strip_refresh(led_strip_handle_t strip)
 {
     ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");

--- a/led_strip/src/led_strip_rmt_dev.c
+++ b/led_strip/src/led_strip_rmt_dev.c
@@ -45,7 +45,7 @@ static esp_err_t led_strip_rmt_set_pixel_rgbw(led_strip_t *strip, uint32_t index
 {
     led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
     ESP_RETURN_ON_FALSE(index < rmt_strip->strip_len, ESP_ERR_INVALID_ARG, TAG, "index out of maximum number of LEDs");
-    ESP_RETURN_ON_FALSE(rmt_strip->bytes_per_pixel == 4, ESP_ERR_INVALID_ARG, TAG, "wrong LED type, expected 4 bytes per pixel");
+    ESP_RETURN_ON_FALSE(rmt_strip->bytes_per_pixel == 4, ESP_ERR_INVALID_ARG, TAG, "wrong LED pixel format, expected 4 bytes per pixel");
     uint8_t *buf_start = rmt_strip->pixel_buf + index * 4;
     // SK6812 component order is GRBW
     *buf_start = green & 0xFF;

--- a/led_strip/src/led_strip_rmt_dev.c
+++ b/led_strip/src/led_strip_rmt_dev.c
@@ -92,9 +92,9 @@ esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const l
     led_strip_rmt_obj *rmt_strip = NULL;
     esp_err_t ret = ESP_OK;
     ESP_GOTO_ON_FALSE(led_config && rmt_config && ret_strip, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
-    ESP_GOTO_ON_FALSE(led_config->led_type >= 0 && led_config->led_type <= 1, ESP_ERR_INVALID_ARG, err, TAG, "invalid led_type");
+    ESP_GOTO_ON_FALSE(led_config->led_pixel_format <= LED_PIXEL_FORMAT_GRBW, ESP_ERR_INVALID_ARG, err, TAG, "invalid led_pixel_format");
     uint8_t bytes_per_pixel;
-    if (led_config->led_type == LED_TYPE_SK6812) {
+    if (led_config->led_pixel_format == LED_PIXEL_FORMAT_GRBW) {
         bytes_per_pixel = 4;
     } else {
         bytes_per_pixel = 3;
@@ -121,7 +121,7 @@ esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const l
 
     led_strip_encoder_config_t strip_encoder_conf = {
         .resolution = resolution,
-        .led_type = led_config->led_type
+        .led_model = led_config->led_model
     };
     ESP_GOTO_ON_ERROR(rmt_new_led_strip_encoder(&strip_encoder_conf, &rmt_strip->strip_encoder), err, TAG, "create LED strip encoder failed");
 

--- a/led_strip/src/led_strip_rmt_encoder.c
+++ b/led_strip/src/led_strip_rmt_encoder.c
@@ -81,22 +81,41 @@ esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rm
     led_encoder->base.encode = rmt_encode_led_strip;
     led_encoder->base.del = rmt_del_led_strip_encoder;
     led_encoder->base.reset = rmt_led_strip_encoder_reset;
-    // different led strip might have its own timing requirements, following parameter is for WS2812
-    rmt_bytes_encoder_config_t bytes_encoder_config = {
-        .bit0 = {
-            .level0 = 1,
-            .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
-            .level1 = 0,
-            .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
-        },
-        .bit1 = {
-            .level0 = 1,
-            .duration0 = 0.9 * config->resolution / 1000000, // T1H=0.9us
-            .level1 = 0,
-            .duration1 = 0.3 * config->resolution / 1000000, // T1L=0.3us
-        },
-        .flags.msb_first = 1 // WS2812 transfer bit order: G7...G0R7...R0B7...B0
-    };
+    rmt_bytes_encoder_config_t bytes_encoder_config;
+    if (config->led_type == LED_TYPE_SK6812) {
+        bytes_encoder_config = (rmt_bytes_encoder_config_t) {
+            .bit0 = {
+                .level0 = 1,
+                .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
+                .level1 = 0,
+                .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
+            },
+            .bit1 = {
+                .level0 = 1,
+                .duration0 = 0.6 * config->resolution / 1000000, // T1H=0.6us
+                .level1 = 0,
+                .duration1 = 0.6 * config->resolution / 1000000, // T1L=0.6us
+            },
+            .flags.msb_first = 1 // SK6812 transfer bit order: G7...G0R7...R0B7...B0W7...W0
+        };
+    } else {
+        // different led strip might have its own timing requirements, following parameter is for WS2812
+        bytes_encoder_config = (rmt_bytes_encoder_config_t) {
+            .bit0 = {
+                .level0 = 1,
+                .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
+                .level1 = 0,
+                .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
+            },
+            .bit1 = {
+                .level0 = 1,
+                .duration0 = 0.9 * config->resolution / 1000000, // T1H=0.9us
+                .level1 = 0,
+                .duration1 = 0.3 * config->resolution / 1000000, // T1L=0.3us
+            },
+            .flags.msb_first = 1 // WS2812 transfer bit order: G7...G0R7...R0B7...B0
+        };
+    }
     ESP_GOTO_ON_ERROR(rmt_new_bytes_encoder(&bytes_encoder_config, &led_encoder->bytes_encoder), err, TAG, "create bytes encoder failed");
     rmt_copy_encoder_config_t copy_encoder_config = {};
     ESP_GOTO_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_config, &led_encoder->copy_encoder), err, TAG, "create copy encoder failed");

--- a/led_strip/src/led_strip_rmt_encoder.c
+++ b/led_strip/src/led_strip_rmt_encoder.c
@@ -82,7 +82,7 @@ esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rm
     led_encoder->base.del = rmt_del_led_strip_encoder;
     led_encoder->base.reset = rmt_led_strip_encoder_reset;
     rmt_bytes_encoder_config_t bytes_encoder_config;
-    if (config->led_type == LED_TYPE_SK6812) {
+    if (config->led_model == LED_MODEL_SK6812) {
         bytes_encoder_config = (rmt_bytes_encoder_config_t) {
             .bit0 = {
                 .level0 = 1,

--- a/led_strip/src/led_strip_rmt_encoder.h
+++ b/led_strip/src/led_strip_rmt_encoder.h
@@ -18,7 +18,7 @@ extern "C" {
  */
 typedef struct {
     uint32_t resolution; /*!< Encoder resolution, in Hz */
-    enum led_type_t led_type;
+    led_model_t led_model;
 } led_strip_encoder_config_t;
 
 /**

--- a/led_strip/src/led_strip_rmt_encoder.h
+++ b/led_strip/src/led_strip_rmt_encoder.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include "driver/rmt_encoder.h"
+#include "led_strip_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,6 +18,7 @@ extern "C" {
  */
 typedef struct {
     uint32_t resolution; /*!< Encoder resolution, in Hz */
+    enum led_type_t led_type;
 } led_strip_encoder_config_t;
 
 /**


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Implementing support for RGBW leds, specifically for SK6812.
These devices have 4 leds, the standard three RGB ones and a fourth white led.