### PR TITLE
esp_tinyusb: String descriptor handling

### DIFF
--- a/usb/esp_tinyusb/Kconfig
+++ b/usb/esp_tinyusb/Kconfig
@@ -30,6 +30,7 @@ menu "TinyUSB Stack"
     endmenu
 
     menu "Descriptor configuration"
+        comment "You can provide your custom descriptors via tinyusb_driver_install()"
         config TINYUSB_DESC_USE_ESPRESSIF_VID
             bool "VID: Use Espressif's vendor ID"
             default y
@@ -160,4 +161,61 @@ menu "TinyUSB Stack"
             help
                 Setting value greater than 0 will enable TinyUSB HID feature.
     endmenu # "HID Device Class (HID)"
+
+    menu "Device Firmware Upgrade (DFU)"
+        choice TINYUSB_DFU_MODE
+            prompt "DFU mode"
+            default TINYUSB_DFU_MODE_NONE
+            help
+                Select which DFU driver you want to use.
+
+            config TINYUSB_DFU_MODE_DFU
+                bool "DFU"
+
+            config TINYUSB_DFU_MODE_DFU_RUNTIME
+                bool "DFU Runtime"
+
+            config TINYUSB_DFU_MODE_NONE
+                bool "None"
+        endchoice
+        config TINYUSB_DFU_BUFSIZE
+            depends on TINYUSB_DFU_MODE_DFU
+            int "DFU XFER BUFFSIZE"
+            default 512
+            help
+                DFU XFER BUFFSIZE.
+    endmenu # Device Firmware Upgrade (DFU)
+
+    menu "Bluetooth Host Class (BTH)"
+        config TINYUSB_BTH_ENABLED
+            bool "Enable TinyUSB BTH feature"
+            default n
+            help
+                Enable TinyUSB BTH feature.
+
+        config TINYUSB_BTH_ISO_ALT_COUNT
+            depends on TINYUSB_BTH_ENABLED
+            int "BTH ISO ALT COUNT"
+            default 0
+            help
+                BTH ISO ALT COUNT.
+    endmenu # "Bluetooth Host Device Class"
+
+    menu "Network driver (ECM/NCM/RNDIS)"
+        choice TINYUSB_NET_MODE
+            prompt "Network mode"
+            default TINYUSB_NET_MODE_NONE
+            help
+                Select network driver you want to use.
+
+            config TINYUSB_NET_MODE_ECM_RNDIS
+                bool "ECM/RNDIS"
+
+            config TINYUSB_NET_MODE_NCM
+                bool "NCM"
+
+            config TINYUSB_NET_MODE_NONE
+                bool "None"
+        endchoice
+    endmenu # "Network driver (ECM/NCM/RNDIS)"
 endmenu # "TinyUSB Stack"

--- a/usb/esp_tinyusb/descriptors_control.c
+++ b/usb/esp_tinyusb/descriptors_control.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,11 +8,13 @@
 #include "esp_log.h"
 #include "descriptors_control.h"
 
+#define USB_STRING_DESCRIPTOR_ARRAY_SIZE 8 // Max 8 string descriptors for a device. LANGID, Manufacturer, Product, Serial number + 4 user defined
+#define MAX_DESC_BUF_SIZE 32               // Max length of string descriptor (can be extended, USB supports lengths up to 255 bytes)
+
 static const char *TAG = "tusb_desc";
-static tusb_desc_device_t s_device_descriptor;
+static const tusb_desc_device_t *s_device_descriptor;
 static const uint8_t *s_configuration_descriptor;
-static char *s_str_descriptor[USB_STRING_DESCRIPTOR_ARRAY_SIZE];
-#define MAX_DESC_BUF_SIZE 32
+static const char *s_str_descriptor[USB_STRING_DESCRIPTOR_ARRAY_SIZE]; // Array of pointers (strings). Statically allocated, can be made dynamic in the future.
 
 // =============================================================================
 // CALLBACKS
