### PR TITLE
nghttp: Update version to 1.52.0

### DIFF
--- a/nghttp/idf_component.yml
+++ b/nghttp/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.50.0"
+version: "1.52.0"
 description: "nghttp2 - HTTP/2 C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/nghttp
 dependencies:

--- a/nghttp/port/include/nghttp2/nghttp2ver.h
+++ b/nghttp/port/include/nghttp2/nghttp2ver.h
@@ -29,7 +29,7 @@
  * @macro
  * Version number of the nghttp2 library release
  */
-#define NGHTTP2_VERSION "1.50.0"
+#define NGHTTP2_VERSION "1.52.0"
 
 /**
  * @macro
@@ -37,6 +37,6 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define NGHTTP2_VERSION_NUM 0x012900
+#define NGHTTP2_VERSION_NUM 0x015200
 
 #endif /* NGHTTP2VER_H */


### PR DESCRIPTION
Update nghttp version to v1.52.0

Binary Footprint: +120 Bytes
Memory Overhead: ~100 Bytes (average of 3 test runs)