### PR TITLE
refactor(led_strip): Remove the hack code (IEC-37)

### DIFF
--- a/led_strip/README.md
+++ b/led_strip/README.md
@@ -40,6 +40,8 @@ You can create multiple LED strip objects with different GPIOs and pixel numbers
 
 SPI peripheral can also be used to generate the timing required by the LED strip. However this backend is not as economical as the RMT one, because it will take up the whole **bus**, unlike the RMT just takes one **channel**. You **CANT** connect other devices to the same SPI bus if it's been used by the led_strip, because the led_strip doesn't have the concept of "Chip Select".
 
+Please note, the SPI backend has a dependency of **ESP-IDF >= 5.1**
+
 #### Allocate LED Strip Object with SPI Backend
 
 ```c

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.4.1"
+version: "2.4.2"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 dependencies:


### PR DESCRIPTION
Since the spi driver has fixed the idle level of MOSI. Remove the operation which controls the register.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
