### PR TITLE
esp_encrypted_img: fix structure member name in esp_decrypt_cfg_t

### DIFF
--- a/esp_encrypted_img/CHANGELOG.md
+++ b/esp_encrypted_img/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 2.0.4
+
+- `rsa_pub_key` member of `esp_decrypt_cfg_t` structure is now deprecated. Please use `rsa_priv_key` instead. 
+- `rsa_pub_key_len` member of `esp_decrypt_cfg_t` structure is now deprecated. Please use `rsa_priv_key_len` instead. 

--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.3"
+version: "2.0.4"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -121,7 +121,7 @@ exit:
 
 esp_decrypt_handle_t esp_encrypted_img_decrypt_start(const esp_decrypt_cfg_t *cfg)
 {
-    if (cfg == NULL || cfg->rsa_pub_key == NULL) {
+    if (cfg == NULL || cfg->rsa_priv_key == NULL) {
         ESP_LOGE(TAG, "esp_encrypted_img_decrypt_start : Invalid argument");
         return NULL;
     }
@@ -133,7 +133,7 @@ esp_decrypt_handle_t esp_encrypted_img_decrypt_start(const esp_decrypt_cfg_t *cf
         goto failure;
     }
 
-    handle->rsa_pem = calloc(1, cfg->rsa_pub_key_len);
+    handle->rsa_pem = calloc(1, cfg->rsa_priv_key_len);
     if (!handle->rsa_pem) {
         ESP_LOGE(TAG, "Couldn't allocate memory to handle->rsa_pem");
         goto failure;
@@ -145,8 +145,8 @@ esp_decrypt_handle_t esp_encrypted_img_decrypt_start(const esp_decrypt_cfg_t *cf
         goto failure;
     }
 
-    memcpy(handle->rsa_pem, cfg->rsa_pub_key, cfg->rsa_pub_key_len);
-    handle->rsa_len = cfg->rsa_pub_key_len;
+    memcpy(handle->rsa_pem, cfg->rsa_priv_key, cfg->rsa_priv_key_len);
+    handle->rsa_len = cfg->rsa_priv_key_len;
     handle->state = ESP_PRE_ENC_IMG_READ_MAGIC;
 
     esp_decrypt_handle_t ctx = (esp_decrypt_handle_t)handle;

--- a/esp_encrypted_img/test/test.c
+++ b/esp_encrypted_img/test/test.c
@@ -23,8 +23,8 @@ extern const uint8_t bin_end[]   asm("_binary_image_bin_end");
 TEST_CASE("Sending all data at once", "[encrypted_img]")
 {
     esp_decrypt_cfg_t cfg = {
-        .rsa_pub_key = (char *)rsa_private_pem_start,
-        .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
+        .rsa_priv_key = (char *)rsa_private_pem_start,
+        .rsa_priv_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
     esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
@@ -53,8 +53,8 @@ TEST_CASE("Sending all data at once", "[encrypted_img]")
 TEST_CASE("Sending 1 byte data at once", "[encrypted_img]")
 {
     esp_decrypt_cfg_t cfg = {
-        .rsa_pub_key = (char *)rsa_private_pem_start,
-        .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
+        .rsa_priv_key = (char *)rsa_private_pem_start,
+        .rsa_priv_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
     esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
@@ -154,8 +154,8 @@ TEST_CASE("Invalid Magic", "[encrypted_img]")
     };
 
     esp_decrypt_cfg_t cfg = {
-        .rsa_pub_key = (char *)rsa_private_pem_start,
-        .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
+        .rsa_priv_key = (char *)rsa_private_pem_start,
+        .rsa_priv_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
     esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
@@ -247,8 +247,8 @@ TEST_CASE("Invalid Image", "[encrypted_img]")
     };
 
     esp_decrypt_cfg_t cfg = {
-        .rsa_pub_key = (char *)rsa_private_pem_start,
-        .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
+        .rsa_priv_key = (char *)rsa_private_pem_start,
+        .rsa_priv_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
     esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
@@ -275,8 +275,8 @@ TEST_CASE("Invalid Image", "[encrypted_img]")
 TEST_CASE("Sending random size data at once", "[encrypted_img]")
 {
     esp_decrypt_cfg_t cfg = {
-        .rsa_pub_key = (char *)rsa_private_pem_start,
-        .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
+        .rsa_priv_key = (char *)rsa_private_pem_start,
+        .rsa_priv_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
     esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);
     TEST_ASSERT_NOT_NULL(ctx);
@@ -314,8 +314,8 @@ TEST_CASE("Sending random size data at once", "[encrypted_img]")
 TEST_CASE("Test canceling decryption frees memory", "[encrypted_img]")
 {
     esp_decrypt_cfg_t cfg = {
-        .rsa_pub_key = (char *)rsa_private_pem_start,
-        .rsa_pub_key_len = rsa_private_pem_end - rsa_private_pem_start,
+        .rsa_priv_key = (char *)rsa_private_pem_start,
+        .rsa_priv_key_len = rsa_private_pem_end - rsa_private_pem_start,
     };
     int free_bytes_start = xPortGetFreeHeapSize();
     esp_decrypt_handle_t ctx = esp_encrypted_img_decrypt_start(&cfg);


### PR DESCRIPTION
1) Fix structure member name in esp_decrypt_cfg_t 
1.1 `rsa_pub_key` to `rsa_priv_key`
1.2 `rsa_pub_key_len` to `rsa_priv_key_len`
2) Fix the return code  in the header file API description