### PR TITLE
RFC: helper component to download files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,7 +22,9 @@ body:
       options:
         - bdc_motor
         - cbor
+        - ccomp_timer
         - coap
+        - download_file
         - eigen
         - esp_encrypted_img
         - esp_jpeg

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -29,6 +29,7 @@ jobs:
             cbor;
             ccomp_timer;
             coap;
+            download_file;
             eigen;
             esp_delta_ota;
             esp_encrypted_img;

--- a/download_file/CMakeLists.txt
+++ b/download_file/CMakeLists.txt
@@ -1,0 +1,9 @@
+idf_component_register(SRCS download_file.c
+                       INCLUDE_DIRS include
+                       REQUIRES
+                            esp_http_client     # esp_http_client.h included in the public header
+                       PRIV_REQUIRES
+                            esp_ringbuf         # uses a ringbuffer
+                            mbedtls             # for certificate bundle
+                            esp_timer           # for benchmarking
+                      )

--- a/download_file/download_file.c
+++ b/download_file/download_file.c
@@ -1,0 +1,216 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) Co. Ltd.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include "sdkconfig.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/ringbuf.h"
+#include "esp_http_client.h"
+#include "esp_crt_bundle.h"
+#include "download_file.h"
+
+static const char *TAG = "file_downloader";
+
+static esp_err_t download_file_event_handler(esp_http_client_event_t *evt);
+static void file_write_task(void *arg);
+
+typedef struct {
+    FILE *f_out;
+    size_t buffer_size;
+    RingbufHandle_t rb;
+    SemaphoreHandle_t start;
+    SemaphoreHandle_t done;
+    bool skip_file_buffer;
+    size_t bytes_downloaded;
+    size_t bytes_written;
+    size_t last_download_percent;
+    size_t content_length;
+    int64_t download_waiting_for_ringbuf_us;
+    int64_t write_waiting_for_sdcard_us;
+    void (*progress_cb)(void *user_data, size_t bytes_done, size_t bytes_total); /*!< Callback to call on progress */
+    void *user_data;
+} download_args_t;
+
+
+esp_err_t download_file(const char *url, FILE *f_out, const download_file_config_t *config)
+{
+    esp_err_t ret = ESP_OK;
+    TaskHandle_t task_handle = NULL;
+    esp_http_client_handle_t client = NULL;
+
+    /* Start the file writing task */
+    download_args_t args = {
+        .f_out = f_out,
+        .buffer_size = config->buffer_size,
+        .rb = xRingbufferCreate(config->buffer_size, RINGBUF_TYPE_BYTEBUF),
+        .start = xSemaphoreCreateBinary(),
+        .done = xSemaphoreCreateBinary(),
+        .skip_file_buffer = config->skip_file_buffer,
+        .progress_cb = config->progress_cb,
+        .user_data = config->user_data,
+    };
+
+    esp_http_client_config_t http_client_config = {
+        .url = url,
+        .event_handler = &download_file_event_handler,
+        .user_data = &args,
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+        .crt_bundle_attach = &esp_crt_bundle_attach,
+#endif
+        .buffer_size = config->buffer_size,
+        .timeout_ms = config->timeout_ms,
+    };
+
+    if (config->http_client_config_cb != NULL) {
+        ESP_GOTO_ON_ERROR(config->http_client_config_cb(config->user_data, &http_client_config), out, TAG, "Failed in config callback");
+    }
+
+    client = esp_http_client_init(&http_client_config);
+    ESP_GOTO_ON_FALSE(client != NULL, ESP_ERR_NO_MEM, out, TAG, "Failed to initialise HTTP client");
+
+    if (config->http_client_post_init_cb != NULL) {
+        ESP_GOTO_ON_ERROR(config->http_client_post_init_cb(config->user_data, client), out, TAG, "Failed in post init callback");
+    }
+
+    int res = xTaskCreatePinnedToCore(&file_write_task, "download_file_task", 4096, &args, 5, &task_handle, 1);
+    ESP_GOTO_ON_FALSE(res == pdPASS, ESP_ERR_NO_MEM, out, TAG, "Failed to create file write task");
+
+    int64_t start = esp_timer_get_time();
+    ret = esp_http_client_perform(client);
+    int64_t end = esp_timer_get_time();
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "HTTP Status = %d, content_length = %"PRIu64,
+                 esp_http_client_get_status_code(client),
+                 esp_http_client_get_content_length(client));
+        ESP_LOGI(TAG, "Time taken: %d ms Speed: %.2f kB/sec", (int) (end - start) / 1000, (args.content_length / 1024.0f) / ((end - start) / 1000000.0f));
+        ESP_LOGI(TAG, "Download task spent %d ms blocked on writing to ringbuffer", (int) args.download_waiting_for_ringbuf_us / 1000);
+        ESP_LOGI(TAG, "File write task spent %d ms blocked on writing to SD card", (int) args.write_waiting_for_sdcard_us / 1000);
+    } else {
+        ESP_LOGE(TAG, "HTTP request failed: %s", esp_err_to_name(ret));
+    }
+
+    xSemaphoreTake(args.done, portMAX_DELAY);
+
+out:
+    if (client != NULL) {
+        esp_http_client_cleanup(client);
+    }
+    vRingbufferDelete(args.rb);
+    vSemaphoreDelete(args.done);
+    return ret;
+}
+
+
+static void file_write_task(void *arg)
+{
+    download_args_t *args = (download_args_t *) arg;
+    args->bytes_written = 0;
+    xSemaphoreTake(args->start, portMAX_DELAY);
+    if (args->content_length == 0) {
+        ESP_LOGE(TAG, "Content length is 0");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    while (args->bytes_written < args->content_length) {
+        size_t remaining = 0;
+        vRingbufferGetInfo(args->rb, NULL, NULL, NULL, NULL, &remaining);
+
+        size_t to_write = args->buffer_size;
+        if (args->bytes_written + remaining == args->content_length) {
+            to_write = remaining;
+        }
+        ESP_LOGD(TAG, "to_write: %d, remaining: %d", to_write, remaining);
+        uint8_t *rb_buf = xRingbufferReceive(args->rb, &to_write, pdMS_TO_TICKS(10000));
+        if (rb_buf == NULL) {
+            ESP_LOGE(TAG, "Failed to read from ringbuffer");
+            continue;
+        }
+        int64_t start = esp_timer_get_time();
+
+        ssize_t written_bytes;
+        if (args->skip_file_buffer) {
+            written_bytes = write(fileno(args->f_out), rb_buf, to_write);
+        } else {
+            written_bytes = fwrite(rb_buf, 1, to_write, args->f_out);
+        }
+        int64_t end = esp_timer_get_time();
+        if (written_bytes != to_write) {
+            ESP_LOGE(TAG, "Failed to write to file");
+            break;
+        }
+        args->write_waiting_for_sdcard_us += end - start;
+        args->bytes_written += written_bytes;
+        vRingbufferReturnItem(args->rb, rb_buf);
+
+        ESP_LOGD(TAG, "Downloaded %d, written %d", args->bytes_downloaded, args->bytes_written);
+        size_t download_percent = (args->bytes_downloaded * 100) / args->content_length;
+        if (download_percent - args->last_download_percent >= 1) {
+            if (args->progress_cb != NULL) {
+                args->progress_cb(args->user_data, args->content_length, args->bytes_written);
+            }
+            args->last_download_percent = download_percent;
+        }
+    }
+    if (args->progress_cb != NULL) {
+        args->progress_cb(args->user_data, args->content_length, args->bytes_written);
+    }
+    ESP_LOGI(TAG, "Download done, written %d bytes to file", args->bytes_written);
+    xSemaphoreGive(args->done);
+    vTaskDelete(NULL);
+}
+
+static esp_err_t download_file_event_handler(esp_http_client_event_t *evt)
+{
+    download_args_t *args = (download_args_t *) evt->user_data;
+    switch (evt->event_id) {
+    case HTTP_EVENT_ERROR:
+        ESP_LOGE(TAG, "HTTP_EVENT_ERROR");
+        break;
+    case HTTP_EVENT_ON_CONNECTED:
+        ESP_LOGD(TAG, "HTTP_EVENT_ON_CONNECTED");
+        break;
+    case HTTP_EVENT_HEADER_SENT:
+        ESP_LOGD(TAG, "HTTP_EVENT_HEADER_SENT");
+        break;
+    case HTTP_EVENT_ON_HEADER:
+        if (strcmp(evt->header_key, "Content-Length") == 0) {
+            args->content_length = atoi(evt->header_value);
+            ESP_LOGI(TAG, "Content-length: %d", args->content_length);
+            // start the file write task
+            xSemaphoreGive(args->start);
+        }
+        break;
+    case HTTP_EVENT_ON_DATA:
+        args->bytes_downloaded += evt->data_len;
+        if (!esp_http_client_is_chunked_response(evt->client)) {
+
+            /* Write out data received in the event */
+            int64_t start = esp_timer_get_time();
+            xRingbufferSend(args->rb, (void *) evt->data, evt->data_len, portMAX_DELAY);
+            int64_t end = esp_timer_get_time();
+            args->download_waiting_for_ringbuf_us += end - start;
+        }
+        break;
+    case HTTP_EVENT_ON_FINISH:
+        ESP_LOGD(TAG, "HTTP_EVENT_ON_FINISH");
+        break;
+    case HTTP_EVENT_DISCONNECTED:
+        ESP_LOGD(TAG, "HTTP_EVENT_DISCONNECTED");
+        break;
+    case HTTP_EVENT_REDIRECT:
+        ESP_LOGD(TAG, "HTTP_EVENT_REDIRECT");
+        break;
+    default:
+        ESP_LOGW(TAG, "Unexpected event id: %d", evt->event_id);
+    }
+    return ESP_OK;
+}

--- a/download_file/idf_component.yml
+++ b/download_file/idf_component.yml
@@ -1,0 +1,6 @@
+version: "1.0.0"
+description: File downloader
+url: https://github.com/espressif/idf-extra-components/tree/master/download_file
+issues: "https://github.com/espressif/idf-extra-components/issues"
+dependencies:
+  idf: ">=5.0"

--- a/download_file/include/download_file.h
+++ b/download_file/include/download_file.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) Co. Ltd.
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+#include "esp_err.h"
+#include "esp_http_client.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configuration for download_file
+ */
+typedef struct {
+    size_t buffer_size;     /*!< Size of buffer to use for download */
+    int timeout_ms;         /*!< Timeout for downloading */
+    size_t download_task_stack; /*!< Stack size for download task */
+    int download_task_priority; /*!< Priority for download task */
+    bool skip_file_buffer; /*!< Skip FILE* stream buffer and write directly to the file descriptor */
+    void *user_data;        /*!< User data to pass to callbacks */
+    esp_err_t (*http_client_config_cb)(void *user_data, esp_http_client_config_t *http_client_config);    /*!< Callback to call to configure http client */
+    esp_err_t (*http_client_post_init_cb)(void *user_data, esp_http_client_handle_t http_client); /*!< Callback to call after http client is initialized */
+    void (*progress_cb)(void *user_data, size_t bytes_done, size_t bytes_total); /*!< Callback to call on progress */
+} download_file_config_t;
+
+#define DOWNLOAD_FILE_CONFIG_DEFAULT() { \
+    .buffer_size = 1024, \
+    .timeout_ms = 10000, \
+    .download_task_stack = 4096, \
+    .download_task_priority = 5, \
+    .user_data = NULL, \
+    .http_client_config_cb = NULL, \
+    .http_client_post_init_cb = NULL, \
+    .progress_cb = NULL, \
+}
+
+esp_err_t download_file(const char *url, FILE *f_out, const download_file_config_t *config);
+
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # 3. Add here if the component is compatible with IDF >= v5.0
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
-    list(APPEND EXTRA_COMPONENT_DIRS ../bdc_motor ../led_strip ../sh2lib ../nghttp ../esp_serial_slave_link ../onewire_bus ../ccomp_timer)
+    list(APPEND EXTRA_COMPONENT_DIRS ../bdc_motor ../led_strip ../sh2lib ../nghttp ../esp_serial_slave_link ../onewire_bus ../ccomp_timer ../download_file)
 endif()
 
 # !This section should NOT be touched when adding new component!


### PR DESCRIPTION
# Summary

A couple of customers have approached us with a problem that downloading of files from the Internet onto the device (e.g. to an SD card) was slow. After analyzing the issue we found that the problem was due to lack of buffering between esp_http_client and the SD driver. This component solves the problem by performing downloading and writing in different tasks, with a (large) ringbuffer in-between to reduce back-pressure to the TCP stack. This avoids degrading download throughput.

This component can download a file over HTTP(S) into a filesystem in Flash, SD card, or into RAM (using `open_memstream`).

The code is in a rather beta state. Error handling is not entirely correct, some things are probably hard-coded, and there are no tests, examples or documentation. I'm mainly posting this to see if anyone else in interested in seeing such functionality. If there is, I can do the remaining work to finish the implementation.

All suggestions are welcome!

--- 
<details><summary>Checklist</summary>


# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

</details>