### PR TITLE
Add support for null class triple (IEC-40)

### DIFF
--- a/usb/usb_host_cdc_acm/CHANGELOG.md
+++ b/usb/usb_host_cdc_acm/CHANGELOG.md
@@ -12,3 +12,6 @@
 - Receive buffer has configurable size. This is useful if you expect data transfers larger then Maximum Packet Size.
 - Receive buffer has 'append' function. In the Data Received callback you can signal that you wait for more data and the current data were not yet processed. In this case, the CDC driver appends new data to the already received data. This is especially useful if the upper layer messages consist of multiple USB transfers and you don't want to waste more RAM and CPU copying the data around.
 
+## 2.0.1
+
+- Add support for USB "triple null" devices, which use USB interface association descriptors, but have Device Class, Device Subclass, and Device Protocol all set to 0x00, instead of 0xEF, 0x02, and 0x01 respectively. USB Standard reference: https://www.usb.org/defined-class-codes, Base Class 00h (Device) section.

--- a/usb/usb_host_cdc_acm/cdc_acm_host.c
+++ b/usb/usb_host_cdc_acm/cdc_acm_host.c
@@ -677,7 +677,7 @@ static esp_err_t cdc_acm_find_intf_and_ep_desc(cdc_dev_t *cdc_dev, uint8_t intf_
     if (((device_desc->bDeviceClass == USB_CLASS_MISC) && (device_desc->bDeviceSubClass == USB_SUBCLASS_COMMON) &&
             (device_desc->bDeviceProtocol == USB_DEVICE_PROTOCOL_IAD)) ||
             ((device_desc->bDeviceClass == USB_CLASS_PER_INTERFACE) && (device_desc->bDeviceSubClass == USB_SUBCLASS_NULL) &&
-            (device_desc->bDeviceProtocol == USB_PROTOCOL_NULL))) {
+             (device_desc->bDeviceProtocol == USB_PROTOCOL_NULL))) {
         // This is a composite device, that uses Interface Association Descriptor
         const usb_standard_desc_t *this_desc = (const usb_standard_desc_t *)config_desc;
         do {

--- a/usb/usb_host_cdc_acm/cdc_acm_host.c
+++ b/usb/usb_host_cdc_acm/cdc_acm_host.c
@@ -26,7 +26,7 @@ static const char *TAG = "cdc_acm";
 // @see USB Interface Association Descriptor: Device Class Code and Use Model rev 1.0, Table 1-1
 #define USB_SUBCLASS_NULL        0x00
 #define USB_SUBCLASS_COMMON        0x02
-#define USB_DEVICE_NULL    0x00
+#define USB_PROTOCOL_NULL    0x00
 #define USB_DEVICE_PROTOCOL_IAD    0x01
 
 // CDC-ACM spinlock

--- a/usb/usb_host_cdc_acm/idf_component.yml
+++ b/usb/usb_host_cdc_acm/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: "2.0.1"
 description: USB Host CDC-ACM driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_cdc_acm
 dependencies:


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
I have number of USB devices that are simple CDC-ACM "serial" devices, but present themselves with  bDeviceClass, bDeviceSubClass, and bDeviceProtocol set to 0x00, which according to the standard (https://www.usb.org/defined-class-codes, Base Class 00h (Device) section) indicates that class information should be determined from the interface descriptors. The implementation to detect the device with the null triple is virtually identical to the already existing IAD device detection.

This change extends the device interface detection to also recognize devices with null class triple.