### PR TITLE
esp_tinyusb: set cpu core affinity of tinyusb default task

### DIFF
--- a/usb/esp_tinyusb/CMakeLists.txt
+++ b/usb/esp_tinyusb/CMakeLists.txt
@@ -24,9 +24,13 @@ if(CONFIG_TINYUSB_CDC_ENABLED)
     list(APPEND srcs
         "cdc.c"
         "tusb_cdc_acm.c"
+        )
+if(CONFIG_VFS_SUPPORT_IO)
+    list(APPEND srcs
         "tusb_console.c"
         "vfs_tinyusb.c"
         )
+endif() # CONFIG_VFS_SUPPORT_IO
 endif() # CONFIG_TINYUSB_CDC_ENABLED
 
 if(CONFIG_TINYUSB_MSC_ENABLED)

--- a/usb/esp_tinyusb/CMakeLists.txt
+++ b/usb/esp_tinyusb/CMakeLists.txt
@@ -10,6 +10,7 @@ set(srcs
     "descriptors_control.c"
     "tinyusb.c"
     "usb_descriptors.c"
+    "tusb_tasks.c"
     )
 
 set(priv_requires
@@ -18,10 +19,6 @@ set(priv_requires
     esp_ringbuf
     fatfs
     )
-
-if(NOT CONFIG_TINYUSB_NO_DEFAULT_TASK)
-    list(APPEND srcs "tusb_tasks.c")
-endif() # CONFIG_TINYUSB_NO_DEFAULT_TASK
 
 if(CONFIG_TINYUSB_CDC_ENABLED)
     list(APPEND srcs
@@ -45,6 +42,15 @@ idf_component_register(SRCS ${srcs}
                        REQUIRED_IDF_TARGETS esp32s2 esp32s3
                        )
 
+# Determine whether tinyusb is fetched from component registry or from local path
+idf_build_get_property(build_components BUILD_COMPONENTS)
+if(tinyusb IN_LIST build_components)
+    set(tinyusb_name tinyusb) # Local component
+else()
+    set(tinyusb_name espressif__tinyusb) # Managed component
+endif()
+
 # Pass tusb_config.h from this component to TinyUSB
-idf_component_get_property(tusb_lib espressif__tinyusb COMPONENT_LIB)
+idf_component_get_property(tusb_lib ${tinyusb_name} COMPONENT_LIB)
+
 target_include_directories(${tusb_lib} PRIVATE "include")

--- a/usb/esp_tinyusb/Kconfig
+++ b/usb/esp_tinyusb/Kconfig
@@ -6,29 +6,6 @@ menu "TinyUSB Stack"
         help
             Specify verbosity of TinyUSB log output.
 
-    menu "TinyUSB task configuration"
-        config TINYUSB_NO_DEFAULT_TASK
-            bool "Do not create a TinyUSB task"
-            default n
-            help
-                This option allows to not create the FreeRTOS task during the driver initialization.
-                User will have to handle TinyUSB events manually.
-
-        config TINYUSB_TASK_PRIORITY
-            int "TinyUSB task priority"
-            default 5
-            depends on !TINYUSB_NO_DEFAULT_TASK
-            help
-                Set the priority of the default TinyUSB main task.
-
-        config TINYUSB_TASK_STACK_SIZE
-            int "TinyUSB task stack size (bytes)"
-            default 4096
-            depends on !TINYUSB_NO_DEFAULT_TASK
-            help
-                Set the stack size of the default TinyUSB main task.
-    endmenu
-
     menu "Descriptor configuration"
         comment "You can provide your custom descriptors via tinyusb_driver_install()"
         config TINYUSB_DESC_USE_ESPRESSIF_VID

--- a/usb/esp_tinyusb/README.md
+++ b/usb/esp_tinyusb/README.md
@@ -7,7 +7,7 @@ This component adds features to TinyUSB that help users with integrating TinyUSB
 It contains:
 * Configuration of USB device and string descriptors
 * USB Serial Device (CDC-ACM) with optional Virtual File System support
-* Input and output streams through USB Serial Device
+* Input and output streams through USB Serial Device. This feature is available only when Virtual File System support is enabled.
 * Other USB classes (MIDI, MSC, HID…) support directly via TinyUSB
 * VBUS monitoring for self-powered devices
 * SPI Flash or sd-card access via MSC USB device Class.

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,6 +1,6 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.2.1
+version: 1.2.2
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule

--- a/usb/esp_tinyusb/include/tinyusb.h
+++ b/usb/esp_tinyusb/include/tinyusb.h
@@ -34,6 +34,10 @@ typedef struct {
     const uint8_t *configuration_descriptor;   /*!< Pointer to a configuration descriptor. If set to NULL, TinyUSB device will use a default configuration descriptor whose values are set in Kconfig */
     bool self_powered;                         /*!< This is a self-powered USB device. USB VBUS must be monitored. */
     int vbus_monitor_io;                       /*!< GPIO for VBUS monitoring. Ignored if not self_powered. */
+    bool no_background_task;                   /*!< When set to false, background task handling tinyusb events is created. */
+    size_t task_priority;                      /*!< Task priority of created background tinyusb task */
+    size_t stack_size;                         /*!< Stack size of crated background tinyusb task */
+    BaseType_t core_id;                        /*!< Select core on which background tinyusb task will run or tskNO_AFFINITY  */
 } tinyusb_config_t;
 
 /**

--- a/usb/esp_tinyusb/include/tusb_tasks.h
+++ b/usb/esp_tinyusb/include/tusb_tasks.h
@@ -16,14 +16,17 @@ extern "C" {
  * @brief This helper function creates and starts a task which wraps `tud_task()`.
  *
  * The wrapper function basically wraps tud_task and some log.
- * Default parameters: stack size and priority as configured, argument = NULL, not pinned to any core.
  * If you have more requirements for this task, you can create your own task which calls tud_task as the last step.
+ *
+ * @param usStackDepth - Stack size of crated background tinyusb task
+ * @param uxPriority  - Task priority of created background tinyusb task
+ * @param xCoreID  - Core on which background tinyusb task will run or tskNO_AFFINITY
  *
  * @retval ESP_OK run tinyusb main task successfully
  * @retval ESP_FAIL run tinyusb main task failed of internal error
  * @retval ESP_ERR_INVALID_STATE tinyusb main task has been created before
  */
-esp_err_t tusb_run_task(void);
+esp_err_t tusb_run_task(const size_t usStackDepth, const size_t uxPriority, const BaseType_t xCoreID);
 
 /**
  * @brief This helper function stops and destroys the task created by `tusb_run_task()`

--- a/usb/esp_tinyusb/tusb_tasks.c
+++ b/usb/esp_tinyusb/tusb_tasks.c
@@ -26,13 +26,13 @@ static void tusb_device_task(void *arg)
     }
 }
 
-esp_err_t tusb_run_task(void)
+esp_err_t tusb_run_task(const size_t usStackDepth, const size_t uxPriority, const BaseType_t xCoreID)
 {
     // This function is not garanteed to be thread safe, if invoked multiple times without calling `tusb_stop_task`, will cause memory leak
     // doing a sanity check anyway
     ESP_RETURN_ON_FALSE(!s_tusb_tskh, ESP_ERR_INVALID_STATE, TAG, "TinyUSB main task already started");
     // Create a task for tinyusb device stack:
-    xTaskCreate(tusb_device_task, "TinyUSB", CONFIG_TINYUSB_TASK_STACK_SIZE, NULL, CONFIG_TINYUSB_TASK_PRIORITY, &s_tusb_tskh);
+    xTaskCreatePinnedToCore(tusb_device_task, "TinyUSB", usStackDepth, NULL, uxPriority, &s_tusb_tskh, xCoreID);
     ESP_RETURN_ON_FALSE(s_tusb_tskh, ESP_FAIL, TAG, "create TinyUSB main task failed");
     return ESP_OK;
 }


### PR DESCRIPTION
1. This change is to set the CPU core affinity to Tinyusb Task.
If the task is not pinned we often see lost packets if the system is put under stress.

2. cdc console feature is enabled only when VFS is enabled.
This is done by compiling the console feature related files only when VFS option is enabled.
If VFS is not enabled, compile error will be thrown. So, it will avoid runtime failure.
Closes https://github.com/espressif/idf-extra-components/issues/164