### PR TITLE
led_strip: fix version dependency

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -1,7 +1,19 @@
-led_strip:
+led_strip/examples/led_strip_rmt_ws2812:
   enable:
-    - if: SOC_RMT_SUPPORTED == 1 and ((IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR >= 1) or (IDF_VERSION_MAJOR > 5)) # Used Clock_source_t type was introduced since IDF V5.1
-    
+    - if: IDF_VERSION_MAJOR > 4
+      reason: Example uses the new RMT driver which was introduced in IDF v5.0
+  disable:
+    - if: CONFIG_SOC_RMT_SUPPORTED != 1
+      reason: Relevant only for RMT enabled targets
+
+led_strip/examples/led_strip_spi_ws2812:
+  enable:
+    - if: (IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR >= 1) or (IDF_VERSION_MAJOR > 5)
+      reason: Example uses some SPI driver features which was introduced in IDF v5.1
+  disable:
+    - if: CONFIG_SOC_GPSPI_SUPPORTED != 1
+      reason: Relevant only for SPI enabled targets
+
 esp_delta_ota:
   enable:
     - if: IDF_VERSION_MAJOR > 4

--- a/led_strip/CMakeLists.txt
+++ b/led_strip/CMakeLists.txt
@@ -1,11 +1,17 @@
+include($ENV{IDF_PATH}/tools/cmake/version.cmake)
+
 set(srcs "src/led_strip_api.c")
 
 if(CONFIG_SOC_RMT_SUPPORTED)
     list(APPEND srcs "src/led_strip_rmt_dev.c" "src/led_strip_rmt_encoder.c")
 endif()
 
-
-list(APPEND srcs "src/led_strip_spi_dev.c")
+# the SPI backend driver relies on something that was added in IDF 5.1
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.1")
+    if(CONFIG_SOC_GPSPI_SUPPORTED)
+        list(APPEND srcs "src/led_strip_spi_dev.c")
+    endif()
+endif()
 
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include" "interface"

--- a/led_strip/README.md
+++ b/led_strip/README.md
@@ -8,7 +8,7 @@ This driver is designed for addressable LEDs like [WS2812](http://www.world-semi
 
 ### The [RMT](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html) Peripheral
 
-This is the most economical way to drive the LEDs because it only consumes one RMT channel, leaving other channels free to use. However, the memory usage increases dramatically with the number of LEDs. If the RMT hardware can't be assist by DMA, the driver will going into interrupt very frequently, thus result in a high CPU usage. What's worse, if the RMT interrupt is delayed or not serviced in time (e.g. if Wi-Fi interrupt happens on the same CPU core), the RMT transaction will be corrupted and the LEDs will display incorrect colors. If you want to use RMT to drive a large number of LEDs, you'd better to enable the DMA feature if possible. [^1]
+This is the most economical way to drive the LEDs because it only consumes one RMT channel, leaving other channels free to use. However, the memory usage increases dramatically with the number of LEDs. If the RMT hardware can't be assist by DMA, the driver will going into interrupt very frequently, thus result in a high CPU usage. What's worse, if the RMT interrupt is delayed or not serviced in time (e.g. if Wi-Fi interrupt happens on the same CPU core), the RMT transaction will be corrupted and the LEDs will display incorrect colors. If you want to use RMT to drive a large number of LEDs, you'd better to enable the DMA feature if possible [^1].
 
 #### Allocate LED Strip Object with RMT Backend
 
@@ -36,4 +36,53 @@ ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip)
 
 You can create multiple LED strip objects with different GPIOs and pixel numbers. The backend driver will automatically allocate the RMT channel for you if there is more available.
 
