### PR TITLE
bugfix(esp_jpeg): fix example uploading failure

### DIFF
--- a/esp_jpeg/idf_component.yml
+++ b/esp_jpeg/idf_component.yml
@@ -3,6 +3,3 @@ description: "JPEG Decoder: TJpgDec"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_jpeg/
 dependencies:
   idf: ">=4.4"
-
-examples:
-  - path: examples/tjpgd


### PR DESCRIPTION
Sorry, I forgot to change the example path in the last PR, thus the CI still fails uploading the esp_jpeg example. https://github.com/espressif/idf-extra-components/actions/runs/5542032824/jobs/10116192367