### PR TITLE
fix(usb/hid): HID Host Driver v.1.0.1

### DIFF
--- a/usb/usb_host_hid/CHANGELOG.md
+++ b/usb/usb_host_hid/CHANGELOG.md
@@ -1,0 +1,12 @@
+## 1.0.1
+
+- Fixed a bug where configuring the driver with `create_background_task = false` did not properly initialize the driver. This lead to `the hid_host_uninstall()` hang-up.
+- Fixed bug where `hid_host_uninstall()` would cause a crash during the call while USB device has not been removed.
+- Added `hid_host_get_device_info()` to get the basic information of a connected USB HID device.
+
+## 1.0.0
+
+- Initial version
+
+
+

--- a/usb/usb_host_hid/CMakeLists.txt
+++ b/usb/usb_host_hid/CMakeLists.txt
@@ -1,3 +1,7 @@
 idf_component_register( SRCS "hid_host.c"
                         INCLUDE_DIRS "include"
 					    PRIV_REQUIRES usb )
+
+# We access packeted USB string descriptor via pointers. The memory used for storing the descritptors
+# allows unaligned access, so this is not an issue
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-address-of-packed-member)

--- a/usb/usb_host_hid/idf_component.yml
+++ b/usb/usb_host_hid/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: USB Host HID driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_hid
 
@@ -8,3 +8,4 @@ dependencies:
 targets:
   - esp32s2
   - esp32s3
+

--- a/usb/usb_host_hid/test/test_hid_basic.h
+++ b/usb/usb_host_hid/test/test_hid_basic.h
@@ -12,9 +12,15 @@
 extern "C" {
 #endif
 
+typedef enum {
+    HID_TEST_EVENT_HANDLE_IN_DRIVER = 0,
+    HID_TEST_EVENT_HANDLE_EXTERNAL
+} hid_test_event_handle_t;
+
 // ------------------------ HID Test -------------------------------------------
 
-void test_hid_setup(hid_host_driver_event_cb_t device_callback);
+void test_hid_setup(hid_host_driver_event_cb_t device_callback,
+                    hid_test_event_handle_t hid_test_event_handle);
 
 void test_hid_teardown(void);
 


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [X] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [X] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [X] _Optional:_ Component contains unit tests
- [X] CI passing

# Changelog
- Fixed a bug where configuring the driver with `create_background_task = false` did not properly initialize the driver. This lead to `the hid_host_uninstall()` hang-up.
- Fixed bug where `hid_host_uninstall()` would cause a crash during the call while USB device has not been removed.
- Added `hid_host_get_device_info()` to get the basic information of a connected USB HID device.

## Behavior description while create_background_task=false
### Brief description
Fix `hid_host_uninstall()` hanging during the closing while driver was installed with `create_background_task = false` configuration.
Unit test `class_specific_requests_with_external_polling` has been added to the test cases.

### Problem
When the `create_background_task = false` configuration is used, the `event_handler_task` is not being created. Thus, the `hid_host_handle_events()` should be called periodically to handle the call `usb_host_client_handle_events()` outside the HID driver.
After `hid_host_install()` with `create_background_task = false` the `usb_host_client_deregister()` will never be called and the semaphore `all_events_handled` will remain taken. 

### Solution
Adding the `hid_host_all_events_was_handled()` to deregister the usb client and unlock the semaphore. 

