### PR TITLE
esp_tinyusb: cdc console feature is enabled only when VFS is enabled

### DIFF
--- a/usb/esp_tinyusb/CMakeLists.txt
+++ b/usb/esp_tinyusb/CMakeLists.txt
@@ -27,9 +27,13 @@ if(CONFIG_TINYUSB_CDC_ENABLED)
     list(APPEND srcs
         "cdc.c"
         "tusb_cdc_acm.c"
+        )
+if(CONFIG_VFS_SUPPORT_IO)
+    list(APPEND srcs
         "tusb_console.c"
         "vfs_tinyusb.c"
         )
+endif() # CONFIG_VFS_SUPPORT_IO
 endif() # CONFIG_TINYUSB_CDC_ENABLED
 
 if(CONFIG_TINYUSB_MSC_ENABLED)
@@ -45,6 +49,15 @@ idf_component_register(SRCS ${srcs}
                        REQUIRED_IDF_TARGETS esp32s2 esp32s3
                        )
 
+# Determine whether tinyusb is fetched from component registry or from local path
+idf_build_get_property(build_components BUILD_COMPONENTS)
+if(tinyusb IN_LIST build_components)
+    set(tinyusb_name tinyusb) # Local component
+else()
+    set(tinyusb_name espressif__tinyusb) # Managed component
+endif()
+
 # Pass tusb_config.h from this component to TinyUSB
-idf_component_get_property(tusb_lib espressif__tinyusb COMPONENT_LIB)
+idf_component_get_property(tusb_lib ${tinyusb_name} COMPONENT_LIB)
+
 target_include_directories(${tusb_lib} PRIVATE "include")

--- a/usb/esp_tinyusb/README.md
+++ b/usb/esp_tinyusb/README.md
@@ -7,7 +7,7 @@ This component adds features to TinyUSB that help users with integrating TinyUSB
 It contains:
 * Configuration of USB device and string descriptors
 * USB Serial Device (CDC-ACM) with optional Virtual File System support
-* Input and output streams through USB Serial Device
+* Input and output streams through USB Serial Device. This feature is available only when Virtual File System support is enabled.
 * Other USB classes (MIDI, MSC, HID…) support directly via TinyUSB
 * VBUS monitoring for self-powered devices
 * SPI Flash or sd-card access via MSC USB device Class.

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,6 +1,6 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.2.1
+version: 1.2.2
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule


### PR DESCRIPTION
cdc console feature is enabled only when VFS is enabled.
This is done by compiling the console feature related files only when VFS option is enabled.
If VFS is not enabled, compile error will be thrown. So, it will avoid runtime failure.


Closes https://github.com/espressif/idf-extra-components/issues/164