### PR TITLE
usb msc host: remove unused variable lun

### DIFF
--- a/usb/usb_host_msc/README.md
+++ b/usb/usb_host_msc/README.md
@@ -27,12 +27,7 @@ MSC driver allows access to USB flash drivers using the BOT “Bulk-Only Transpo
 ## Known issues
 
 - Driver only supports USB 2.0 flash drives using the BOT “Bulk-Only Transport” protocol and the Transparent SCSI command set
-- Composite USB devices are not supported
 
 ## Examples
 
 - For an example, refer to [msc_host_example](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/msc)
-
-## Troubleshooting
-
-After connecting composite USB device, driver prints `COMPOSITE DEVICES UNSUPPORTED` 

--- a/usb/usb_host_msc/idf_component.yml
+++ b/usb/usb_host_msc/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: USB Host MSC driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_msc
 

--- a/usb/usb_host_msc/src/msc_host.c
+++ b/usb/usb_host_msc/src/msc_host.c
@@ -348,7 +348,6 @@ esp_err_t msc_host_install_device(uint8_t device_address, msc_host_device_handle
     uint32_t block_size, block_count;
     const usb_config_desc_t *config_desc;
     msc_device_t *msc_device;
-    uint8_t lun;
     size_t transfer_size = 512; // Normally the smallest block size
 
     MSC_GOTO_ON_FALSE( msc_device = calloc(1, sizeof(msc_device_t)), ESP_ERR_NO_MEM );
@@ -369,15 +368,9 @@ esp_err_t msc_host_install_device(uint8_t device_address, msc_host_device_handle
                            msc_device->handle,
                            msc_device->config.iface_num, 0) );
 
-    MSC_GOTO_ON_ERROR( msc_get_max_lun(msc_device, &lun) );
     MSC_GOTO_ON_ERROR( scsi_cmd_inquiry(msc_device) );
     MSC_GOTO_ON_ERROR( msc_wait_for_ready_state(msc_device, WAIT_FOR_READY_TIMEOUT_MS) );
     MSC_GOTO_ON_ERROR( scsi_cmd_read_capacity(msc_device, &block_size, &block_count) );
-
-    // Configuration descriptor size of simple MSC device is 32 bytes.
-    if (config_desc->wTotalLength != 32) {
-        ESP_LOGE(TAG, "COMPOSITE DEVICES UNSUPPORTED");
-    }
 
     msc_device->disk.block_size = block_size;
     msc_device->disk.block_count = block_count;


### PR DESCRIPTION
1. remove unused variable 'lun'
2. usb composite device (msc + cdc) verified for its working.