### PR TITLE
feature/add reset_pre_error in pid_ctrl (IEC-30)

### DIFF
--- a/pid_ctrl/README.md
+++ b/pid_ctrl/README.md
@@ -1,3 +1,3 @@
 # Proportional integral derivative controller
 
-[![Component Registry](https://components.espressif.com/components/espressif/pcap/badge.svg)](https://components.espressif.com/components/espressif/pcap)
+[![Component Registry](https://components.espressif.com/components/espressif/pid_ctrl/badge.svg)](https://components.espressif.com/components/espressif/pid_ctrl)

--- a/pid_ctrl/idf_component.yml
+++ b/pid_ctrl/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.1"
+version: "0.2.0"
 description: Proportional-integral-derivative controller
 url: https://github.com/espressif/idf-extra-components/tree/master/pid_ctrl
 dependencies:

--- a/pid_ctrl/include/pid_ctrl.h
+++ b/pid_ctrl/include/pid_ctrl.h
@@ -95,6 +95,16 @@ esp_err_t pid_update_parameters(pid_ctrl_block_handle_t pid, const pid_ctrl_para
  */
 esp_err_t pid_compute(pid_ctrl_block_handle_t pid, float input_error, float *ret_result);
 
+/**
+ * @brief Reset the accumulation in pid_ctrl_block
+ *
+ * @param[in] pid PID control block handle, created by `pid_new_control_block()`
+ * @return
+ *      - ESP_OK: Reset successfully
+ *      - ESP_ERR_INVALID_ARG: Reset failed because of invalid argument
+ */
+esp_err_t pid_reset_ctrl_block(pid_ctrl_block_handle_t pid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pid_ctrl/src/pid_ctrl.c
+++ b/pid_ctrl/src/pid_ctrl.c
@@ -138,3 +138,13 @@ esp_err_t pid_update_parameters(pid_ctrl_block_handle_t pid, const pid_ctrl_para
     }
     return ESP_OK;
 }
+
+esp_err_t pid_reset_ctrl_block(pid_ctrl_block_handle_t pid)
+{
+    ESP_RETURN_ON_FALSE(pid, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    pid->integral_err = 0;
+    pid->previous_err1 = 0;
+    pid->previous_err2 = 0;
+    pid->last_output = 0;
+    return ESP_OK;
+}


### PR DESCRIPTION
There are occasions when it is necessary to reset the previously accumulated error (e.g. when the motor is stopped and then started again). This commit add a reset_pre_error function in pid_ctrl. And fix a hyperlink error in pid_ctrl README.md

Closes https://github.com/espressif/idf-extra-components/issues/203

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
