### PR TITLE
USB MSC: speed optimization

### DIFF
--- a/usb/esp_modem_usb_dte/idf_component.yml
+++ b/usb/esp_modem_usb_dte/idf_component.yml
@@ -1,9 +1,9 @@
 ## IDF Component Manager Manifest File
-version: "1.1.0"
+version: "1.1.0~1"
 description: USB DTE plugin for esp_modem component
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_modem_usb_dte
 
 dependencies:
   idf: ">=4.4"
   usb_host_cdc_acm: "2.*"
-  esp_modem: "^0.1.28"
+  esp_modem: ">=0.1.28,<2.0.0"

--- a/usb/test_app/main/usb_test_main.c
+++ b/usb/test_app/main/usb_test_main.c
@@ -12,7 +12,7 @@
 static size_t before_free_8bit;
 static size_t before_free_32bit;
 
-#define TEST_MEMORY_LEAK_THRESHOLD (-10000) // @todo MSC test are leaking memory
+#define TEST_MEMORY_LEAK_THRESHOLD (-530)
 static void check_leak(size_t before_free, size_t after_free, const char *type)
 {
     ssize_t delta = after_free - before_free;

--- a/usb/test_app/main/usb_test_main.c
+++ b/usb/test_app/main/usb_test_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/usb/test_app/pytest_usb_host.py
+++ b/usb/test_app/pytest_usb_host.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: CC0-1.0
 
 from typing import Tuple
@@ -23,10 +23,7 @@ def test_usb_host(dut: Tuple[IdfDut, IdfDut]) -> None:
     device.expect_exact('USB initialization DONE')
 
     # 1.2 Run CDC test
-    host.expect_exact('Press ENTER to see the list of tests.')
-    host.write('[cdc_acm]')
-    host.expect_unity_test_output()
-    host.expect_exact("Enter next test, or 'enter' to see menu")
+    host.run_all_single_board_cases(group='cdc_acm')
 
     # 2.1 Prepare USB device for MSC test
     device.serial.hard_reset()
@@ -35,9 +32,7 @@ def test_usb_host(dut: Tuple[IdfDut, IdfDut]) -> None:
     device.expect_exact('USB initialization DONE')
 
     # 2.2 Run MSC test
-    host.write('[usb_msc]')
-    host.expect_unity_test_output()
-    host.expect_exact("Enter next test, or 'enter' to see menu")
+    host.run_all_single_board_cases(group='usb_msc')
 
     # 3.1 Prepare USB device with one Interface for HID tests
     device.serial.hard_reset()
@@ -46,9 +41,7 @@ def test_usb_host(dut: Tuple[IdfDut, IdfDut]) -> None:
     device.expect_exact('HID mock device with 1xInterface (Protocol=None) has been started')
 
     # 3.2 Run HID tests
-    host.write('[hid_host]')
-    host.expect_unity_test_output()
-    host.expect_exact("Enter next test, or 'enter' to see menu")
+    host.run_all_single_board_cases(group='hid_host')
 
     # 3.3 Prepare USB device with two Interfaces for HID tests
     device.serial.hard_reset()
@@ -57,6 +50,4 @@ def test_usb_host(dut: Tuple[IdfDut, IdfDut]) -> None:
     device.expect_exact('HID mock device with 2xInterfaces (Protocol=BootKeyboard, Protocol=BootMouse) has been started')
 
     # 3.4 Run HID tests
-    host.write('[hid_host]')
-    host.expect_unity_test_output()
-    host.expect_exact("Enter next test, or 'enter' to see menu")
+    host.run_all_single_board_cases(group='hid_host')

--- a/usb/usb_host_msc/CHANGELOG.md
+++ b/usb/usb_host_msc/CHANGELOG.md
@@ -1,0 +1,23 @@
+## 1.0.0
+
+- Initial version
+
+## 1.0.1
+
+- Fix compatibility with IDF v4.4
+
+## 1.0.2
+
+- Increase transfer timeout to 5 seconds to handle slower flash disks
+
+## 1.0.4
+
+- Claim support for USB composite devices
+
+## 1.1.0
+
+- Significantly increase performance with Virtual File System by allowing longer transfers
+- Optimize used heap memory by reusing the Virtual File System buffer
+- Optimize CPU usage by putting the background MSC task to 'Blocked' state indefinitely when there is nothing to do
+- Fix MSC commands for devices on interface numbers other than zero
+- Replace unsafe debug functions for direct access of MSC sectors with private SCSI commands

--- a/usb/usb_host_msc/CMakeLists.txt
+++ b/usb/usb_host_msc/CMakeLists.txt
@@ -4,6 +4,10 @@ set(sources src/msc_scsi_bot.c
             src/msc_host_vfs.c)
 
 idf_component_register( SRCS ${sources}
-                        INCLUDE_DIRS include
+                        INCLUDE_DIRS include include/usb # 'include' is here for backwards compatibility
                         PRIV_INCLUDE_DIRS private_include
                         REQUIRES usb fatfs )
+
+# We access packeted USB string descriptor via pointers. The memory used for storing the descritptors
+# allows unaligned access, so this is not an issue
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-address-of-packed-member)

--- a/usb/usb_host_msc/CMakeLists.txt
+++ b/usb/usb_host_msc/CMakeLists.txt
@@ -4,8 +4,8 @@ set(sources src/msc_scsi_bot.c
             src/msc_host_vfs.c)
 
 idf_component_register( SRCS ${sources}
-                        INCLUDE_DIRS include include/usb # 'include' is here for backwards compatibility
-                        PRIV_INCLUDE_DIRS private_include
+                        INCLUDE_DIRS include include/usb # 'include/usb' is here for backwards compatibility
+                        PRIV_INCLUDE_DIRS private_include include/esp_private
                         REQUIRES usb fatfs )
 
 # We access packeted USB string descriptor via pointers. The memory used for storing the descritptors

--- a/usb/usb_host_msc/idf_component.yml
+++ b/usb/usb_host_msc/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.5"
+version: "1.1.0"
 description: USB Host MSC driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_msc
 

--- a/usb/usb_host_msc/idf_component.yml
+++ b/usb/usb_host_msc/idf_component.yml
@@ -1,9 +1,9 @@
-version: "1.0.4"
+version: "1.0.5"
 description: USB Host MSC driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_msc
 
 dependencies:
