### PR TITLE
Bugfix/json parser and others

### DIFF
--- a/json_parser/idf_component.yml
+++ b/json_parser/idf_component.yml
@@ -1,9 +1,14 @@
-version: "1.0.3"
+version: "1.0.2"
 description: This is a simple, light weight JSON parser built on top of jsmn
 url: https://github.com/espressif/json_parser
 dependencies:
   jsmn:
     version: "~1.1"
-    rules:
-      - if: "idf_version >=5.0"
+    # The "rules" entry is temporarily disabled, as idf-component-manager
+    # doesn't support uploading components with such entries to the registry.
+    # Re-enable this after the bug fix in idf-component-manager is released,
+    # and increase the component version to 1.0.3.
+    #
+    # rules:
+    #   - if: "idf_version >=5.0"
     override_path: "../jsmn/"

--- a/json_parser/idf_component.yml
+++ b/json_parser/idf_component.yml
@@ -6,3 +6,4 @@ dependencies:
     version: "~1.1"
     rules:
       - if: "idf_version >=5.0"
+    override_path: "../jsmn/"

--- a/json_parser/test/CMakeLists.txt
+++ b/json_parser/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS test_json_parser.c
+                       PRIV_REQUIRES json_parser unity)

--- a/json_parser/test/test_json_parser.c
+++ b/json_parser/test/test_json_parser.c
@@ -1,0 +1,61 @@
+#include <assert.h>
+#include <string.h>
+#include "json_parser.h"
+#include "unity.h"
+
+#define json_test_str   "{\n\"str_val\" :    \"JSON Parser\",\n" \
+            "\t\"float_val\" : 2.0,\n" \
+            "\"int_val\" : 2017,\n" \
+            "\"bool_val\" : false,\n" \
+            "\"supported_el\" :\t [\"bool\",\"int\","\
+            "\"float\",\"str\"" \
+            ",\"object\",\"array\"],\n" \
+            "\"features\" : { \"objects\":true, "\
+            "\"arrays\":\"yes\"},\n"\
+            "\"int_64\":109174583252}"
+
+TEST_CASE("json_parser basic tests", "[json_parser]")
+{
+    jparse_ctx_t jctx;
+    int ret = json_parse_start(&jctx, json_test_str, strlen(json_test_str));
+    TEST_ASSERT_EQUAL(OS_SUCCESS, ret);
+
+    char str_val[64];
+    int int_val, num_elem;
+    int64_t int64_val;
+    bool bool_val;
+    float float_val;
+
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_string(&jctx, "str_val", str_val, sizeof(str_val)));
+    TEST_ASSERT_EQUAL_STRING("JSON Parser", str_val);
+
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_float(&jctx, "float_val", &float_val));
+    TEST_ASSERT(fabs(float_val - 2.0f) < 0.0001f)
+
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_int(&jctx, "int_val", &int_val));
+    TEST_ASSERT_EQUAL_INT(2017, int_val);
+
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_bool(&jctx, "bool_val", &bool_val));
+    TEST_ASSERT_EQUAL(false, bool_val);
+
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_array(&jctx, "supported_el", &num_elem));
+    const char *expected_values[] = {"bool", "int", "float", "str", "object", "array"};
+    TEST_ASSERT_EQUAL(sizeof(expected_values) / sizeof(expected_values[0]), num_elem);
+    for (int i = 0; i < num_elem; ++i) {
+        TEST_ASSERT_EQUAL(OS_SUCCESS, json_arr_get_string(&jctx, i, str_val, sizeof(str_val)));
+        TEST_ASSERT_EQUAL_STRING(expected_values[i], str_val);
+    }
+    json_obj_leave_array(&jctx);
+
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_object(&jctx, "features"));
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_bool(&jctx, "objects", &bool_val));
+    TEST_ASSERT_EQUAL(true, bool_val);
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_string(&jctx, "arrays", str_val, sizeof(str_val)));
+    TEST_ASSERT_EQUAL_STRING("yes", str_val);
+    json_obj_leave_object(&jctx);
+
+    TEST_ASSERT_EQUAL(OS_SUCCESS, json_obj_get_int64(&jctx, "int_64", &int64_val));
+    TEST_ASSERT(int64_val == 109174583252);
+
+    json_parse_end(&jctx);
+}

--- a/sh2lib/idf_component.yml
+++ b/sh2lib/idf_component.yml
@@ -3,4 +3,6 @@ description: HTTP2 TLS Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/sh2lib
 dependencies:
   idf: ">=5.0"
-  espressif/nghttp: ">=1.41.0"
+  espressif/nghttp:
+    version: ">=1.41.0"
+    override_path: "../nghttp"

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -5,7 +5,7 @@ include($ENV{IDF_PATH}/tools/cmake/version.cmake)
 
 # Add newly added components to one of these lines:
 # 1. Add here if the component is compatible with IDF >= v4.3
-set(EXTRA_COMPONENT_DIRS ../libsodium ../expat ../cbor ../jsmn ../qrcode ../coap ../eigen ../fmt)
+set(EXTRA_COMPONENT_DIRS ../libsodium ../expat ../cbor ../jsmn ../qrcode ../coap ../eigen ../fmt ../json_parser ../json_generator)
 
 # 2. Add here if the component is compatible with IDF >= v4.4
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "4.4")


### PR DESCRIPTION
## Change description

* Include json_parser and json_generator components into the test_app build.
* Add a test for json_parser, based on https://github.com/espressif/json_parser/blob/master/tests/main.c
* Specify override_path for jsmn in json_parser. Since jsmn is in the same repository, we want to use the copy of the component from the repository when building the test app.
* Likewise, add override_path for nghttp in sh2lib.
* Revert the "rules" entry for json_parser added in #140, since it is not currently supported by idf-component-manager when uploading components to the registry. This requires a bugfix release on the idf-component-manager side, which might take several days. Reverting this change helps unblock CI.

There are no functional changes for components themselves, so I'm not increasing the versions here.