@@ -20,68 +22,65 @@ static char *s_str_descriptor[USB_STRING_DESCRIPTOR_ARRAY_SIZE];
 
 /**
  * @brief Invoked when received GET DEVICE DESCRIPTOR.
- * Application returns pointer to descriptor
+ * Descriptor contents must exist long enough for transfer to complete
  *
- * @return uint8_t const*
+ * @return Pointer to device descriptor
  */
 uint8_t const *tud_descriptor_device_cb(void)
 {
-    return (uint8_t const *)&s_device_descriptor;
+    return (uint8_t const *)s_device_descriptor;
 }
 
 /**
  * @brief Invoked when received GET CONFIGURATION DESCRIPTOR.
  * Descriptor contents must exist long enough for transfer to complete
  *
- * @param index
- * @return uint8_t const* Application return pointer to descriptor
+ * @param[in] index Index of required configuration
+ * @return Pointer to configuration descriptor
  */
 uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
 {
-    (void)index; // for multiple configurations
+    (void)index; // Unused, this driver supports only 1 configuration
     return s_configuration_descriptor;
 }
 
-static uint16_t _desc_str[MAX_DESC_BUF_SIZE];
-
-// Invoked when received GET STRING DESCRIPTOR request
-// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+/**
+ * @brief Invoked when received GET STRING DESCRIPTOR request
+ *
+ * @param[in] index   Index of required descriptor
+ * @param[in] langid  Language of the descriptor
+ * @return Pointer to UTF-16 string descriptor
+ */
 uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 {
-    (void) langid;
-
+    (void) langid; // Unused, this driver supports only one language in string descriptors
     uint8_t chr_count;
+    static uint16_t _desc_str[MAX_DESC_BUF_SIZE];
 
-    if ( index == 0) {
+    if (index == 0) {
         memcpy(&_desc_str[1], s_str_descriptor[0], 2);
         chr_count = 1;
     } else {
-        // Convert ASCII string into UTF-16
-
-        if ( index >= sizeof(s_str_descriptor) / sizeof(s_str_descriptor[0]) ) {
-            ESP_LOGE(TAG, "String index (%u) is out of bounds, check your string descriptor", index);
+        if (index >= USB_STRING_DESCRIPTOR_ARRAY_SIZE) {
+            ESP_LOGW(TAG, "String index (%u) is out of bounds, check your string descriptor", index);
             return NULL;
         }
 
         if (s_str_descriptor[index] == NULL) {
-            ESP_LOGE(TAG, "String index (%u) points to NULL, check your string descriptor", index);
+            ESP_LOGW(TAG, "String index (%u) points to NULL, check your string descriptor", index);
             return NULL;
         }
 
         const char *str = s_str_descriptor[index];
+        chr_count = strnlen(str, MAX_DESC_BUF_SIZE - 1); // Buffer len - header
 
-        // Cap at max char
-        chr_count = strlen(str);
-        if ( chr_count > MAX_DESC_BUF_SIZE - 1 ) {
-            chr_count = MAX_DESC_BUF_SIZE - 1;
-        }
-
+        // Convert ASCII string into UTF-16
         for (uint8_t i = 0; i < chr_count; i++) {
             _desc_str[1 + i] = str[i];
         }
     }
 
-    // first byte is length (including header), second byte is string type
+    // First byte is length in bytes (including header), second byte is descriptor type (TUSB_DESC_STRING)
     _desc_str[0] = (TUSB_DESC_STRING << 8 ) | (2 * chr_count + 2);
 
     return _desc_str;
@@ -91,8 +90,11 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 // Driver functions
 // =============================================================================
 
-void tusb_set_descriptor(const tusb_desc_device_t *dev_desc, const char **str_desc, const uint8_t *cfg_desc)
+void tinyusb_set_descriptor(const tusb_desc_device_t *dev_desc, const char **str_desc, int str_desc_count, const uint8_t *cfg_desc)
 {
+    assert(dev_desc && str_desc && cfg_desc);
+    assert(str_desc_count <= USB_STRING_DESCRIPTOR_ARRAY_SIZE);
+
     ESP_LOGI(TAG, "\n"
              "┌─────────────────────────────────┐\n"
              "│  USB Device Descriptor Summary  │\n"
@@ -124,27 +126,15 @@ void tusb_set_descriptor(const tusb_desc_device_t *dev_desc, const char **str_de
              dev_desc->idVendor, dev_desc->idProduct, dev_desc->bcdDevice,
              dev_desc->iManufacturer, dev_desc->iProduct, dev_desc->iSerialNumber,
              dev_desc->bNumConfigurations);
-    s_device_descriptor = *dev_desc;
+
+    // Save passed descriptors
+    s_device_descriptor = dev_desc;
     s_configuration_descriptor = cfg_desc;
-
-    if (str_desc != NULL) {
-        memcpy(s_str_descriptor, str_desc,
-               sizeof(s_str_descriptor[0])*USB_STRING_DESCRIPTOR_ARRAY_SIZE);
-    }
+    memcpy(s_str_descriptor, str_desc, str_desc_count * sizeof(str_desc[0]));
 }
 
-tusb_desc_device_t *tusb_get_active_desc(void)
+void tinyusb_set_str_descriptor(const char *str, int str_idx)
 {
-    return &s_device_descriptor;
-}
-
-char **tusb_get_active_str_desc(void)
-{
-    return s_str_descriptor;
-}
-
-void tusb_clear_descriptor(void)
-{
-    memset(&s_device_descriptor, 0, sizeof(s_device_descriptor));
-    memset(&s_str_descriptor, 0, sizeof(s_str_descriptor));
+    assert(str_idx < USB_STRING_DESCRIPTOR_ARRAY_SIZE);
+    s_str_descriptor[str_idx] = str;
 }

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,11 +1,11 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.0.3
+version: 1.0.4
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
-    version: '0.*' 
+    version: '0.*'
     public: true
 targets:
 - esp32s2

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,11 +1,11 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.0.4
+version: 1.1.0
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
-    version: '0.*'
+    version: '>=0.14.2'
     public: true
 targets:
 - esp32s2

--- a/usb/esp_tinyusb/include/tinyusb.h
+++ b/usb/esp_tinyusb/include/tinyusb.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,10 +9,7 @@
 #include <stdbool.h>
 #include "esp_err.h"
 #include "tusb.h"
-#include "tusb_option.h"
-#include "tusb_config.h"
 #include "tinyusb_types.h"
-
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,7 +28,8 @@ typedef struct {
         const tusb_desc_device_t *device_descriptor; /*!< Pointer to a device descriptor. If set to NULL, the TinyUSB device will use a default device descriptor whose values are set in Kconfig */
         const tusb_desc_device_t *descriptor  __attribute__((deprecated)); /*!< Alias to `device_descriptor` for backward compatibility */
     };
-    const char **string_descriptor;            /*!< Pointer to an array of string descriptors */
+    const char **string_descriptor;            /*!< Pointer to array of string descriptors. If set to NULL, TinyUSB device will use a default string descriptors whose values are set in Kconfig */
+    int string_descriptor_count;               /*!< Number of descriptors in above array */
     bool external_phy;                         /*!< Should USB use an external PHY */
     const uint8_t *configuration_descriptor;   /*!< Pointer to a configuration descriptor. If set to NULL, TinyUSB device will use a default configuration descriptor whose values are set in Kconfig */
     bool self_powered;                         /*!< This is a self-powered USB device. USB VBUS must be monitored. */

--- a/usb/esp_tinyusb/include/tinyusb_types.h
+++ b/usb/esp_tinyusb/include/tinyusb_types.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,13 +11,10 @@ extern "C" {
 #endif
 
 #define USB_ESPRESSIF_VID 0x303A
-#define USB_STRING_DESCRIPTOR_ARRAY_SIZE 8 // (4 + TINYUSB_STR_DESC_LEN)
 
 typedef enum {
     TINYUSB_USBDEV_0,
 } tinyusb_usbdev_t;
-
-typedef const char *tusb_desc_strarray_device_t[USB_STRING_DESCRIPTOR_ARRAY_SIZE];
 
 #ifdef __cplusplus
 }

--- a/usb/esp_tinyusb/include/tusb_cdc_acm.h
+++ b/usb/esp_tinyusb/include/tusb_cdc_acm.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,11 +11,14 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/semphr.h"
-#include "freertos/timers.h"
-#include "tusb.h"
-#include "tinyusb.h"
+#include "tinyusb_types.h"
+#include "esp_err.h"
+#include "sdkconfig.h"
+
+#if (CONFIG_TINYUSB_CDC_ENABLED != 1)
+#error "TinyUSB CDC driver must be enabled in menuconfig"
+#endif
+
 
 /**
  * @brief CDC ports available to setup

--- a/usb/esp_tinyusb/include/tusb_config.h
+++ b/usb/esp_tinyusb/include/tusb_config.h
@@ -57,6 +57,27 @@ extern "C" {
 #   define CONFIG_TINYUSB_CUSTOM_CLASS_ENABLED 0
 #endif
 
+#ifndef CONFIG_TINYUSB_NET_MODE_ECM_RNDIS
+#   define CONFIG_TINYUSB_NET_MODE_ECM_RNDIS 0
+#endif
+
+#ifndef CONFIG_TINYUSB_NET_MODE_NCM
+#   define CONFIG_TINYUSB_NET_MODE_NCM 0
+#endif
+
+#ifndef CONFIG_TINYUSB_DFU_MODE_DFU
+#   define CONFIG_TINYUSB_DFU_MODE_DFU 0
+#endif
+
+#ifndef CONFIG_TINYUSB_DFU_MODE_DFU_RUNTIME
+#   define CONFIG_TINYUSB_DFU_MODE_DFU_RUNTIME 0
+#endif
+
+#ifndef CONFIG_TINYUSB_BTH_ENABLED
+#   define CONFIG_TINYUSB_BTH_ENABLED 0
+#   define CONFIG_TINYUSB_BTH_ISO_ALT_COUNT 0
+#endif
+
 #ifndef CONFIG_TINYUSB_DEBUG_LEVEL
 #   define CONFIG_TINYUSB_DEBUG_LEVEL 0
 #endif
@@ -93,10 +114,22 @@ extern "C" {
 // MSC Buffer size of Device Mass storage
 #define CFG_TUD_MSC_BUFSIZE         CONFIG_TINYUSB_MSC_BUFSIZE
 
+// MIDI macros
 #define CFG_TUD_MIDI_EP_BUFSIZE     64
 #define CFG_TUD_MIDI_EPSIZE         CFG_TUD_MIDI_EP_BUFSIZE
 #define CFG_TUD_MIDI_RX_BUFSIZE     64
 #define CFG_TUD_MIDI_TX_BUFSIZE     64
+
+// Vendor FIFO size of TX and RX
+// If not configured vendor endpoints will not be buffered
+#define CFG_TUD_VENDOR_RX_BUFSIZE   64
+#define CFG_TUD_VENDOR_TX_BUFSIZE   64
+
+// DFU macros
+#define CFG_TUD_DFU_XFER_BUFSIZE    CONFIG_TINYUSB_DFU_BUFSIZE
+
+// Number of BTH ISO alternatives
+#define CFG_TUD_BTH_ISO_ALT_COUNT   CONFIG_TINYUSB_BTH_ISO_ALT_COUNT
 
 // Enabled device class driver
 #define CFG_TUD_CDC                 CONFIG_TINYUSB_CDC_COUNT
@@ -104,6 +137,11 @@ extern "C" {
 #define CFG_TUD_HID                 CONFIG_TINYUSB_HID_COUNT
 #define CFG_TUD_MIDI                CONFIG_TINYUSB_MIDI_COUNT
 #define CFG_TUD_CUSTOM_CLASS        CONFIG_TINYUSB_CUSTOM_CLASS_ENABLED
+#define CFG_TUD_ECM_RNDIS           CONFIG_TINYUSB_NET_MODE_ECM_RNDIS
+#define CFG_TUD_NCM                 CONFIG_TINYUSB_NET_MODE_NCM
+#define CFG_TUD_DFU                 CONFIG_TINYUSB_DFU_MODE_DFU
+#define CFG_TUD_DFU_RUNTIME         CONFIG_TINYUSB_DFU_MODE_DFU_RUNTIME
+#define CFG_TUD_BTH                 CONFIG_TINYUSB_BTH_ENABLED
 
 #ifdef __cplusplus
 }

--- a/usb/esp_tinyusb/include_private/descriptors_control.h
+++ b/usb/esp_tinyusb/include_private/descriptors_control.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,16 +7,32 @@
 #pragma once
 
 #include "tusb.h"
-#include "tinyusb_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void tusb_set_descriptor(const tusb_desc_device_t *dev_desc, const char **str_desc, const uint8_t *cfg_desc);
-tusb_desc_device_t *tusb_get_active_desc(void);
-char **tusb_get_active_str_desc(void);
-void tusb_clear_descriptor(void);
+/**
+ * @brief Set descriptors for this driver
+ *
+ * @attention All descriptors passed to this function must exist for the duration of USB device lifetime
+ *
+ * @param[in] dev_desc Device descriptor
+ * @param[in] str_desc Pointer to array of UTF-8 strings
+ * @param[in] str_desc_count Number of descriptors in str_desc
+ * @param[in] cfg_desc Configuration descriptor
+ */
+void tinyusb_set_descriptor(const tusb_desc_device_t *dev_desc, const char **str_desc, int str_desc_count, const uint8_t *cfg_desc);
+
+/**
+ * @brief Set specific string descriptor
+ *
+ * @attention The descriptor passed to this function must exist for the duration of USB device lifetime
+ *
+ * @param[in] str     UTF-8 string
+ * @param[in] str_idx String descriptor index
+ */
+void tinyusb_set_str_descriptor(const char *str, int str_idx);
 
 #ifdef __cplusplus
 }

--- a/usb/esp_tinyusb/include_private/usb_descriptors.h
+++ b/usb/esp_tinyusb/include_private/usb_descriptors.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,19 +7,33 @@
 #pragma once
 
 #include "tusb.h"
-#include "tinyusb_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define _PID_MAP(itf, n) ((CFG_TUD_##itf) << (n))
-
-extern tusb_desc_device_t descriptor_tinyusb;
-extern tusb_desc_strarray_device_t descriptor_str_tinyusb;
-
+/**
+ * @brief Device descriptor generated from Kconfig
+ *
+ * This descriptor is used by default.
+ * The user can provide his own device descriptor during tinyusb_driver_install() call
+ */
 extern const tusb_desc_device_t descriptor_dev_kconfig;
-extern tusb_desc_strarray_device_t descriptor_str_kconfig;
+
+/**
+ * @brief Array of string descriptors generated from Kconfig
+ *
+ * This descriptor is used by default.
+ * The user can provide his own descriptor during tinyusb_driver_install() call
+ */
+extern const char *descriptor_str_kconfig[];
+
+/**
+ * @brief Configuration descriptor generated from Kconfig
+ *
+ * This descriptor is used by default.
+ * The user can provide his own configuration descriptor during tinyusb_driver_install() call
+ */
 extern const uint8_t descriptor_cfg_kconfig[];
 
 #ifdef __cplusplus

--- a/usb/esp_tinyusb/tinyusb.c
+++ b/usb/esp_tinyusb/tinyusb.c
@@ -60,8 +60,8 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     if (config->configuration_descriptor) {
         cfg_descriptor = config->configuration_descriptor;
     } else {
-#if (CONFIG_TINYUSB_HID_COUNT > 0 || CONFIG_TINYUSB_MIDI_COUNT > 0)
-        // For HID and MIDI devices, configuration descriptor must be provided
+        // Default configuration descriptor is provided only for CDC and MSC classes
+#if (CFG_TUD_HID > 0 || CFG_TUD_MIDI > 0 || CFG_TUD_CUSTOM_CLASS > 0 || CFG_TUD_ECM_RNDIS > 0 || CFG_TUD_NCM > 0 || CFG_TUD_DFU > 0 || CFG_TUD_DFU_RUNTIME > 0 || CFG_TUD_BTH > 0)
         ESP_RETURN_ON_FALSE(config->configuration_descriptor, ESP_ERR_INVALID_ARG, TAG, "Configuration descriptor must be provided for this device");
 #else
         cfg_descriptor = descriptor_cfg_kconfig;
@@ -78,7 +78,7 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
         }
     } else {
         string_descriptor = descriptor_str_kconfig;
-        while(descriptor_str_kconfig[++string_descriptor_count] != NULL);
+        while (descriptor_str_kconfig[++string_descriptor_count] != NULL);
         ESP_LOGW(TAG, "The device's string descriptor is not provided by user, using default.");
     }
 

--- a/usb/esp_tinyusb/usb_descriptors.c
+++ b/usb/esp_tinyusb/usb_descriptors.c
@@ -1,11 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "usb_descriptors.h"
 #include "sdkconfig.h"
+#include "tinyusb_types.h"
 
 /*
  * A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
@@ -14,50 +15,13 @@
  * Auto ProductID layout's Bitmap:
  *   [MSB]         HID | MSC | CDC          [LSB]
  */
+#define _PID_MAP(itf, n) ((CFG_TUD_##itf) << (n))
 #define USB_TUSB_PID (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
     _PID_MAP(MIDI, 3) ) //| _PID_MAP(AUDIO, 4) | _PID_MAP(VENDOR, 5) )
 
-/**** TinyUSB default ****/
-tusb_desc_device_t descriptor_tinyusb = {
-    .bLength = sizeof(descriptor_tinyusb),
-    .bDescriptorType = TUSB_DESC_DEVICE,
-    .bcdUSB = 0x0200,
-
-#if CFG_TUD_CDC
-    // Use Interface Association Descriptor (IAD) for CDC
-    // As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
-    .bDeviceClass = TUSB_CLASS_MISC,
-    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
-    .bDeviceProtocol = MISC_PROTOCOL_IAD,
-#else
-    .bDeviceClass = 0x00,
-    .bDeviceSubClass = 0x00,
-    .bDeviceProtocol = 0x00,
-#endif
-
-    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
-
-    .idVendor = 0xCafe,
-    .idProduct = USB_TUSB_PID,
-    .bcdDevice = 0x0100,
-
-    .iManufacturer = 0x01,
-    .iProduct = 0x02,
-    .iSerialNumber = 0x03,
-
-    .bNumConfigurations = 0x01
-};
-
-tusb_desc_strarray_device_t descriptor_str_tinyusb = {
-    // array of pointer to string descriptors
-    (char[]){0x09, 0x04}, // 0: is supported language is English (0x0409)
-    "TinyUSB",            // 1: Manufacturer
-    "TinyUSB Device",     // 2: Product
-    "123456",             // 3: Serials, should use chip ID
-};
-/* End of TinyUSB default */
-
 /**** Kconfig driven Descriptor ****/
+
+//------------- Device Descriptor -------------//
 const tusb_desc_device_t descriptor_dev_kconfig = {
     .bLength = sizeof(descriptor_dev_kconfig),
     .bDescriptorType = TUSB_DESC_DEVICE,
@@ -98,7 +62,8 @@ const tusb_desc_device_t descriptor_dev_kconfig = {
     .bNumConfigurations = 0x01
 };
 
-tusb_desc_strarray_device_t descriptor_str_kconfig = {
+//------------- Array of String Descriptors -------------//
+const char *descriptor_str_kconfig[] = {
     // array of pointer to string descriptors
     (char[]){0x09, 0x04},                // 0: is supported language is English (0x0409)
     CONFIG_TINYUSB_DESC_MANUFACTURER_STRING, // 1: Manufacturer
@@ -116,10 +81,10 @@ tusb_desc_strarray_device_t descriptor_str_kconfig = {
 #else
     "",
 #endif
-
+    NULL                                     // NULL: Must be last. Indicates end of array
 };
 
-//------------- Configuration Descriptor -------------//
+//------------- Interfaces enumeration -------------//
 enum {
 #if CFG_TUD_CDC
     ITF_NUM_CDC = 0,
@@ -163,6 +128,7 @@ enum {
 #endif
 };
 
+//------------- Configuration Descriptor -------------//
 uint8_t const descriptor_cfg_kconfig[] = {
     // Configuration number, interface count, string index, total length, attribute, power in mA
     TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, TUSB_DESC_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),


### PR DESCRIPTION
There are following changes:

### Commit 816c3ad7d036e6563953cce840ef5c8e039ddd61
* Cleanup TinyUSB string descriptors handling. Remove unused code. Add length check to arguments passed to `tinyusb_driver_install`
* Add private option to modify string descriptors

### Commit  770d9a9204e7a7c5936de5c61f99b2845cc46f89
* Use latest [tinyusb](https://components.espressif.com/components/espressif/tinyusb) v0.14.2
* Update Kconfig and tusb_config.h for new feature (Bluetooth, NET, DFU)

~### Commit 97a108e686134149f250366e0fdd3703e7c80afc~
~* Proposal of MAC string handling for NET class~
~* Will be dropped~

Related #133 

I can split the PR into 2, if it is easier to review.
