### PR TITLE
color component description was misleading (IEC-7)

### DIFF
--- a/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
+++ b/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
@@ -49,7 +49,7 @@ void app_main(void)
     ESP_LOGI(TAG, "Start blinking LED strip");
     while (1) {
         if (led_on_off) {
-            /* Set the LED pixel using RGB from 0 (0%) to 255 (100%) for each color */
+            /* Set the LED pixel using RGB in percentages from 0-100 (not the more common RGB units ranging 0-255) for each color */
             ESP_ERROR_CHECK(led_strip_set_pixel(led_strip, 0, 16, 16, 16));
             /* Refresh the strip to send data */
             ESP_ERROR_CHECK(led_strip_refresh(led_strip));


### PR DESCRIPTION
Colors differ largely from any RGB color picker if led_strip_set_pixel() is fed by RGB units ranging 0-255 like found in most color pickers. Turns out that led_strip_set_pixel() is expecting percentages of each color component. That way the LED has the color one was dialing in with the color picker. However there only few color pickers that also tell percentages of the color components in addition to RGB units. This picker does exactly that: https://colors.artyclick.com/color-names-dictionary/color-names/neon-blue-color

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
