### PR TITLE
usb: add ECM device class

### DIFF
--- a/usb/esp_tinyusb/Kconfig
+++ b/usb/esp_tinyusb/Kconfig
@@ -112,6 +112,14 @@ menu "TinyUSB Stack"
                 MSC FIFO size, in bytes.
     endmenu # "Massive Storage Class"
 
+    menu "USB Network Class (NCM)"
+        config TINYUSB_NCM_ENABLE
+            bool "Enable TinyUSB NCM driver"
+            default n
+            help
+                Enable USB NET TinyUSB driver.
+    endmenu # "usb network"
+
     menu "Communication Device Class (CDC)"
         config TINYUSB_CDC_ENABLED
             bool "Enable TinyUSB CDC feature"

--- a/usb/esp_tinyusb/include/tinyusb.h
+++ b/usb/esp_tinyusb/include/tinyusb.h
@@ -36,6 +36,7 @@ typedef struct {
     const uint8_t *configuration_descriptor;   /*!< Pointer to a configuration descriptor. If set to NULL, TinyUSB device will use a default configuration descriptor whose values are set in Kconfig */
     bool self_powered;                         /*!< This is a self-powered USB device. USB VBUS must be monitored. */
     int vbus_monitor_io;                       /*!< GPIO for VBUS monitoring. Ignored if not self_powered. */
+    uint8_t network_mac_id;                    /*!< Point to MAC description string index. Ignored if NCM disabled. */
 } tinyusb_config_t;
 
 /**

--- a/usb/esp_tinyusb/include/tusb_config.h
+++ b/usb/esp_tinyusb/include/tusb_config.h
@@ -33,6 +33,10 @@
 extern "C" {
 #endif
 
+#ifndef CONFIG_TINYUSB_NCM_ENABLE
+#   define CONFIG_TINYUSB_NCM_ENABLE 0
+#endif
+
 #ifndef CONFIG_TINYUSB_CDC_ENABLED
 #   define CONFIG_TINYUSB_CDC_ENABLED 0
 #endif
@@ -104,6 +108,8 @@ extern "C" {
 #define CFG_TUD_HID                 CONFIG_TINYUSB_HID_COUNT
 #define CFG_TUD_MIDI                CONFIG_TINYUSB_MIDI_COUNT
 #define CFG_TUD_CUSTOM_CLASS        CONFIG_TINYUSB_CUSTOM_CLASS_ENABLED
+
+#define CFG_TUD_NCM                CONFIG_TINYUSB_NCM_ENABLE
 
 #ifdef __cplusplus
 }

--- a/usb/esp_tinyusb/include_private/descriptors_control.h
+++ b/usb/esp_tinyusb/include_private/descriptors_control.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-void tusb_set_descriptor(const tusb_desc_device_t *dev_desc, const char **str_desc, const uint8_t *cfg_desc);
+void tusb_set_descriptor(const tusb_desc_device_t *dev_desc, const char **str_desc, const uint8_t *cfg_desc, const uint8_t mac_id);
 tusb_desc_device_t *tusb_get_active_desc(void);
 char **tusb_get_active_str_desc(void);
 void tusb_clear_descriptor(void);

--- a/usb/esp_tinyusb/tinyusb.c
+++ b/usb/esp_tinyusb/tinyusb.c
@@ -82,7 +82,7 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
         ESP_LOGW(TAG, "The device's device descriptor is not provided by user, using default.");
     }
 
-    tusb_set_descriptor(dev_descriptor, string_descriptor, cfg_descriptor);
+    tusb_set_descriptor(dev_descriptor, string_descriptor, cfg_descriptor, config->network_mac_id);
 
     ESP_RETURN_ON_FALSE(tusb_init(), ESP_FAIL, TAG, "Init TinyUSB stack failed");
 #if !CONFIG_TINYUSB_NO_DEFAULT_TASK


### PR DESCRIPTION
Added support for USB NCM class.
This MR relies on a tinyusb [MR](https://github.com/espressif/tinyusb/pull/9). The USB NCM example will be placed in the examples/peripherals/usb/device/tusb_ncm directory under esp-idf repository.
