### PR TITLE
esp_tinyusb: add USB device class NCM (IEC-17)

### DIFF
--- a/usb/esp_tinyusb/CMakeLists.txt
+++ b/usb/esp_tinyusb/CMakeLists.txt
@@ -38,6 +38,10 @@ if(CONFIG_TINYUSB_MSC_ENABLED)
         )
 endif() # CONFIG_TINYUSB_MSC_ENABLED
 
+if(CONFIG_TINYUSB_NET_MODE_NCM)
+    list(APPEND srcs "tinyusb_net.c")
+endif() # CONFIG_TINYUSB_NET_MODE_NCM
+
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS ${includes_public}
                        PRIV_INCLUDE_DIRS ${includes_private}

--- a/usb/esp_tinyusb/include/tinyusb_net.h
+++ b/usb/esp_tinyusb/include/tinyusb_net.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "tinyusb_types.h"
+#include "esp_err.h"
+#include "sdkconfig.h"
+
+#if (CONFIG_TINYUSB_NET_MODE_NONE != 1)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*net_recv_handler_t)(void *buffer, uint16_t len);
+
+/**
+ * @brief ESP TinyUSB NCM driver configuration structure
+ */
+typedef struct {
+    const uint8_t *mac_addr; /*!< MAC address. Must be 6 bytes long. */
+    net_recv_handler_t recv_handle; /*!< TinyUSB receive data handle */
+} tinyusb_net_config_t;
+
+/**
+ * @brief Initialize TinyUSB NET driver
+ *
+ * @param[in] usb_dev USB device to use
+ * @param[in] cfg     Configuration of the driver
+ * @return esp_err_t
+ */
+esp_err_t tinyusb_net_init(tinyusb_usbdev_t usb_dev, const tinyusb_net_config_t *cfg);
+
+/**
+ * @brief TinyUSB NET driver send data
+ *
+ * @param[in] buffer USB send data
+ * @param[in] len     Send data len
+ * @return esp_err_t
+ */
+esp_err_t tinyusb_net_send(void *buffer, uint16_t len);
+
+#endif
+
+//TODO: Define ESP-specific functions
+#ifdef __cplusplus
+}
+#endif

--- a/usb/esp_tinyusb/include_private/usb_descriptors.h
+++ b/usb/esp_tinyusb/include_private/usb_descriptors.h
@@ -36,6 +36,8 @@ extern const char *descriptor_str_kconfig[];
  */
 extern const uint8_t descriptor_cfg_kconfig[];
 
+uint8_t tusb_get_mac_string_id(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/usb/esp_tinyusb/tinyusb.c
+++ b/usb/esp_tinyusb/tinyusb.c
@@ -61,12 +61,13 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
         cfg_descriptor = config->configuration_descriptor;
     } else {
         // Default configuration descriptor is provided only for CDC and MSC classes
-#if (CFG_TUD_HID > 0 || CFG_TUD_MIDI > 0 || CFG_TUD_CUSTOM_CLASS > 0 || CFG_TUD_ECM_RNDIS > 0 || CFG_TUD_NCM > 0 || CFG_TUD_DFU > 0 || CFG_TUD_DFU_RUNTIME > 0 || CFG_TUD_BTH > 0)
+#if (CFG_TUD_HID > 0 || CFG_TUD_MIDI > 0 || CFG_TUD_CUSTOM_CLASS > 0)
         ESP_RETURN_ON_FALSE(config->configuration_descriptor, ESP_ERR_INVALID_ARG, TAG, "Configuration descriptor must be provided for this device");
 #else
-        cfg_descriptor = descriptor_cfg_kconfig;
-        ESP_LOGW(TAG, "The device's configuration descriptor is not provided by user, using default.");
+         cfg_descriptor = descriptor_cfg_kconfig;
+         ESP_LOGW(TAG, "The device's configuration descriptor is not provided by user, using default.");
 #endif
+
     }
 
     if (config->string_descriptor) {

--- a/usb/esp_tinyusb/tinyusb_net.c
+++ b/usb/esp_tinyusb/tinyusb_net.c
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "tinyusb_net.h"
+#include "descriptors_control.h"
+#include "usb_descriptors.h"
+
+#define MAC_ADDR_LEN 6 // In bytes
+
+static net_recv_handler_t net_recv_callback;
+
+esp_err_t tinyusb_net_send(void *buffer, uint16_t len)
+{
+    for (;;)
+    {
+        /* if TinyUSB isn't ready, we must signal back to lwip that there is nothing we can do */
+        if (!tud_ready()) {
+            return ESP_FAIL;
+        }
+
+        /* if the network driver can accept another packet, we make it happen */
+        if (tud_network_can_xmit(len))
+        {
+            tud_network_xmit(buffer, len);
+            return ESP_OK;
+        }
+
+        /* transfer execution to TinyUSB in the hopes that it will finish transmitting the prior packet */
+        tud_task();
+    }
+
+}
+
+esp_err_t tinyusb_net_init(tinyusb_usbdev_t usb_dev, const tinyusb_net_config_t *cfg)
+{
+    (void) usb_dev;
+    uint8_t mac_id;
+
+    // Convert MAC address into UTF-8
+    static char mac_str[2 * MAC_ADDR_LEN + 1]; // +1 for NULL terminator
+    for (unsigned i = 0; i < MAC_ADDR_LEN; i++) {
+        mac_str[2 * i]     = "0123456789ABCDEF"[(cfg->mac_addr[i] >> 4) & 0x0F];
+        mac_str[2 * i + 1] = "0123456789ABCDEF"[(cfg->mac_addr[i] >> 0) & 0x0F];
+    }
+    mac_str[2 * MAC_ADDR_LEN] = '\0';
+    net_recv_callback = cfg->recv_handle;
+    mac_id = tusb_get_mac_string_id();
+    // Pass it to Descriptor control module
+    tinyusb_set_str_descriptor(mac_str, mac_id);
+
+    return ESP_OK;
+}
+
+//--------------------------------------------------------------------+
+// tinyusb callbacks
+//--------------------------------------------------------------------+
+bool tud_network_recv_cb(const uint8_t *src, uint16_t size)
+{
+    if (size == 0 || src == NULL) {
+        return false;
+    }
+    if (net_recv_callback) {
+        net_recv_callback((void *)src, size);
+    }
+    tud_network_recv_renew();
+    return true;
+}
+
+uint16_t tud_network_xmit_cb(uint8_t *dst, void *ref, uint16_t arg)
+{
+    uint16_t len = arg;
+
+    /* traverse the "pbuf chain"; see ./lwip/src/core/pbuf.c for more info */
+    memcpy(dst, ref, len);
+    return len;
+}


### PR DESCRIPTION
Added support for NCM class, and the corresponding example can be found in IDF MR: [22232](https://gitlab.espressif.cn:6688/espressif/esp-idf/-/merge_requests/22232)