-  idf: ">=4.4"
+  idf: ">=4.4.1"
 
 targets:
   - esp32s2

--- a/usb/usb_host_msc/include/esp_private/msc_scsi_bot.h
+++ b/usb/usb_host_msc/include/esp_private/msc_scsi_bot.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 #include "esp_err.h"
-#include "msc_common.h"
+#include "usb/msc_host.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -21,35 +21,31 @@ typedef struct {
     uint8_t code_q;
 } scsi_sense_data_t;
 
-esp_err_t scsi_cmd_read10(msc_device_t *device,
+esp_err_t scsi_cmd_read10(msc_host_device_handle_t device,
                           uint8_t *data,
                           uint32_t sector_address,
                           uint32_t num_sectors,
                           uint32_t sector_size);
 
-esp_err_t scsi_cmd_write10(msc_device_t *device,
+esp_err_t scsi_cmd_write10(msc_host_device_handle_t device,
                            const uint8_t *data,
                            uint32_t sector_address,
                            uint32_t num_sectors,
                            uint32_t sector_size);
 
-esp_err_t scsi_cmd_read_capacity(msc_device_t *device,
+esp_err_t scsi_cmd_read_capacity(msc_host_device_handle_t device,
                                  uint32_t *block_size,
                                  uint32_t *block_count);
 
-esp_err_t scsi_cmd_sense(msc_device_t *device, scsi_sense_data_t *sense);
+esp_err_t scsi_cmd_sense(msc_host_device_handle_t device, scsi_sense_data_t *sense);
 
-esp_err_t scsi_cmd_unit_ready(msc_device_t *device);
+esp_err_t scsi_cmd_unit_ready(msc_host_device_handle_t device);
 
-esp_err_t scsi_cmd_inquiry(msc_device_t *device);
+esp_err_t scsi_cmd_inquiry(msc_host_device_handle_t device);
 
-esp_err_t scsi_cmd_prevent_removal(msc_device_t *device, bool prevent);
+esp_err_t scsi_cmd_prevent_removal(msc_host_device_handle_t device, bool prevent);
 
-esp_err_t scsi_cmd_mode_sense(msc_device_t *device);
-
-esp_err_t msc_mass_reset(msc_device_t *device);
-
-esp_err_t msc_get_max_lun(msc_device_t *device, uint8_t *lun);
+esp_err_t scsi_cmd_mode_sense(msc_host_device_handle_t device);
 
 #ifdef __cplusplus
 }

--- a/usb/usb_host_msc/include/usb/msc_host.h
+++ b/usb/usb_host_msc/include/usb/msc_host.h
@@ -19,6 +19,7 @@ extern "C" {
 #define ESP_ERR_MSC_MOUNT_FAILED    (ESP_ERR_MSC_HOST_BASE + 1)  /*!< Failed to mount storage */
 #define ESP_ERR_MSC_FORMAT_FAILED   (ESP_ERR_MSC_HOST_BASE + 2)  /*!< Failed to format storage */
 #define ESP_ERR_MSC_INTERNAL        (ESP_ERR_MSC_HOST_BASE + 3)  /*!< MSC host internal error */
+#define ESP_ERR_MSC_STALL           (ESP_ERR_MSC_HOST_BASE + 4)  /*!< USB transfer stalled */
 
 #define MSC_STR_DESC_SIZE 32
 

--- a/usb/usb_host_msc/include/usb/msc_host.h
+++ b/usb/usb_host_msc/include/usb/msc_host.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,7 +9,7 @@
 #include <wchar.h>
 #include <stdint.h>
 #include "esp_err.h"
-#include <freertos/FreeRTOS.h>
+#include "freertos/FreeRTOS.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -118,13 +118,14 @@ esp_err_t msc_host_uninstall_device(msc_host_device_handle_t device);
  * @param[in]  size   Number of bytes to be read
  * @return esp_err_t
  */
-esp_err_t msc_host_read_sector(msc_host_device_handle_t device, size_t sector, void *data, size_t size);
+esp_err_t msc_host_read_sector(msc_host_device_handle_t device, size_t sector, void *data, size_t size)
+__attribute__((deprecated("use API from esp_private/msc_scsi_bot.h")));
 
 /**
  * @brief Helper function for writing sector to mass storage device.
  *
  * @warning This call is not thread safe and should not be combined
- *          with accesses to storare through file system.
+ *          with accesses to storage through file system.
  *
  * @note  Provided sector and size cannot exceed
  *        sector_count and sector_size obtained from msc_host_device_info_t
@@ -135,7 +136,8 @@ esp_err_t msc_host_read_sector(msc_host_device_handle_t device, size_t sector, v
  * @param[in]  size   Number of bytes to be written
  * @return esp_err_t
  */
-esp_err_t msc_host_write_sector(msc_host_device_handle_t device, size_t sector, const void *data, size_t size);
+esp_err_t msc_host_write_sector(msc_host_device_handle_t device, size_t sector, const void *data, size_t size)
+__attribute__((deprecated("use API from esp_private/msc_scsi_bot.h")));
 
 /**
  * @brief Handle MSC HOST events.
@@ -147,9 +149,6 @@ esp_err_t msc_host_handle_events(uint32_t timeout_ms);
 
 /**
  * @brief Gets devices information.
- *
- * @warning This call is not thread safe and should not be combined
- *          with accesses to storare through file system.
  *
  * @param[in]  device  Handle to device
  * @param[out] info  Structure to be populated with device info

--- a/usb/usb_host_msc/include/usb/msc_host.h
+++ b/usb/usb_host_msc/include/usb/msc_host.h
@@ -164,6 +164,18 @@ esp_err_t msc_host_get_device_info(msc_host_device_handle_t device, msc_host_dev
  */
 esp_err_t msc_host_print_descriptors(msc_host_device_handle_t device);
 
+/**
+ * @brief MSC Bulk Only Transport Reset Recovery
+ *
+ * @see USB Mass Storage Class – Bulk Only Transport, Chapter 5.3.4
+ *
+ * @param[in] device Handle of MSC device
+ * @return
+ *       - ESP_OK:  The device was recovered from reset
+ *       - ESP_FAI: Recovery unsuccessful, might indicate broken device
+ */
+esp_err_t msc_host_reset_recovery(msc_host_device_handle_t device);
+
 #ifdef __cplusplus
 }
 #endif //__cplusplus

--- a/usb/usb_host_msc/include/usb/msc_host_vfs.h
+++ b/usb/usb_host_msc/include/usb/msc_host_vfs.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "esp_vfs_fat.h"
-#include "msc_host.h"
+#include "usb/msc_host.h"
 #include "esp_err.h"
 
 #ifdef __cplusplus

--- a/usb/usb_host_msc/private_include/msc_common.h
+++ b/usb/usb_host_msc/private_include/msc_common.h
@@ -41,9 +41,36 @@ typedef struct msc_host_device {
     usb_disk_t disk;
 } msc_device_t;
 
-esp_err_t msc_bulk_transfer(msc_device_t *device_handle, uint8_t *data, size_t size, msc_endpoint_t ep);
+/**
+ * @brief Trigger a BULK transfer to device: zero copy
+ *
+ * Data buffer ownership is transferred to the MSC driver and the application cannot access it before the transfer finishes.
+ * The buffer must be DMA capable, as it is going to be accessed by USB DMA.
+ *
+ * This function significantly improves performance with usage of Virtual File System, which creates a intermediate buffer for each opened file.
+ * The intermediate VFS buffer is then used for USB transfers too, which eliminates need of 2 large buffers and unnecessary copying of the data.
+ * The user can set size of the VFS buffer with setvbuf() function.
+ *
+ * @param[in]    device_handle MSC device handle
+ * @param[inout] data          Data buffer. Direction depends on 'ep'. Must be DMA capable.
+ * @param[in]    size          Size of buffer in bytes
+ * @param[in]    ep            Direction of the transfer
+ * @return esp_err_t
+ */
+esp_err_t msc_bulk_transfer_zcpy(msc_device_t *device_handle, uint8_t *data, size_t size, msc_endpoint_t ep);
 
+/**
+ * @brief Trigger a CTRL transfer to device
+ *
+ * The request and data must be filled by accessing private device_handle->xfer before calling this function
+ *
+ * @param[in] device_handle MSC device handle
+ * @param[in] len           Length of the transfer
+ * @return esp_err_t
+ */
 esp_err_t msc_control_transfer(msc_device_t *device_handle, size_t len);
+
+esp_err_t clear_feature(msc_device_t *device, uint8_t endpoint);
 
 #define MSC_GOTO_ON_ERROR(exp) ESP_GOTO_ON_ERROR(exp, fail, TAG, "")
 

--- a/usb/usb_host_msc/private_include/msc_common.h
+++ b/usb/usb_host_msc/private_include/msc_common.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,7 +34,6 @@ typedef struct {
 
 typedef struct msc_host_device {
     STAILQ_ENTRY(msc_host_device) tailq_entry;
-    usb_transfer_status_t transfer_status;
     SemaphoreHandle_t transfer_done;
     usb_device_handle_t handle;
     usb_transfer_t *xfer;
@@ -44,7 +43,7 @@ typedef struct msc_host_device {
 
 esp_err_t msc_bulk_transfer(msc_device_t *device_handle, uint8_t *data, size_t size, msc_endpoint_t ep);
 
-esp_err_t msc_control_transfer(msc_device_t *device_handle, usb_transfer_t *xfer, size_t len);
+esp_err_t msc_control_transfer(msc_device_t *device_handle, size_t len);
 
 #define MSC_GOTO_ON_ERROR(exp) ESP_GOTO_ON_ERROR(exp, fail, TAG, "")
 

--- a/usb/usb_host_msc/src/diskio_usb.c
+++ b/usb/usb_host_msc/src/diskio_usb.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,18 +32,14 @@ static DRESULT usb_disk_read (BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
     assert(pdrv < FF_VOLUMES);
     assert(s_disks[pdrv]);
 
-    esp_err_t err;
     usb_disk_t *disk = s_disks[pdrv];
     size_t sector_size = disk->block_size;
     msc_device_t *dev = __containerof(disk, msc_device_t, disk);
 
-    for (int i = 0; i < count; i++) {
-        err = scsi_cmd_read10(dev, &buff[i * sector_size], sector + i, 1, sector_size);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "scsi_cmd_read10 failed (%d)", err);
-            return RES_ERROR;
-        }
-
+    esp_err_t err = scsi_cmd_read10(dev, buff, sector, count, sector_size);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "scsi_cmd_read10 failed (%d)", err);
+        return RES_ERROR;
     }
 
     return RES_OK;
@@ -54,18 +50,14 @@ static DRESULT usb_disk_write (BYTE pdrv, const BYTE *buff, DWORD sector, UINT c
     assert(pdrv < FF_VOLUMES);
     assert(s_disks[pdrv]);
 
-    esp_err_t err;
     usb_disk_t *disk = s_disks[pdrv];
     size_t sector_size = disk->block_size;
     msc_device_t *dev = __containerof(disk, msc_device_t, disk);
 
-    for (int i = 0; i < count; i++) {
-        err = scsi_cmd_write10(dev, &buff[i * sector_size], sector + i, 1, sector_size);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "scsi_cmd_write10 failed (%d)", err);
-            return RES_ERROR;
-        }
-
+    esp_err_t err = scsi_cmd_write10(dev, buff, sector, count, sector_size);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "scsi_cmd_write10 failed (%d)", err);
+        return RES_ERROR;
     }
     return RES_OK;
 }

