### PR TITLE
ci: fix libpng not uploaded since there's no zlib in the registry yet

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Upload components to component service
         uses: espressif/upload-components-ci-action@v1
         with:
+          # Please try to keep the directories list sorted.
+          #
+          # Do note, however, that if you are updating two components in the same PR
+          # and one depends on the other, the new version of the 2nd component won't
+          # be found in the registry when the 1st component is uploaded.
+          #
+          # This is only a problem if you are adding two components for the first time,
+          # or if the 2nd component depends on the exact (new) version of the first one.
+          #
           directories: >
             bdc_motor;
             cbor;
@@ -30,7 +39,6 @@ jobs:
             json_generator;
             json_parser;
             led_strip;
-            libpng;
             libsodium;
             nghttp;
             pcap;
@@ -48,5 +56,6 @@ jobs:
             usb/usb_host_uvc;
             usb/usb_host_vcp;
             zlib;
+            libpng;
           namespace: "espressif"
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
Unfortunately sorting the list of components in https://github.com/espressif/idf-extra-components/pull/160 had one disadvantage: if two new components are added in the same PR and the (alphabetically) 1st one depends on the 2nd one, the upload of the 1st component will fail (https://github.com/espressif/idf-extra-components/actions/runs/4512604342/jobs/7946288243).

This PR moves libpng to the end of the list so that it gets uploaded after zlib is uploaded for the first time. We can revert to the correct sorting order in a follow-up PR.