### PR TITLE
check components in PRs

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -1,6 +1,11 @@
 name: Push components to Espressif Component Service
 
 on:
+  # For pull requests: perform upload with "--dry-run" argument,
+  # i.e. validate that the component passes all checks for being uploaded.
+  pull_request:
+
+  # For pushes to master: actually upload the components to the registry.
   push:
     branches:
       - master
@@ -12,6 +17,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+      - run: |
+          echo "${{ ( github.ref_name != 'master' || github.repository_owner != 'espressif' ) && 'Checking' || 'Uploading' }} components"
       - name: Upload components to component service
         uses: espressif/upload-components-ci-action@v1
         with:
@@ -65,4 +72,7 @@ jobs:
             zlib;
             libpng;
           namespace: "espressif"
+          # API token will only be available in the master branch in the main repository.
+          # However, dry-run doesn't require a valid token.
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
+          dry_run: ${{ github.ref_name != 'master' || github.repository_owner != 'espressif' }}


### PR DESCRIPTION
Verify components in PRs by running the upload action with --dry-run argument (based on https://github.com/espressif/upload-components-ci-action/pull/12)

Will hopefully prevent issues like https://github.com/espressif/idf-extra-components/pull/219 and https://github.com/espressif/idf-extra-components/pull/161.