--- a/usb/usb_host_msc/src/msc_host.c
+++ b/usb/usb_host_msc/src/msc_host.c
@@ -401,7 +401,6 @@ esp_err_t msc_host_uninstall_device(msc_host_device_handle_t device)
     return msc_deinit_device((msc_device_t *)device, false);
 }
 
-
 esp_err_t msc_host_read_sector(msc_host_device_handle_t device, size_t sector, void *data, size_t size)
 {
     MSC_RETURN_ON_INVALID_ARG(device);

--- a/usb/usb_host_msc/src/msc_host.c
+++ b/usb/usb_host_msc/src/msc_host.c
@@ -22,9 +22,10 @@
 #include "msc_scsi_bot.h"
 #include "usb/usb_types_ch9.h"
 #include "usb/usb_helpers.h"
+#include "soc/soc_memory_layout.h"
 
+// MSC driver spin lock
 static portMUX_TYPE msc_lock = portMUX_INITIALIZER_UNLOCKED;
-
 #define MSC_ENTER_CRITICAL()    portENTER_CRITICAL(&msc_lock)
 #define MSC_EXIT_CRITICAL()     portEXIT_CRITICAL(&msc_lock)
 
@@ -45,6 +46,39 @@ static portMUX_TYPE msc_lock = portMUX_INITIALIZER_UNLOCKED;
         }                                       \
     } while(0)
 
