### PR TITLE
led_strip: fix uninitialized bytes_per_pixel

### DIFF
--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.3.1"
+version: "2.3.2"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 dependencies:

--- a/led_strip/src/led_strip_rmt_dev.c
+++ b/led_strip/src/led_strip_rmt_dev.c
@@ -100,7 +100,7 @@ esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const l
     esp_err_t ret = ESP_OK;
     ESP_GOTO_ON_FALSE(led_config && rmt_config && ret_strip, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
     ESP_GOTO_ON_FALSE(led_config->led_pixel_format < LED_PIXEL_FORMAT_INVALID, ESP_ERR_INVALID_ARG, err, TAG, "invalid led_pixel_format");
-    uint8_t bytes_per_pixel;
+    uint8_t bytes_per_pixel = 3;
     if (led_config->led_pixel_format == LED_PIXEL_FORMAT_GRBW) {
         bytes_per_pixel = 4;
     } else if (led_config->led_pixel_format == LED_PIXEL_FORMAT_GRB) {


### PR DESCRIPTION
` bytes_per_pixel` can be uninitialized if the assert is disabled.

Closes https://github.com/espressif/idf-extra-components/issues/177