### PR TITLE
usb: Bump UVC version

### DIFF
--- a/usb/usb_host_uvc/idf_component.yml
+++ b/usb/usb_host_uvc/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: USB Host UVC driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_uvc
 


### PR DESCRIPTION
The version was not bumped during https://github.com/espressif/idf-extra-components/commit/7331abceabaaae5c9e905106bf0aa8c4938f7215

Closes https://github.com/espressif/esp-idf/issues/10581