+// MSC Control requests
+#define USB_MASS_REQ_INIT_RESET(ctrl_req_ptr, intf_num) ({                  \
+    (ctrl_req_ptr)->bmRequestType = USB_BM_REQUEST_TYPE_DIR_OUT |           \
+                                    USB_BM_REQUEST_TYPE_TYPE_CLASS |        \
+                                    USB_BM_REQUEST_TYPE_RECIP_INTERFACE;    \
+    (ctrl_req_ptr)->bRequest = 0xFF;                                        \
+    (ctrl_req_ptr)->wValue = 0;                                             \
+    (ctrl_req_ptr)->wIndex = (intf_num);                                    \
+    (ctrl_req_ptr)->wLength = 0;                                            \
+})
+
+#define USB_MASS_REQ_INIT_GET_MAX_LUN(ctrl_req_ptr, intf_num) ({            \
+    (ctrl_req_ptr)->bmRequestType = USB_BM_REQUEST_TYPE_DIR_IN |            \
+                                    USB_BM_REQUEST_TYPE_TYPE_CLASS |        \
+                                    USB_BM_REQUEST_TYPE_RECIP_INTERFACE;    \
+    (ctrl_req_ptr)->bRequest = 0xFE;                                        \
+    (ctrl_req_ptr)->wValue = 0;                                             \
+    (ctrl_req_ptr)->wIndex = (intf_num);                                    \
+    (ctrl_req_ptr)->wLength = 1;                                            \
+})
+
+#define FEATURE_SELECTOR_ENDPOINT   0
+#define USB_SETUP_PACKET_INIT_CLEAR_FEATURE_EP(ctrl_req_ptr, ep_num) ({     \
+    (ctrl_req_ptr)->bmRequestType = USB_BM_REQUEST_TYPE_DIR_OUT |           \
+                                    USB_BM_REQUEST_TYPE_TYPE_STANDARD |     \
+                                    USB_BM_REQUEST_TYPE_RECIP_ENDPOINT;     \
+    (ctrl_req_ptr)->bRequest = USB_B_REQUEST_CLEAR_FEATURE;                 \
+    (ctrl_req_ptr)->wValue = FEATURE_SELECTOR_ENDPOINT;                     \
+    (ctrl_req_ptr)->wIndex = (ep_num);                                      \
+    (ctrl_req_ptr)->wLength = 0;                                            \
+})
+
+#define DEFAULT_XFER_SIZE   (64) // Transfer size used for all transfers apart from SCSI read/write
 #define WAIT_FOR_READY_TIMEOUT_MS 3000
 #define SCSI_COMMAND_SET    0x06
 #define BULK_ONLY_TRANSFER  0x50
@@ -100,6 +134,73 @@ static const usb_intf_desc_t *find_msc_interface(const usb_config_desc_t *config
         next_desc = next_interface_desc(next_desc, total_length, offset);
     };
     return NULL;
