### PR TITLE
ci: build and run the test app with release/v5.0

### DIFF
--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v4.3", "release-v4.4", "latest"]
+        idf_ver: ["release-v4.3", "release-v4.4", "release-v5.0", "latest"]
         idf_target: ["esp32", "esp32c3", "esp32s3"] # @todo ESP32S2 has less RAM and the test_app will not fit
         exclude:
           - idf_ver: "release-v4.3"
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v4.3", "release-v4.4", "latest"]
+        idf_ver: ["release-v4.3", "release-v4.4", "release-v5.0", "latest"]
         idf_target: ["esp32", "esp32c3", "esp32s3"]
         exclude:
           - idf_ver: "release-v4.3"


### PR DESCRIPTION
Release/v5.0 was already used in the usb and cbor workflows. This PR adds it to the common test_app as well.