### PR TITLE
tjpgd: remove ROM support for esp32h2

### DIFF
--- a/esp_jpeg/Kconfig
+++ b/esp_jpeg/Kconfig
@@ -2,10 +2,10 @@ menu "JPEG Decoder"
 
     config JD_USE_ROM
         bool "Use TinyJPG Decoder from ROM"
-        depends on (!IDF_TARGET_ESP32S2 && !IDF_TARGET_ESP32C2)
+        depends on (!IDF_TARGET_ESP32S2 && !IDF_TARGET_ESP32C2 && !IDF_TARGET_ESP32H2)
         default y
         help
-            By default, Espressif SoCs use TJpg decoder implemented in ROM code. 
+            By default, Espressif SoCs use TJpg decoder implemented in ROM code.
             If this feature is disabled, new configuration of TJpg decoder can be used.
             Refer to REAME.md for more details.
 

--- a/esp_jpeg/idf_component.yml
+++ b/esp_jpeg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "1.0.5"
 description: "JPEG Decoder: TJpgDec"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_jpeg/
 dependencies:


### PR DESCRIPTION
ESP32H2's ROM doesn't contain the tjpgd library.