### PR TITLE
led_strip: support configurable channel block size

### DIFF
--- a/led_strip/CHANGELOG.md
+++ b/led_strip/CHANGELOG.md
@@ -21,3 +21,7 @@
       led_model, used to configure bit timing (LED_MODEL_WS2812, LED_MODEL_SK6812)
   - new API led_strip_set_pixel_rgbw
   - new interface type set_pixel_rgbw
+
+## 2.3.0
+
+- Support configurable RMT channel size by setting `mem_block_symbols`

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.2.1"
+version: "2.3.0"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 dependencies:

--- a/led_strip/include/led_strip_rmt.h
+++ b/led_strip/include/led_strip_rmt.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,13 +14,13 @@
 extern "C" {
 #endif
 
-
 /**
  * @brief LED Strip RMT specific configuration
  */
 typedef struct {
     rmt_clock_source_t clk_src; /*!< RMT clock source */
     uint32_t resolution_hz;     /*!< RMT tick resolution, if set to zero, a default resolution (10MHz) will be applied */
+    size_t mem_block_symbols;   /*!< How many RMT symbols can one RMT channel hold at one time. Set to 0 will fallback to use the default size. */
     struct {
         uint32_t with_dma: 1;   /*!< Use DMA to transmit data */
     } flags;

--- a/led_strip/src/led_strip_rmt_dev.c
+++ b/led_strip/src/led_strip_rmt_dev.c
@@ -14,6 +14,13 @@
 #include "led_strip_rmt_encoder.h"
 
 #define LED_STRIP_RMT_DEFAULT_RESOLUTION 10000000 // 10MHz resolution
+#define LED_STRIP_RMT_DEFAULT_TRANS_QUEUE_SIZE 4
+// the memory size of each RMT channel, in words (4 bytes)
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#define LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS 64
+#else
+#define LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS 48
+#endif
 
 static const char *TAG = "led_strip_rmt";
 
@@ -110,12 +117,17 @@ esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const l
     if (rmt_config->clk_src) {
         clk_src = rmt_config->clk_src;
     }
+    size_t mem_block_symbols = LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS;
+    // override the default value if the user sets it
+    if (rmt_config->mem_block_symbols) {
+        mem_block_symbols = rmt_config->mem_block_symbols;
+    }
     rmt_tx_channel_config_t rmt_chan_config = {
         .clk_src = clk_src,
         .gpio_num = led_config->strip_gpio_num,
-        .mem_block_symbols = 64,
+        .mem_block_symbols = mem_block_symbols,
         .resolution_hz = resolution,
-        .trans_queue_depth = 4,
+        .trans_queue_depth = LED_STRIP_RMT_DEFAULT_TRANS_QUEUE_SIZE,
         .flags.with_dma = rmt_config->flags.with_dma,
         .flags.invert_out = led_config->flags.invert_out,
     };


### PR DESCRIPTION
Introduce a new configuration entry: `mem_block_symbols` so that the channel block size can be customized by the user.

Closes https://github.com/espressif/idf-extra-components/issues/138