### PR TITLE
esp_encrypted_img: fix gcc-12 compile errors

### DIFF
--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.2"
+version: "2.0.3"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -251,7 +251,7 @@ static void read_and_cache_data(esp_encrypted_img_t *handle, pre_enc_decrypt_arg
 {
     const int data_left = data_size - handle->binary_file_read;
     const int data_recv = args->data_in_len - *curr_index;
-    if (handle->state == ESP_PRE_ENC_IMG_READ_IV && handle->iv) {
+    if (handle->state == ESP_PRE_ENC_IMG_READ_IV) {
         memcpy(handle->iv + handle->cache_buf_len, args->data_in + *curr_index, MIN(data_recv, data_left));
     } else if (handle->state == ESP_PRE_ENC_IMG_READ_AUTH) {
         memcpy(handle->auth_tag + handle->cache_buf_len, args->data_in + *curr_index, MIN(data_recv, data_left));


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
While testing GCC-12 I found this error:

```
../managed_components/espressif__esp_encrypted_img/src/esp_encrypted_img.c: In function 'read_and_cache_data':
../managed_components/espressif__esp_encrypted_img/src/esp_encrypted_img.c:254:50: error: the comparison will always evaluate as 'true' for the address of 'iv' will never be NULL [-Werror=address]
  254 |     if (handle->state == ESP_PRE_ENC_IMG_READ_IV && handle->iv) {
      |                                                  ^~
../managed_components/espressif__esp_encrypted_img/src/esp_encrypted_img.c:46:10: note: 'iv' declared here
   46 |     char iv[IV_SIZE];
      |          ^~
```