### PR TITLE
esp_tinyusb: add MSC pre mount/unmount changed event and callback

### DIFF
--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,6 +1,6 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.3.0
+version: 1.3.1
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule


### PR DESCRIPTION
Add additional pre mount/unmount changed event and callback.
This will be delivered (if subscribed) BEFORE mount/unmount operation is started.
This will be helpful to the user who wants to be notified before the mount/unmount operation starts.
One such requirement is mentioned [here](https://esp32.com/viewtopic.php?f=13&t=34535).