+}
+
+esp_err_t clear_feature(msc_device_t *device, uint8_t endpoint)
+{
+    usb_device_handle_t dev = device->handle;
+    usb_transfer_t *xfer = device->xfer;
+
+    esp_err_t err = usb_host_endpoint_flush(dev, endpoint);
+    if (ESP_OK != err ) {
+        // The endpoint cannot be flushed if it does not have STALL condition
+        // Return without ESP_LOGE
+        return err;
+    }
+    MSC_RETURN_ON_ERROR( usb_host_endpoint_clear(dev, endpoint) );
+
+    USB_SETUP_PACKET_INIT_CLEAR_FEATURE_EP((usb_setup_packet_t *)xfer->data_buffer, endpoint);
+    MSC_RETURN_ON_ERROR( msc_control_transfer(device,  USB_SETUP_PACKET_SIZE) );
+
+    return ESP_OK;
+}
+
+/**
+ * @brief Bulk-Only Mass Storage Reset
+ *
+ * This class-specific request shall ready the device for the next CBW from the host.
+ * The device shall preserve the value of its bulk data toggle bits and endpoint STALL conditions despite the Bulk-Only Mass Storage Reset.
+ *
+ * @see USB Mass Storage Class – Bulk Only Transport, Chapter 3.1
+ *
+ * @param[in] dev MSC device handle
+ * @return esp_err_t
+ */
+static esp_err_t msc_mass_reset(msc_host_device_handle_t dev)
+{
+    msc_device_t *device = (msc_device_t *)dev;
+    usb_transfer_t *xfer = device->xfer;
+
+    USB_MASS_REQ_INIT_RESET((usb_setup_packet_t *)xfer->data_buffer, device->config.iface_num);
+    MSC_RETURN_ON_ERROR( msc_control_transfer(device, USB_SETUP_PACKET_SIZE) );
+
+    return ESP_OK;
+}
+
+/**
+ * @brief MSC get maximum Logical Unit Number
+ *
+ * If the device implements 3 LUNs, the returned value is 2. (LUN0, LUN1, LUN2).
+ *
+ * This driver does not support multiple LUNs yet.
+ *
+ * @see USB Mass Storage Class – Bulk Only Transport, Chapter 3.2
+ *
+ * @param[in]  dev MSC device handle
+ * @param[out] lun Maximum Logical Unit Number
+ * @return esp_err_t
+ */
+__attribute__((unused)) static esp_err_t msc_get_max_lun(msc_host_device_handle_t dev, uint8_t *lun)
+{
+    msc_device_t *device = (msc_device_t *)dev;
+    usb_transfer_t *xfer = device->xfer;
+
+    USB_MASS_REQ_INIT_GET_MAX_LUN((usb_setup_packet_t *)xfer->data_buffer, device->config.iface_num);
+    MSC_RETURN_ON_ERROR( msc_control_transfer(device, USB_SETUP_PACKET_SIZE + 1) );
+
+    *lun = xfer->data_buffer[USB_SETUP_PACKET_SIZE];
+
+    return ESP_OK;
 }
 
 /**
@@ -234,15 +335,19 @@ static void event_handler_task(void *arg)
 
 static msc_device_t *find_msc_device(usb_device_handle_t device_handle)
 {
-    msc_host_device_handle_t device;
+    msc_device_t *iter;
+    msc_device_t *device_found = NULL;
 
-    STAILQ_FOREACH(device, &s_msc_driver->devices_tailq, tailq_entry) {
-        if (device_handle == device->handle) {
-            return device;
+    MSC_ENTER_CRITICAL();
+    STAILQ_FOREACH(iter, &s_msc_driver->devices_tailq, tailq_entry) {
+        if (device_handle == iter->handle) {
+            device_found = iter;
+            break;
         }
     }
+    MSC_EXIT_CRITICAL();
 
-    return NULL;
+    return device_found;
 }
 
 static void client_event_cb(const usb_host_client_event_msg_t *event, void *arg)
@@ -352,7 +457,6 @@ esp_err_t msc_host_install_device(uint8_t device_address, msc_host_device_handle
     uint32_t block_size, block_count;
     const usb_config_desc_t *config_desc;
     msc_device_t *msc_device;
-    size_t transfer_size = 512; // Normally the smallest block size
 
     MSC_GOTO_ON_FALSE( msc_device = calloc(1, sizeof(msc_device_t)), ESP_ERR_NO_MEM );
 
@@ -366,7 +470,7 @@ esp_err_t msc_host_install_device(uint8_t device_address, msc_host_device_handle
     MSC_GOTO_ON_ERROR( usb_host_device_open(s_msc_driver->client_handle, device_address, &msc_device->handle) );
     MSC_GOTO_ON_ERROR( usb_host_get_active_config_descriptor(msc_device->handle, &config_desc) );
     MSC_GOTO_ON_ERROR( extract_config_from_descriptor(config_desc, &msc_device->config) );
-    MSC_GOTO_ON_ERROR( usb_host_transfer_alloc(transfer_size, 0, &msc_device->xfer) );
+    MSC_GOTO_ON_ERROR( usb_host_transfer_alloc(DEFAULT_XFER_SIZE, 0, &msc_device->xfer) );
     MSC_GOTO_ON_ERROR( usb_host_interface_claim(
                            s_msc_driver->client_handle,
                            msc_device->handle,
@@ -378,14 +482,6 @@ esp_err_t msc_host_install_device(uint8_t device_address, msc_host_device_handle
 
     msc_device->disk.block_size = block_size;
     msc_device->disk.block_count = block_count;
-
-    if (block_size > transfer_size) {
-        usb_transfer_t *larger_xfer;
-        MSC_GOTO_ON_ERROR( usb_host_transfer_alloc(block_size, 0, &larger_xfer) );
-        usb_host_transfer_free(msc_device->xfer);
-        msc_device->xfer = larger_xfer;
-    }
-
     *msc_device_handle = msc_device;
 
     return ESP_OK;
@@ -482,51 +578,64 @@ static void transfer_callback(usb_transfer_t *transfer)
 static usb_transfer_status_t wait_for_transfer_done(usb_transfer_t *xfer)
 {
     msc_device_t *device = (msc_device_t *)xfer->context;
-    usb_transfer_status_t status = xfer->status;
     BaseType_t received = xSemaphoreTake(device->transfer_done, pdMS_TO_TICKS(xfer->timeout_ms));
+    usb_transfer_status_t status = xfer->status;
 
     if (received != pdTRUE) {
         usb_host_endpoint_halt(xfer->device_handle, xfer->bEndpointAddress);
         usb_host_endpoint_flush(xfer->device_handle, xfer->bEndpointAddress);
-        xSemaphoreTake(device->transfer_done, portMAX_DELAY);
-        return USB_TRANSFER_STATUS_TIMED_OUT;
+        usb_host_endpoint_clear(xfer->device_handle, xfer->bEndpointAddress);
+        xSemaphoreTake(device->transfer_done, portMAX_DELAY); // Since we flushed the EP, this should return immediately
+        status = USB_TRANSFER_STATUS_TIMED_OUT;
     }
 
     return status;
 }
 
-esp_err_t msc_bulk_transfer(msc_device_t *device, uint8_t *data, size_t size, msc_endpoint_t ep)
+esp_err_t msc_bulk_transfer_zcpy(msc_device_t *device, uint8_t *data, size_t size, msc_endpoint_t ep)
 {
+    esp_err_t ret = ESP_OK;
+    MSC_RETURN_ON_FALSE(esp_ptr_dma_capable(data), ESP_FAIL); // The passed buffer must be DMA capable
     usb_transfer_t *xfer = device->xfer;
-    MSC_RETURN_ON_FALSE(size <= xfer->data_buffer_size, ESP_ERR_INVALID_SIZE);
     uint8_t endpoint = (ep == MSC_EP_IN) ? device->config.bulk_in_ep : device->config.bulk_out_ep;
+    uint8_t *backup_buffer = xfer->data_buffer;
+    size_t backup_size = xfer->data_buffer_size;
+    size_t actual_size;
+
+    uint8_t **ptr = (uint8_t **)(&(xfer->data_buffer));
+    size_t *siz = (size_t *)(&(xfer->data_buffer_size));
 
     if (is_in_endpoint(endpoint)) {
-        xfer->num_bytes = usb_round_up_to_mps(size, device->config.bulk_in_mps);
+        actual_size = usb_round_up_to_mps(size, device->config.bulk_in_mps);
     } else {
-        memcpy(xfer->data_buffer, data, size);
-        xfer->num_bytes = size;
+        actual_size = size;
     }
 
+    // Attention: Here we modify 'private' members data_buffer and data_buffer_size
+    *ptr = data;
+    *siz = actual_size;
+    xfer->num_bytes = actual_size;
     xfer->device_handle = device->handle;
     xfer->bEndpointAddress = endpoint;
     xfer->callback = transfer_callback;
     xfer->timeout_ms = 5000;
     xfer->context = device;
 
-    MSC_RETURN_ON_ERROR( usb_host_transfer_submit(xfer) );
-    if (USB_TRANSFER_STATUS_COMPLETED != wait_for_transfer_done(xfer)) {
-        if (USB_TRANSFER_STATUS_STALL == wait_for_transfer_done(xfer)) {
-            return ESP_ERR_MSC_STALL;
-        }
-        return ESP_ERR_MSC_INTERNAL;
+    MSC_GOTO_ON_ERROR( usb_host_transfer_submit(xfer) );
+    const usb_transfer_status_t status = wait_for_transfer_done(xfer);
+    switch (status) {
+    case USB_TRANSFER_STATUS_COMPLETED:
+        ret = ESP_OK; break;
+    case USB_TRANSFER_STATUS_STALL:
+        ret = ESP_ERR_MSC_STALL; break;
+    default:
+        ret = ESP_ERR_MSC_INTERNAL; break;
     }
 
-    if (is_in_endpoint(endpoint)) {
-        memcpy(data, xfer->data_buffer, size);
-    }
-
-    return ESP_OK;
+fail:
+    *ptr = backup_buffer;
+    *siz = backup_size;
+    return ret;
 }
 
 esp_err_t msc_control_transfer(msc_device_t *device, size_t len)
@@ -541,4 +650,14 @@ esp_err_t msc_control_transfer(msc_device_t *device, size_t len)
 
     MSC_RETURN_ON_ERROR( usb_host_transfer_submit_control(s_msc_driver->client_handle, xfer));
     return wait_for_transfer_done(xfer) == USB_TRANSFER_STATUS_COMPLETED ? ESP_OK : ESP_ERR_MSC_INTERNAL;
+}
+
+esp_err_t msc_host_reset_recovery(msc_host_device_handle_t device)
+{
+    // Clear feature will fail if there is not STALL on the endpoint, so we don't check the errors here
+    clear_feature(device, device->config.bulk_in_ep);
+    clear_feature(device, device->config.bulk_out_ep);
+    ESP_RETURN_ON_ERROR( msc_mass_reset(device), TAG, "Mass reset failed" );
+    MSC_RETURN_ON_ERROR( msc_wait_for_ready_state(device, WAIT_FOR_READY_TIMEOUT_MS) );
+    return ESP_OK;
 }

--- a/usb/usb_host_msc/src/msc_host_vfs.c
+++ b/usb/usb_host_msc/src/msc_host_vfs.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <sys/param.h>
 #include "msc_common.h"
-#include "msc_host_vfs.h"
+#include "usb/msc_host_vfs.h"
 #include "diskio_impl.h"
 #include "ffconf.h"
 #include "ff.h"

--- a/usb/usb_host_msc/src/msc_scsi_bot.c
+++ b/usb/usb_host_msc/src/msc_scsi_bot.c
@@ -63,44 +63,15 @@ static const char *TAG = "USB_MSC_SCSI";
         .cbw_length = cbw_len,                  \
     }
 
-#define FEATURE_SELECTOR_ENDPOINT   0
 #define CSW_SIGNATURE   0x53425355
 #define CBW_SIZE        31
-
-#define USB_MASS_REQ_INIT_RESET(ctrl_req_ptr, intf_num) ({                  \
-    (ctrl_req_ptr)->bmRequestType = USB_BM_REQUEST_TYPE_DIR_OUT |           \
-                                    USB_BM_REQUEST_TYPE_TYPE_CLASS |        \
-                                    USB_BM_REQUEST_TYPE_RECIP_INTERFACE;    \
-    (ctrl_req_ptr)->bRequest = 0xFF;                                        \
-    (ctrl_req_ptr)->wValue = 0;                                             \
-    (ctrl_req_ptr)->wIndex = (intf_num);                                    \
-    (ctrl_req_ptr)->wLength = 0;                                            \
-})
-
-#define USB_MASS_REQ_INIT_GET_MAX_LUN(ctrl_req_ptr, intf_num) ({            \
-    (ctrl_req_ptr)->bmRequestType = USB_BM_REQUEST_TYPE_DIR_IN |            \
-                                    USB_BM_REQUEST_TYPE_TYPE_CLASS |        \
-                                    USB_BM_REQUEST_TYPE_RECIP_INTERFACE;    \
-    (ctrl_req_ptr)->bRequest = 0xFE;                                        \
-    (ctrl_req_ptr)->wValue = 0;                                             \
-    (ctrl_req_ptr)->wIndex = (intf_num);                                    \
-    (ctrl_req_ptr)->wLength = 1;                                            \
-})
-
-#define USB_SETUP_PACKET_INIT_CLEAR_FEATURE_EP(ctrl_req_ptr, ep_num) ({     \
-    (ctrl_req_ptr)->bmRequestType = USB_BM_REQUEST_TYPE_DIR_OUT |           \
-                                    USB_BM_REQUEST_TYPE_TYPE_STANDARD |     \
-                                    USB_BM_REQUEST_TYPE_RECIP_ENDPOINT;     \
-    (ctrl_req_ptr)->bRequest = USB_B_REQUEST_CLEAR_FEATURE;                 \
-    (ctrl_req_ptr)->wValue = FEATURE_SELECTOR_ENDPOINT;                     \
-    (ctrl_req_ptr)->wIndex = (ep_num);                                      \
-    (ctrl_req_ptr)->wLength = 0;                                            \
-})
 
 #define CWB_FLAG_DIRECTION_IN (1<<7) // device -> host
 
 /**
  * @brief Command Block Wrapper structure
+ *
+ * @see USB Mass Storage Class – Bulk Only Transport, Table 5.1
  */
 typedef struct __attribute__((packed))
 {
@@ -114,6 +85,8 @@ typedef struct __attribute__((packed))
 
 /**
  * @brief Command Status Wrapper structure
+ *
+ * @see USB Mass Storage Class – Bulk Only Transport, Table 5.2
  */
 typedef struct __attribute__((packed))
 {
@@ -248,61 +221,50 @@ static esp_err_t check_csw(msc_csw_t *csw, uint32_t tag)
     return csw_ok ? ESP_OK : ESP_FAIL;
 }
 
-static esp_err_t clear_feature(msc_device_t *device, uint8_t endpoint)
-{
-    usb_device_handle_t dev = device->handle;
-    usb_transfer_t *xfer = device->xfer;
-
-    MSC_RETURN_ON_ERROR( usb_host_endpoint_clear(dev, endpoint) );
-    USB_SETUP_PACKET_INIT_CLEAR_FEATURE_EP((usb_setup_packet_t *)xfer->data_buffer, endpoint);
-    MSC_RETURN_ON_ERROR( msc_control_transfer(device,  USB_SETUP_PACKET_SIZE) );
-
-    return ESP_OK;
-}
-
-esp_err_t msc_mass_reset(msc_device_t *device)
-{
-    usb_transfer_t *xfer = device->xfer;
-
-    USB_MASS_REQ_INIT_RESET((usb_setup_packet_t *)xfer->data_buffer, 0);
-    MSC_RETURN_ON_ERROR( msc_control_transfer(device, USB_SETUP_PACKET_SIZE) );
-
-    return ESP_OK;
-}
-
-esp_err_t msc_get_max_lun(msc_device_t *device, uint8_t *lun)
-{
-    usb_transfer_t *xfer = device->xfer;
-
-    USB_MASS_REQ_INIT_GET_MAX_LUN((usb_setup_packet_t *)xfer->data_buffer, 0);
-    MSC_RETURN_ON_ERROR( msc_control_transfer(device, USB_SETUP_PACKET_SIZE + 1) );
-
-    *lun = xfer->data_buffer[USB_SETUP_PACKET_SIZE];
-
-    return ESP_OK;
-}
-
-static esp_err_t bot_execute_command(msc_device_t *device, msc_cbw_t *cbw, void *data, size_t size)
+/**
+ * @brief Execute BOT command
+ *
+ * There are multiple stages in BOT command:
+ * 1. Command transport
+ * 2. Data transport (optional)
+ * 3. Status transport
+ * 3.1. Error recovery (in case of error)
+ *
+ * This function is not 'static' so it could be called from unit test
+ *
+ * @see USB Mass Storage Class – Bulk Only Transport, Chapter 5.3
+ *
+ * @param[in] device MSC device handle
+ * @param[in] cbw    Command Block Wrapper
+ * @param[in] data   Data (optional)
+ * @param[in] size   Size of data in bytes
+ * @return esp_err_t
+ */
+esp_err_t bot_execute_command(msc_device_t *device, msc_cbw_t *cbw, void *data, size_t size)
 {
     msc_csw_t csw;
     msc_endpoint_t ep = (cbw->flags & CWB_FLAG_DIRECTION_IN) ? MSC_EP_IN : MSC_EP_OUT;
 
-    MSC_RETURN_ON_ERROR( msc_bulk_transfer(device, (uint8_t *)cbw, CBW_SIZE, MSC_EP_OUT) );
+    // 1. Command transport
+    MSC_RETURN_ON_ERROR( msc_bulk_transfer_zcpy(device, (uint8_t *)cbw, CBW_SIZE, MSC_EP_OUT) );
 
+    // 2. Optional data transport
     if (data) {
-        MSC_RETURN_ON_ERROR( msc_bulk_transfer(device, (uint8_t *)data, size, ep) );
+        MSC_RETURN_ON_ERROR( msc_bulk_transfer_zcpy(device, (uint8_t *)data, size, ep) );
     }
 
-    esp_err_t err = msc_bulk_transfer(device, (uint8_t *)&csw, sizeof(msc_csw_t), MSC_EP_IN);
+    // 3. Status transport
+    esp_err_t err = msc_bulk_transfer_zcpy(device, (uint8_t *)&csw, sizeof(msc_csw_t), MSC_EP_IN);
 
+    // 3.1 Error recovery
     if (err == ESP_ERR_MSC_STALL) {
-        ESP_RETURN_ON_ERROR( clear_feature(device, MSC_EP_IN), TAG, "Clear feature failed" );
-        // Try to read csw again after clearing feature
-        err = msc_bulk_transfer(device, (uint8_t *)&csw, sizeof(msc_csw_t), MSC_EP_IN);
-        if (err) {
-            ESP_RETURN_ON_ERROR( clear_feature(device, MSC_EP_IN), TAG, "Clear feature failed" );
-            ESP_RETURN_ON_ERROR( msc_mass_reset(device), TAG, "Mass reset failed" );
-            return ESP_FAIL;
+        // In case of the status transport failure, we can try reading the status again after clearing feature
+        ESP_RETURN_ON_ERROR( clear_feature(device, device->config.bulk_in_ep), TAG, "Clear feature failed" );
+        err = msc_bulk_transfer_zcpy(device, (uint8_t *)&csw, sizeof(msc_csw_t), MSC_EP_IN);
+        if (ESP_OK != err) {
+            // In case the repeated status transport failed we do reset recovery
+            // We don't check the error code here, the command has already failed.
+            msc_host_reset_recovery(device);
         }
     }
 
@@ -312,12 +274,13 @@ static esp_err_t bot_execute_command(msc_device_t *device, msc_cbw_t *cbw, void 
 }
 
 
-esp_err_t scsi_cmd_read10(msc_device_t *device,
+esp_err_t scsi_cmd_read10(msc_host_device_handle_t dev,
                           uint8_t *data,
                           uint32_t sector_address,
                           uint32_t num_sectors,
                           uint32_t sector_size)
 {
+    msc_device_t *device = (msc_device_t *)dev;
     cbw_read10_t cbw = {
         CBW_BASE_INIT(IN_DIR, CBW_CMD_SIZE(cbw_read10_t), num_sectors * sector_size),
         .opcode = SCSI_CMD_READ10,
@@ -329,12 +292,13 @@ esp_err_t scsi_cmd_read10(msc_device_t *device,
     return bot_execute_command(device, &cbw.base, data, num_sectors * sector_size);
 }
 
-esp_err_t scsi_cmd_write10(msc_device_t *device,
+esp_err_t scsi_cmd_write10(msc_host_device_handle_t dev,
                            const uint8_t *data,
                            uint32_t sector_address,
                            uint32_t num_sectors,
                            uint32_t sector_size)
 {
+    msc_device_t *device = (msc_device_t *)dev;
     cbw_write10_t cbw = {
         CBW_BASE_INIT(OUT_DIR, CBW_CMD_SIZE(cbw_write10_t), num_sectors * sector_size),
         .opcode = SCSI_CMD_WRITE10,
@@ -345,8 +309,9 @@ esp_err_t scsi_cmd_write10(msc_device_t *device,
     return bot_execute_command(device, &cbw.base, (void *)data, num_sectors * sector_size);
 }
 
-esp_err_t scsi_cmd_read_capacity(msc_device_t *device, uint32_t *block_size, uint32_t *block_count)
+esp_err_t scsi_cmd_read_capacity(msc_host_device_handle_t dev, uint32_t *block_size, uint32_t *block_count)
 {
+    msc_device_t *device = (msc_device_t *)dev;
     cbw_read_capacity_response_t response;
 
     cbw_read_capacity_t cbw = {
@@ -362,8 +327,9 @@ esp_err_t scsi_cmd_read_capacity(msc_device_t *device, uint32_t *block_size, uin
     return ESP_OK;
 }
 
-esp_err_t scsi_cmd_unit_ready(msc_device_t *device)
+esp_err_t scsi_cmd_unit_ready(msc_host_device_handle_t dev)
 {
+    msc_device_t *device = (msc_device_t *)dev;
     cbw_unit_ready_t cbw = {
         CBW_BASE_INIT(IN_DIR, CBW_CMD_SIZE(cbw_unit_ready_t), 0),
         .opcode = SCSI_CMD_TEST_UNIT_READY,
@@ -372,8 +338,9 @@ esp_err_t scsi_cmd_unit_ready(msc_device_t *device)
     return bot_execute_command(device, &cbw.base, NULL, 0);
 }
 
-esp_err_t scsi_cmd_sense(msc_device_t *device, scsi_sense_data_t *sense)
+esp_err_t scsi_cmd_sense(msc_host_device_handle_t dev, scsi_sense_data_t *sense)
 {
+    msc_device_t *device = (msc_device_t *)dev;
     cbw_sense_response_t response;
 
     cbw_sense_t cbw = {
@@ -396,8 +363,9 @@ esp_err_t scsi_cmd_sense(msc_device_t *device, scsi_sense_data_t *sense)
     return ESP_OK;
 }
 
-esp_err_t scsi_cmd_inquiry(msc_device_t *device)
+esp_err_t scsi_cmd_inquiry(msc_host_device_handle_t dev)
 {
+    msc_device_t *device = (msc_device_t *)dev;
     cbw_inquiry_response_t response = { 0 };
 
     cbw_inquiry_t cbw = {
@@ -409,8 +377,9 @@ esp_err_t scsi_cmd_inquiry(msc_device_t *device)
     return bot_execute_command(device, &cbw.base, &response, sizeof(response) );
 }
 
-esp_err_t scsi_cmd_mode_sense(msc_device_t *device)
+esp_err_t scsi_cmd_mode_sense(msc_host_device_handle_t dev)
 {
+    msc_device_t *device = (msc_device_t *)dev;
     mode_sense_response_t response = { 0 };
 
     mode_sense_t cbw = {
@@ -423,12 +392,13 @@ esp_err_t scsi_cmd_mode_sense(msc_device_t *device)
     return bot_execute_command(device, &cbw.base, &response, sizeof(response) );
 }
 
-esp_err_t scsi_cmd_prevent_removal(msc_device_t *device, bool prevent)
+esp_err_t scsi_cmd_prevent_removal(msc_host_device_handle_t dev, bool prevent)
 {
+    msc_device_t *device = (msc_device_t *)dev;
     prevent_allow_medium_removal_t cbw = {
         CBW_BASE_INIT(OUT_DIR, CBW_CMD_SIZE(prevent_allow_medium_removal_t), 0),
         .opcode = SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL,
-        .prevent = 1,
+        .prevent = (uint8_t) prevent,
     };
 
     return bot_execute_command(device, &cbw.base, NULL, 0);

--- a/usb/usb_host_msc/test/test_common.h
+++ b/usb/usb_host_msc/test/test_common.h
@@ -18,9 +18,7 @@ void device_app(void);
 void device_app_sdmmc(void);
 #endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_SDMMC_HOST_SUPPORTED */
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
 #define README_CONTENTS \
 "This is tinyusb's MassStorage Class demo.\r\n\r\n\
 If you find any bugs or get any questions, feel free to file an\r\n\
 issue at github.com/hathach/tinyusb"
-#endif /* ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0) */

--- a/usb/usb_host_msc/test/test_msc.c
+++ b/usb/usb_host_msc/test/test_msc.c
@@ -1,6 +1,6 @@
 
 /*
- * SPDX-FileCopyrightText: 2015-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -10,7 +10,7 @@
 #include <unistd.h>
 #include "esp_private/usb_phy.h"
 #include "usb/usb_host.h"
-#include "msc_host_vfs.h"
+#include "usb/msc_host_vfs.h"
 #include "test_common.h"
 #include "esp_idf_version.h"
 


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description

- Significantly increase performance with Virtual File System by allowing longer transfers
- Optimize used heap memory by reusing the Virtual File System buffer
- Optimize CPU usage by putting the background MSC task to 'Blocked' state indefinitely when there is nothing to do
- Fix MSC commands for devices on interface numbers other than zero
- Replace unsafe debug functions for direct access of MSC sectors with private SCSI commands

After the application starts new USB transfer, the USB-OTG peripheral will schedule it for next frame (which can be as delayed as 1ms). Therefore, the application must submit large-enough (>1kB) transfers to fully leverage USB FullSpeed bandwidth. For larger USB transfers we need more DMA capable memory, plus we need the same amount for memory for buffer in Virtual File System.

This change reuses the VFS buffer for USB transfers, which saves memory and does not require any copying between buffers. Plus, the user gets a convenient API to change the buffer size per file with `setvbuf()`, without any configuration of the MSC driver
