### PR TITLE
Revert "Revert "json_parser: add idf_version rules for jsmn"" (IEC-29)

### DIFF
--- a/json_parser/idf_component.yml
+++ b/json_parser/idf_component.yml
@@ -1,14 +1,9 @@
-version: "1.0.2"
+version: "1.0.3"
 description: This is a simple, light weight JSON parser built on top of jsmn
 url: https://github.com/espressif/json_parser
 dependencies:
   jsmn:
     version: "~1.1"
-    # The "rules" entry is temporarily disabled, as idf-component-manager
-    # doesn't support uploading components with such entries to the registry.
-    # Re-enable this after the bug fix in idf-component-manager is released,
-    # and increase the component version to 1.0.3.
-    #
-    # rules:
-    #   - if: "idf_version >=5.0"
+    rules:
+      - if: "idf_version >=5.0"
     override_path: "../jsmn/"


### PR DESCRIPTION
This reverts commit 7b08cd0df5978e4cace8321d5cd9823c053e0c5d.

The idf component manager now supports uploading components with rules.

# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
This just reverts an earlier change which was added due to a bug in idf component manager, which did not allow external components to have "rules" in dependencies. Now that the bug is fixed, we can add back the rules.