-[^1]: The DMA feature is not available on all ESP chips. Please check the data sheet before using it.
+### The [SPI](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/spi_master.html) Peripheral
+
+SPI peripheral can also be used to generate the timing required by the LED strip. However this backend is not as economical as the RMT one, because it will take up the whole **bus**, unlike the RMT just takes one **channel**. You **CANT** connect other devices to the same SPI bus if it's been used by the led_strip, because the led_strip doesn't have the concept of "Chip Select".
+
+#### Allocate LED Strip Object with SPI Backend
+
+```c
+#define BLINK_GPIO 0
+
+led_strip_handle_t led_strip;
+
+/* LED strip initialization with the GPIO and pixels number*/
+led_strip_config_t strip_config = {
+    .strip_gpio_num = BLINK_GPIO, // The GPIO that connected to the LED strip's data line
+    .max_leds = 1, // The number of LEDs in the strip,
+    .led_pixel_format = LED_PIXEL_FORMAT_GRB, // Pixel format of your LED strip
+    .led_model = LED_MODEL_WS2812, // LED strip model
+    .flags.invert_out = false, // whether to invert the output signal (useful when your hardware has a level inverter)
+};
+
+led_strip_spi_config_t spi_config = {
+    .clk_src = SPI_CLK_SRC_DEFAULT, // different clock source can lead to different power consumption
+    .flags.with_dma = true, // Using DMA can improve performance and help drive more LEDs
+    .spi_bus = SPI2_HOST,   // SPI bus ID
+};
+ESP_ERROR_CHECK(led_strip_new_spi_device(&strip_config, &spi_config, &led_strip));
+```
+
+The number of LED strip objects can be created depends on how many free SPI buses are free to use in your project.
+
+## FAQ
+
+* Which led_strip backend should I choose?
+  * It depends on your application requirement and target chip's ability.
+
+    ```mermaid
+    flowchart LR
+    A{Is RMT supported?}
+    A --> |No| B[SPI backend]
+    B --> C{Does the led strip has \n a larger number of LEDs?}
+    C --> |No| D[Don't have to enable the DMA of the backend]
+    C --> |Yes| E[Enable the DMA of the backend]
+    A --> |Yes| F{Does the led strip has \n a larger number of LEDs?}
+    F --> |Yes| G{Does RMT support DMA?}
+    G --> |Yes| E
+    G --> |No| B
+    F --> |No| H[RMT backend] --> D
+    ```
+
+[^1]: The RMT DMA feature is not available on all ESP chips. Please check the data sheet before using it.

--- a/led_strip/examples/led_strip_rmt_ws2812/main/idf_component.yml
+++ b/led_strip/examples/led_strip_rmt_ws2812/main/idf_component.yml
@@ -1,6 +1,5 @@
 ## IDF Component Manager Manifest File
 dependencies:
   espressif/led_strip:
-    version: '^2.4'
+    version: '^2'
     override_path: '../../../'
-  idf: ">=5.1"

--- a/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
+++ b/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
@@ -11,7 +11,7 @@
 #include "esp_err.h"
 
 // GPIO assignment
-#define LED_STRIP_BLINK_GPIO  14
+#define LED_STRIP_BLINK_GPIO  2
 // Numbers of the LED in the strip
 #define LED_STRIP_LED_NUMBERS 24
 // 10MHz resolution, 1 tick = 0.1us (led strip needs a high resolution)
