### PR TITLE
feat: Add API to abort decryption process in esp_encrypted_img component

### DIFF
--- a/esp_encrypted_img/CHANGELOG.md
+++ b/esp_encrypted_img/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0
+
+### Enhancements:
+- Added an API to abort the decryption process: `esp_encrypted_img_decrypt_abort`
+- Added an API to check if the complete data has been received: `esp_encrypted_img_is_complete_data_received`
+
 ## 2.0.4
 
 - `rsa_pub_key` member of `esp_decrypt_cfg_t` structure is now deprecated. Please use `rsa_priv_key` instead. 

--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.4"
+version: "2.1.0"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/include/esp_encrypted_img.h
+++ b/esp_encrypted_img/include/esp_encrypted_img.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <stdbool.h>
 #include <esp_err.h>
 #include <esp_idf_version.h>
 
@@ -114,11 +115,42 @@ esp_err_t esp_encrypted_img_decrypt_data(esp_decrypt_handle_t ctx, pre_enc_decry
 *
 * @param[in]   ctx   esp_decrypt_handle_t handle
 *
+* @note This API cleans the decrypt handle and return ESP_FAIL if the complete data has not been decrypted. Verify if complete data
+*       has been decrypted using API `esp_encrypted_img_is_complete_data_received` to prevent an early call to this API.
+*
 * @return
-*    - ESP_FAIL    On failure
-*    - ESP_OK
+*    - ESP_FAIL                 On failure
+*    - ESP_ERR_INVALID_ARG      Invalid argument
+*    - ESP_OK                   Success
 */
 esp_err_t esp_encrypted_img_decrypt_end(esp_decrypt_handle_t ctx);
+
+/**
+* @brief  Checks if the complete data has been decrypted.
+*
+* @note This API checks if complete data has been supplied to `esp_encrypted_img_decrypt_data`. This can be used to prevent an early
+*       call to `esp_encrypted_img_decrypt_end` which cleans up the decrypt handle. If this API returns true, then call `esp_encrypted_img_decrypt_end`.
+*       If this API returns false, and there is some other error (like network error) due to which decryption process should be terminated,
+*       call `esp_encrypted_img_decrypt_abort` to clean up the handle.
+*
+* @param[in]  ctx   esp_decrypt_handle_t handle
+*
+* @return
+*     - true
+*     - false
+*/
+bool esp_encrypted_img_is_complete_data_received(esp_decrypt_handle_t ctx);
+
+/**
+* @brief  Abort the decryption process
+*
+* @param[in]   ctx   esp_decrypt_handle_t handle
+*
+* @return
+*    - ESP_ERR_INVALID_ARG  Invalid argument
+*    - ESP_OK               Success
+*/
+esp_err_t esp_encrypted_img_decrypt_abort(esp_decrypt_handle_t ctx);
 
 
 #ifdef __cplusplus

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -454,3 +454,23 @@ exit:
     free(handle);
     return err;
 }
+
+bool esp_encrypted_img_is_complete_data_received(esp_decrypt_handle_t ctx)
+{
+    esp_encrypted_img_t *handle = (esp_encrypted_img_t *)ctx;
+    return (handle != NULL && handle->binary_file_len == handle->binary_file_read);
+}
+
+esp_err_t esp_encrypted_img_decrypt_abort(esp_decrypt_handle_t ctx)
+{
+    esp_encrypted_img_t *handle = (esp_encrypted_img_t *)ctx;
+    if (handle == NULL) {
+        ESP_LOGE(TAG, "esp_encrypted_img_decrypt_data: Invalid argument");
+        return ESP_ERR_INVALID_ARG;
+    }
+    mbedtls_gcm_free(&handle->gcm_ctx);
+    free(handle->cache_buf);
+    free(handle->rsa_pem);
+    free(handle);
+    return ESP_OK;
+}


### PR DESCRIPTION
- Added an API to abort the decryption process in esp_encrypted_img: `esp_encrypted_img_decrypt_abort`
- Added an API to check if the complete data has been received: `esp_encrypted_img_is_complete_data_received`

