### PR TITLE
USB: CDC-ACM enhacements

### DIFF
--- a/usb/esp_modem_usb_dte/esp_modem_usb.cpp
+++ b/usb/esp_modem_usb_dte/esp_modem_usb.cpp
@@ -78,6 +78,7 @@ public:
         const cdc_acm_host_device_config_t esp_modem_cdc_acm_device_config = {
             .connection_timeout_ms = usb_config->timeout_ms,
             .out_buffer_size = config->dte_buffer_size,
+            .in_buffer_size = config->dte_buffer_size,
             .event_cb = handle_notif,
             .data_cb = handle_rx,
             .user_arg = this
@@ -133,14 +134,15 @@ private:
     bool operator!= (const UsbTerminal &param) const = delete;
     static TaskHandle_t usb_host_lib_task; // Reused by multiple devices or between reconnections
 
-    static void handle_rx(uint8_t *data, size_t data_len, void *user_arg)
+    static bool handle_rx(const uint8_t *data, size_t data_len, void *user_arg)
     {
         ESP_LOG_BUFFER_HEXDUMP(TAG, data, data_len, ESP_LOG_DEBUG);
         UsbTerminal *this_terminal = static_cast<UsbTerminal *>(user_arg);
         if (data_len > 0 && this_terminal->on_read) {
-            this_terminal->on_read(data, data_len);
+            return this_terminal->on_read((uint8_t *)data, data_len);
         } else {
             ESP_LOGD(TAG, "Unhandled RX data");
+            return true;
         }
     }
 

--- a/usb/usb_host_cdc_acm/CHANGELOG.md
+++ b/usb/usb_host_cdc_acm/CHANGELOG.md
@@ -1,0 +1,14 @@
+## 1.0.0
+
+- Initial version
+
+## 1.0.4
+
+- C++ methods are now virtual to allow derived classes to override them.
+
+## 2.0.0
+
+- New function `cdc_acm_host_register_new_dev_callback`. This allows you to get New Device notifications even if you use the default driver.
+- Receive buffer has configurable size. This is useful if you expect data transfers larger then Maximum Packet Size.
+- Receive buffer has 'append' function. In the Data Received callback you can signal that you wait for more data and the current data were not yet processed. In this case, the CDC driver appends new data to the already received data. This is especially useful if the upper layer messages consist of multiple USB transfers and you don't want to waste more RAM and CPU copying the data around.
+

--- a/usb/usb_host_cdc_acm/README.md
+++ b/usb/usb_host_cdc_acm/README.md
@@ -2,14 +2,14 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/usb_host_cdc_acm/badge.svg)](https://components.espressif.com/components/espressif/usb_host_cdc_acm)
 
-This directory contains an implementation of a USB CDC-ACM Host Class Driver that is implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
+This component contains an implementation of a USB CDC-ACM Host Class Driver that is implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
 
 ## Supported Devices
 
 The CDC-ACM Host driver supports the following types of CDC devices:
 
 1. CDC-ACM devices
-2. CDC-like vendor specific devices (usually found on USB to UART bridge devices)
+2. CDC-like vendor specific devices (usually found on USB to UART bridge devices or cellular modems)
 
 ### CDC-ACM Devices
 
@@ -36,7 +36,7 @@ The following steps outline the typical API call pattern of the CDC-ACM Class Dr
 
 1. Install the USB Host Library via `usb_host_install()`
 2. Install the CDC-ACM driver via `cdc_acm_host_install()`
-3. Call `cdc_acm_host_open()`/`cdc_acm_host_open_vendor_specific()` to open a target CDC-ACM/CDC-like device. These functions will block until the target device is connected
+3. Call `cdc_acm_host_open()`/`cdc_acm_host_open_vendor_specific()` to open a target CDC-ACM/CDC-like device. These functions will block until the target device is connected or time-out
 4. To transmit data, call `cdc_acm_host_data_tx_blocking()`
 5. When data is received, the driver will automatically run the receive data callback
 6. An opened device can be closed via `cdc_acm_host_close()`
@@ -44,5 +44,7 @@ The following steps outline the typical API call pattern of the CDC-ACM Class Dr
 
 ## Examples
 
-- For an example with a CDC-ACM device, refer to [cdc_acm_host](../../cdc_acm_host)
-- For an example with a CDC-like device, refer to [cdc_acm_host_bg96](../../cdc_acm_bg96)
+- For an example with a CDC-ACM device, refer to [cdc_acm_host](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc/cdc_acm_host)
+- For an example with a CDC-like device, refer to [cdc_acm_host_bg96](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc/cdc_acm_bg96)
+- For an example with Virtual COM devices, refer to [cdc_acm_vcp](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/cdc/cdc_acm_vcp)
+- For examples with [esp_modem](https://components.espressif.com/components/espressif/esp_modem), refer to [esp_modem examples](https://github.com/espressif/esp-protocols/tree/master/components/esp_modem/examples)

--- a/usb/usb_host_cdc_acm/idf_component.yml
+++ b/usb/usb_host_cdc_acm/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "2.0.0"
 description: USB Host CDC-ACM driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_cdc_acm
 dependencies:

--- a/usb/usb_host_cdc_acm/idf_component.yml
+++ b/usb/usb_host_cdc_acm/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "1.1.0"
 description: USB Host CDC-ACM driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_cdc_acm
 dependencies:

--- a/usb/usb_host_cdc_acm/include/usb/cdc_acm_host.h
+++ b/usb/usb_host_cdc_acm/include/usb/cdc_acm_host.h
@@ -145,6 +145,16 @@ esp_err_t cdc_acm_host_install(const cdc_acm_host_driver_config_t *driver_config
 esp_err_t cdc_acm_host_uninstall(void);
 
 /**
+ * @brief Register new USB device callback
+ *
+ * The callback will be called for every new USB device, not just CDC-ACM class.
+ *
+ * @param[in] new_dev_cb New device callback function
+ * @return esp_err_t
+ */
+esp_err_t cdc_acm_host_register_new_dev_callback(cdc_acm_new_dev_callback_t new_dev_cb);
+
+/**
  * @brief Open CDC-ACM compliant device
  *
  * CDC-ACM compliant device must contain either an Interface Association Descriptor or CDC-Union descriptor,

--- a/usb/usb_host_cdc_acm/include/usb/cdc_acm_host.h
+++ b/usb/usb_host_cdc_acm/include/usb/cdc_acm_host.h
@@ -83,12 +83,20 @@ typedef void (*cdc_acm_new_dev_callback_t)(usb_device_handle_t usb_dev);
 
 /**
  * @brief Data receive callback type
+ *
+ * @param[in] data     Pointer to received data
+ * @param[in] data_len Lenght of received data in bytes
+ * @param[in] user_arg User's argument passed to open function
+ * @return true        Received data was processed     -> Flush RX buffer
+ * @return false       Received data was NOT processed -> Append new data to the buffer
  */
-typedef void (*cdc_acm_data_callback_t)(uint8_t *data, size_t data_len, void *user_arg);
+typedef bool (*cdc_acm_data_callback_t)(const uint8_t *data, size_t data_len, void *user_arg);
 
 /**
  * @brief Device event callback type
- * @see cdc_acm_host_dev_event_data_t
+ *
+ * @param[in] event    Event strucutre
+ * @param[in] user_arg User's argument passed to open function
  */
 typedef void (*cdc_acm_host_dev_callback_t)(const cdc_acm_host_dev_event_data_t *event, void *user_ctx);
 

--- a/usb/usb_host_cdc_acm/include/usb/cdc_acm_host.h
+++ b/usb/usb_host_cdc_acm/include/usb/cdc_acm_host.h
@@ -110,6 +110,7 @@ typedef struct {
 typedef struct {
     uint32_t connection_timeout_ms;       /**< Timeout for USB device connection in [ms] */
     size_t out_buffer_size;               /**< Maximum size of USB bulk out transfer, set to 0 for read-only devices */
+    size_t in_buffer_size;                /**< Maximum size of USB bulk in transfer */
     cdc_acm_host_dev_callback_t event_cb; /**< Device's event callback function. Can be NULL */
     cdc_acm_data_callback_t data_cb;      /**< Device's data RX callback function. Can be NULL for write-only devices */
     void *user_arg;                       /**< User's argument that will be passed to the callbacks */

--- a/usb/usb_host_ftdi_vcp/include/usb/vcp_ftdi.hpp
+++ b/usb/usb_host_ftdi_vcp/include/usb/vcp_ftdi.hpp
@@ -94,7 +94,7 @@ private:
      * @param[in] data_len Received data length
      * @param[in] user_arg Pointer to FT23x class
      */
-    static void ftdi_rx(uint8_t *data, size_t data_len, void *user_arg);
+    static bool ftdi_rx(const uint8_t *data, size_t data_len, void *user_arg);
 
     // Just a wrapper to recover user's argument
     static void ftdi_event(const cdc_acm_host_dev_event_data_t *event, void *user_ctx);

--- a/usb/usb_host_ftdi_vcp/usb_host_ftdi_vcp.cpp
+++ b/usb/usb_host_ftdi_vcp/usb_host_ftdi_vcp.cpp
@@ -86,7 +86,7 @@ esp_err_t FT23x::set_control_line_state(bool dtr, bool rts)
     return this->send_custom_request(FTDI_WRITE_REQ, FTDI_CMD_SET_MHS, rts ? 0x21 : 0x20, this->intf, 0, NULL); // RTS
 }
 
-void FT23x::ftdi_rx(uint8_t *data, size_t data_len, void *user_arg)
+bool FT23x::ftdi_rx(const uint8_t *data, size_t data_len, void *user_arg)
 {
     FT23x *this_ftdi = (FT23x *)user_arg;
 
@@ -113,8 +113,9 @@ void FT23x::ftdi_rx(uint8_t *data, size_t data_len, void *user_arg)
 
     // Dispatch data if any
     if (data_len > 2) {
-        this_ftdi->user_data_cb(&data[2], data_len - 2, this_ftdi->user_arg);
+        return this_ftdi->user_data_cb(&data[2], data_len - 2, this_ftdi->user_arg);
     }
+    return true;
 }
 
 void FT23x::ftdi_event(const cdc_acm_host_dev_event_data_t *event, void *user_ctx)

--- a/usb/usb_host_vcp/usb_host_vcp.cpp
+++ b/usb/usb_host_vcp/usb_host_vcp.cpp
@@ -61,13 +61,8 @@ CdcAcmDevice *VCP::open(const cdc_acm_host_device_config_t *dev_config, uint8_t 
 
     // dev_config->connection_timeout_ms is normally meant for 1 device,
     // but here it is a timeout for the whole function call
-    cdc_acm_host_device_config_t _config = {
-        .connection_timeout_ms = 1,
-        .out_buffer_size = dev_config->out_buffer_size,
-        .event_cb = dev_config->event_cb,
-        .data_cb = dev_config->data_cb,
-        .user_arg = dev_config->user_arg,
-    };
+    cdc_acm_host_device_config_t _config = *dev_config;
+    _config.connection_timeout_ms = 1;
 
     // Try opening all registered devices, return on first success
     do {


### PR DESCRIPTION
# Change description

## Change log

- New function `cdc_acm_host_register_new_dev_callback`. This allows you to get New Device notifications even if you use the default driver, or you didn't install the driver yourself
- Receive buffer has configurable size. This is useful if you expect data transfers larger then Maximum Packet Size.
- Receive buffer has 'append' function. In the Data Received callback you can signal that you wait for more data and the current data were not yet processed. In this case, the CDC driver appends new data to the already received data. This is especially useful if the upper layer messages consist of multiple USB transfers and you don't want to waste more RAM and CPU copying the data around.

### Breaking change
The last point^ is unfortunately a breaking change. Some cellular modems in [esp_modem](https://components.espressif.com/components/espressif/esp_modem) need it.

### Additional info
- Test and README extended
- There are changes in other USB components too -> the CI needs all components compatible with latest version of CDC-ACM. These components will be properly updated and release in subsequent PR