@@ -46,7 +46,6 @@ led_strip_handle_t configure_led(void)
 
 void app_main(void)
 {
-
     led_strip_handle_t led_strip = configure_led();
     bool led_on_off = false;
 

--- a/led_strip/examples/led_strip_spi_ws2812/main/led_strip_spi_ws2812_main.c
+++ b/led_strip/examples/led_strip_spi_ws2812/main/led_strip_spi_ws2812_main.c
@@ -11,11 +11,9 @@
 #include "esp_err.h"
 
 // GPIO assignment
-#define LED_STRIP_BLINK_GPIO  14
+#define LED_STRIP_BLINK_GPIO  2
 // Numbers of the LED in the strip
 #define LED_STRIP_LED_NUMBERS 24
-// 2.5MHz resolution, 1 tick = 0.4us (led strip needs a high resolution)
-#define LED_STRIP_SPI_RES_HZ  (2.5 * 1000 * 1000)
 
 static const char *TAG = "example";
 
@@ -32,10 +30,9 @@ led_strip_handle_t configure_led(void)
 
     // LED strip backend configuration: SPI
     led_strip_spi_config_t spi_config = {
-        .clk_src = SPI_CLK_SRC_DEFAULT,        // different clock source can lead to different power consumption
-        .resolution_hz = LED_STRIP_SPI_RES_HZ, // SPI counter clock frequency
-        .flags.with_dma = true,                // SPI peripheral always support DMA and non-DMA. But we recommend to use the DMA in the led_strip application.
-        .spi_bus = SPI2_HOST,
+        .clk_src = SPI_CLK_SRC_DEFAULT, // different clock source can lead to different power consumption
+        .flags.with_dma = true,         // Using DMA can improve performance and help drive more LEDs
+        .spi_bus = SPI2_HOST,           // SPI bus ID
     };
 
     // LED Strip object handle
@@ -47,7 +44,6 @@ led_strip_handle_t configure_led(void)
 
 void app_main(void)
 {
-
     led_strip_handle_t led_strip = configure_led();
     bool led_on_off = false;
 

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,5 +1,5 @@
-version: "2.4.0"
+version: "2.4.1"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 dependencies:
-  idf: ">=5.1"
+  idf: ">=5.0"

--- a/led_strip/include/led_strip.h
+++ b/led_strip/include/led_strip.h
@@ -8,8 +8,8 @@
 #include <stdint.h>
 #include "esp_err.h"
 #include "led_strip_rmt.h"
-
 #include "led_strip_spi.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/led_strip/include/led_strip_spi.h
+++ b/led_strip/include/led_strip_spi.h
@@ -19,8 +19,7 @@ extern "C" {
  */
 typedef struct {
     spi_clock_source_t clk_src; /*!< SPI clock source */
-    uint32_t resolution_hz;     /*!< SPI tick resolution, if set to zero, a default resolution (2.5MHz) will be applied */
-    spi_host_device_t spi_bus;  /*!< SPI Host. Which buses are available depends on the specific chip */
+    spi_host_device_t spi_bus;  /*!< SPI bus ID. Which buses are available depends on the specific chip */
     struct {
         uint32_t with_dma: 1;   /*!< Use DMA to transmit data */
     } flags;
@@ -36,6 +35,7 @@ typedef struct {
  * @return
  *      - ESP_OK: create LED strip handle successfully
  *      - ESP_ERR_INVALID_ARG: create LED strip handle failed because of invalid argument
+ *      - ESP_ERR_NOT_SUPPORTED: create LED strip handle failed because of unsupported configuration
  *      - ESP_ERR_NO_MEM: create LED strip handle failed because of out of memory
  *      - ESP_FAIL: create LED strip handle failed because some other error
  */
@@ -44,4 +44,3 @@ esp_err_t led_strip_new_spi_device(const led_strip_config_t *led_config, const l
 #ifdef __cplusplus
 }
 #endif
-

--- a/test_app/CMakeLists.txt
+++ b/test_app/CMakeLists.txt
@@ -14,12 +14,7 @@ endif()
 
 # 3. Add here if the component is compatible with IDF >= v5.0
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
-    list(APPEND EXTRA_COMPONENT_DIRS ../bdc_motor ../sh2lib ../nghttp ../esp_serial_slave_link ../onewire_bus ../ccomp_timer)
-endif()
-
-# 4. Add here if the component is compatible with IDF >= v5.1
-if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.1")
-    list(APPEND EXTRA_COMPONENT_DIRS ../led_strip)
+    list(APPEND EXTRA_COMPONENT_DIRS ../bdc_motor ../led_strip ../sh2lib ../nghttp ../esp_serial_slave_link ../onewire_bus ../ccomp_timer)
 endif()
 
 # !This section should NOT be touched when adding new component!


### PR DESCRIPTION
Continue to the previous PR: https://github.com/espressif/idf-extra-components/pull/190

* Changed the dependency, now the led_strip still relies on the idf v5.0, instead of v5.1
* Updated the README to describe the new SPI backend usage and a diagram to help user choose which backend
