### PR TITLE
Update sh2lib component version. New version includes http2_request e…

### DIFF
--- a/sh2lib/CHANGELOG.md
+++ b/sh2lib/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.5
+
+- Added http2_request example in the component.

--- a/sh2lib/idf_component.yml
+++ b/sh2lib/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "1.0.5"
 description: HTTP2 TLS Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/sh2lib
 dependencies:


### PR DESCRIPTION
This PR updates the version of sh2lib component.
http2_request example was added in the component recently in PR: https://github.com/espressif/idf-extra-components/pull/193. Updating the version will make the example available through component registry.