### PR TITLE
Add a tinyusb_driver_uninstall to tinyusb.c (IEC-41)

### DIFF
--- a/usb/esp_tinyusb/include/tinyusb.h
+++ b/usb/esp_tinyusb/include/tinyusb.h
@@ -55,7 +55,7 @@ typedef struct {
  */
 esp_err_t tinyusb_driver_install(const tinyusb_config_t *config);
 
-// TODO esp_err_t tinyusb_driver_uninstall(void); (IDF-1474)
+esp_err_t tinyusb_driver_uninstall(void);
 
 #ifdef __cplusplus
 }

--- a/usb/esp_tinyusb/include/tusb_cdc_acm.h
+++ b/usb/esp_tinyusb/include/tusb_cdc_acm.h
@@ -113,6 +113,14 @@ typedef struct {
 esp_err_t tusb_cdc_acm_init(const tinyusb_config_cdcacm_t *cfg);
 
 /**
+ * @brief De-initialize CDC ACM.
+ *
+ * @param[in] itf Index of CDC interface
+ * @return esp_err_t
+ */
+esp_err_t tusb_cdc_acm_deinit(int itf);
+
+/**
  * @brief Register a callback invoking on CDC event. If the callback had been
  *        already registered, it will be overwritten
  *

--- a/usb/esp_tinyusb/tinyusb.c
+++ b/usb/esp_tinyusb/tinyusb.c
@@ -101,6 +101,7 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     return ESP_OK;
 }
 
-esp_err_t tinyusb_driver_uninstall() {
+esp_err_t tinyusb_driver_uninstall()
+{
     return usb_del_phy(phy_hdl);
 }

--- a/usb/esp_tinyusb/tinyusb.c
+++ b/usb/esp_tinyusb/tinyusb.c
@@ -100,3 +100,7 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config)
     ESP_LOGI(TAG, "TinyUSB Driver installed");
     return ESP_OK;
 }
+
+esp_err_t tinyusb_driver_uninstall() {
+    return usb_del_phy(phy_hdl);
+}

--- a/usb/esp_tinyusb/tusb_cdc_acm.c
+++ b/usb/esp_tinyusb/tusb_cdc_acm.c
@@ -327,6 +327,11 @@ fail:
     return ret;
 }
 
+esp_err_t tusb_cdc_acm_deinit(int itf)
+{
+    return tinyusb_cdc_deinit(itf);
+}
+
 bool tusb_cdc_acm_initialized(tinyusb_cdcacm_itf_t itf)
 {
     esp_tusb_cdcacm_t *acm = get_acm(itf);


### PR DESCRIPTION
This makes it possible for user code to work around the bug where the USB/JTAG interface cannot be re-initialized after calling `tinyusb_driver_install` even if the chip is restarted with `esp_restart` (https://github.com/espressif/esp-idf/issues/9826#issuecomment-1694089147).

Currently user code cannot do this without a modification to `tinyusb.c` since there's no way to access `static usb_phy_handle_t phy_hdl;` outside of that file.

With this change, user code can run the following to deactivate TinyUSB and bring back the USB/JTAG interface.

```
tinyusb_driver_uninstall();
usb_phy_config_t phy_conf = {
    .controller = USB_PHY_CTRL_SERIAL_JTAG,
};
usb_phy_handle_t jtag_phy;
usb_new_phy(&phy_conf, &jtag_phy);
```