### PR TITLE
ci: add an action to update submodules

### DIFF
--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -1,0 +1,25 @@
+name: Update submodules
+
+on:
+  schedule:
+    - cron: '0 0 * * SUN' # Sunday midnight
+  workflow_dispatch:               # Or manually
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_submodules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0
+      - name: Update submodules
+        uses: igrr/github-actions/update_submodule_versions@feature/update_submodule_versions
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          git-author-name: ${{ secrets.SUBMODULE_UPDATE_AUTHOR_NAME }}
+          git-author-email: ${{ secrets.SUBMODULE_UPDATE_AUTHOR_EMAIL }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,36 +1,100 @@
 [submodule "libsodium/libsodium"]
 	path = libsodium/libsodium
 	url = https://github.com/jedisct1/libsodium.git
+	# libsodium doesn't tag new releases since 0.18.0, 'stable' branch is considered
+	# to be the latest stable release. See:
+	# https://github.com/jedisct1/libsodium/issues/1041#issuecomment-799812417
+	# However since idf_component.yml had the version already set to 0.20.0,
+	# we can't update the version automatically (it would be set it back to 0.18.0~n)
+	# autoupdate = false
 [submodule "cbor/tinycbor"]
 	path = cbor/tinycbor
 	url = https://github.com/intel/tinycbor.git
+	autoupdate = true
+	autoupdate-branch = main
+	autoupdate-tag-glob = v[0-9]*.[0-9]*.[0-9]*
+	autoupdate-manifest = cbor/idf_component.yml
+	autoupdate-ver-regex = v([0-9]+).([0-9]+).([0-9]+)
 [submodule "nghttp/nghttp2"]
 	path = nghttp/nghttp2
 	url = https://github.com/nghttp2/nghttp2.git
+	autoupdate = true
+	autoupdate-branch = master
+	autoupdate-tag-glob = v[0-9]*.[0-9]*.[0-9]*
+	autoupdate-manifest = nghttp/idf_component.yml
+	autoupdate-ver-regex = v([0-9]+).([0-9]+).([0-9]+)
 [submodule "expat/expat"]
 	path = expat/expat
 	url = https://github.com/libexpat/libexpat.git
+	autoupdate = true
+	autoupdate-branch = master
+	autoupdate-tag-glob = R_[0-9]*_[0-9]*_[0-9]*
+	autoupdate-manifest = expat/idf_component.yml
+	autoupdate-ver-regex = R_([0-9]+)_([0-9]+)_([0-9]+)
 [submodule "coap/libcoap"]
 	path = coap/libcoap
 	url = https://github.com/obgm/libcoap.git
+	autoupdate = true
+	autoupdate-branch = develop
+	autoupdate-tag-glob = v[0-9]*.[0-9]*.[0-9]*
+	autoupdate-include-lightweight = true
+	autoupdate-manifest = coap/idf_component.yml
+	autoupdate-ver-regex = v([0-9]+).([0-9]+).([0-9]+)
 [submodule "usb/usb_host_uvc/libuvc"]
 	path = usb/usb_host_uvc/libuvc
 	url = https://github.com/libuvc/libuvc.git
+	autoupdate = true
+	autoupdate-branch = master
+	autoupdate-tag-glob = v[0-9]*.[0-9]*.[0-9]*
+	autoupdate-include-lightweight = true
+	# Not updating the manifest automatically,
+	# since the component version is ahead of the upstream version
 [submodule "eigen/eigen"]
 	path = eigen/eigen
 	url = https://gitlab.com/libeigen/eigen.git
+	autoupdate = true
+	autoupdate-branch = 3.4
+	autoupdate-tag-glob = [0-9]*.[0-9]*.[0-9]*
+	autoupdate-include-lightweight = true
+	autoupdate-manifest = eigen/idf_component.yml
+	autoupdate-ver-regex = ([0-9]+).([0-9]+).([0-9]+)
 [submodule "fmt/fmt"]
 	path = fmt/fmt
 	url = https://github.com/fmtlib/fmt.git
+	autoupdate = true
+	autoupdate-branch = master
+	autoupdate-tag-glob = [0-9]*.[0-9]*.[0-9]*
+	autoupdate-include-lightweight = true
+	autoupdate-manifest = fmt/idf_component.yml
+	autoupdate-ver-regex = ([0-9]+).([0-9]+).([0-9]+)
 [submodule "esp_delta_ota/detools"]
 	path = esp_delta_ota/detools
 	url = https://github.com/eerimoq/detools.git
+	# not updating automatically, as this is not an upstream repo
+	# but a tool used by the component
 [submodule "quirc/quirc"]
 	path = quirc/quirc
 	url = https://github.com/dlbeer/quirc.git
+	autoupdate = true
+	autoupdate-branch = master
+	autoupdate-tag-glob = v[0-9]*.[0-9]*
+	autoupdate-include-lightweight = true
+	autoupdate-manifest = quirc/idf_component.yml
+	autoupdate-ver-regex = v([0-9]+).([0-9]+)
 [submodule "zlib/zlib"]
 	path = zlib/zlib
 	url = https://github.com/madler/zlib.git
+	autoupdate = true
+	autoupdate-branch = master
+	autoupdate-tag-glob = v[0-9]*.[0-9]*.[0-9]*
+	autoupdate-manifest = zlib/idf_component.yml
+	autoupdate-ver-regex = v([0-9]+).([0-9]+).([0-9]+)
 [submodule "libpng/libpng"]
 	path = libpng/libpng
 	url = https://github.com/glennrp/libpng.git
+	autoupdate = true
+	autoupdate-branch = libpng16
+	autoupdate-include-lightweight = true
+	autoupdate-tag-glob = v[0-9]*.[0-9]*.[0-9]*
+	autoupdate-manifest = libpng/idf_component.yml
+	autoupdate-ver-regex = v([0-9]+).([0-9]+).([0-9]+)


### PR DESCRIPTION
This PR adds a new CI action to automatically update submodules, opening PRs for updates.

Example PRs can be seen in the fork:
* https://github.com/igrr/idf-extra-components/pull/7
* https://github.com/igrr/idf-extra-components/pull/8

Uses the following Github action:
* https://github.com/espressif/github-actions/pull/40

Description of config options in .gitmodules can be found the [README.md of update_submodule_versions action](https://github.com/igrr/github-actions/blob/feature/update_submodule_versions/update_submodule_versions/README.md).

## TODO

- [ ] Set SUBMODULE_UPDATE_AUTHOR_NAME and SUBMODULE_UPDATE_AUTHOR_EMAIL variables in repository settings after merging

---
Closes https://github.com/espressif/idf-extra-components/issues/29