### PR TITLE
usb: fix gcc-12 compile errors

### DIFF
--- a/usb/usb_host_ch34x_vcp/idf_component.yml
+++ b/usb/usb_host_ch34x_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.0"
+version: "1.0.1"
 description: USB Host driver for CH34x series of chips
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_ch34x_vcp
 dependencies:

--- a/usb/usb_host_ch34x_vcp/include/usb/vcp_ch34x.hpp
+++ b/usb/usb_host_ch34x_vcp/include/usb/vcp_ch34x.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <vector>
 #include "usb/cdc_acm_host.h"

--- a/usb/usb_host_cp210x_vcp/idf_component.yml
+++ b/usb/usb_host_cp210x_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.0"
+version: "1.0.1"
 description: USB Host driver for CP210x series of chips
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_cp210x_vcp
 dependencies:

--- a/usb/usb_host_cp210x_vcp/include/usb/vcp_cp210x.hpp
+++ b/usb/usb_host_cp210x_vcp/include/usb/vcp_cp210x.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <vector>
 #include "usb/cdc_acm_host.h"

--- a/usb/usb_host_ftdi_vcp/idf_component.yml
+++ b/usb/usb_host_ftdi_vcp/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.0.0"
+version: "1.0.1"
 description: USB Host driver for FTDI USB<->UART converters series of chips
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_ftdi_vcp
 dependencies:

--- a/usb/usb_host_ftdi_vcp/include/usb/vcp_ftdi.hpp
+++ b/usb/usb_host_ftdi_vcp/include/usb/vcp_ftdi.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <vector>
 #include "usb/cdc_acm_host.h"


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Fix for gcc-12 builds

The compile errors were:

```
In file included from ../main/cdc_acm_vcp_example_main.cpp:16:
../managed_components/espressif__usb_host_ch34x_vcp/include/usb/vcp_ch34x.hpp:56:46: error: 'constexpr const std::array<short unsigned int, 3> esp_usb::CH34x::pids' has incomplete type
   56 |     static constexpr std::array<uint16_t, 3> pids = {CH340_PID, CH340_PID_1, CH341_PID};
      |                                              ^~~~
In file included from ../main/cdc_acm_vcp_example_main.cpp:17:
../managed_components/espressif__usb_host_cp210x_vcp/include/usb/vcp_cp210x.hpp:108:46: error: 'constexpr const std::array<short unsigned int, 3> esp_usb::CP210x::pids' has incomplete type
  108 |     static constexpr std::array<uint16_t, 3> pids = {CP210X_PID, CP2105_PID, CP2108_PID};
      |                                              ^~~~
In file included from ../main/cdc_acm_vcp_example_main.cpp:18:
../managed_components/espressif__usb_host_ftdi_vcp/include/usb/vcp_ftdi.hpp:61:46: error: 'constexpr const std::array<short unsigned int, 2> esp_usb::FT23x::pids' has incomplete type
   61 |     static constexpr std::array<uint16_t, 2> pids = {FT232_PID, FT231_PID};
      |                                              ^~~~
```
