### PR TITLE
json_parser: add idf_version rules for jsmn

### DIFF
--- a/json_parser/idf_component.yml
+++ b/json_parser/idf_component.yml
@@ -1,5 +1,8 @@
-version: "1.0.2"
+version: "1.0.3"
 description: This is a simple, light weight JSON parser built on top of jsmn
 url: https://github.com/espressif/json_parser
 dependencies:
-  jsmn: "~1.1"
+  jsmn:
+    version: "~1.1"
+    rules:
+      - if: "idf_version >=5.0"


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Fix a compilation error of `json_parser` component on idf v4.x.

Because the jsmn component was part of idf v4.4 and earlier.

The compile errors were:
```c
  ERROR: Cannot process component requirements.  Multiple candidates to
  satisfy project requirements:

    requirement: "jsmn" candidates: "espressif__jsmn, jsmn"


```