### PR TITLE
Make max files configurable in tusb_msc_storage.c (IEC-44)

### DIFF
--- a/usb/esp_tinyusb/CHANGELOG.md
+++ b/usb/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1
+
+- MSC: Fix maximum files open
+- CDC-ACM: Add uninstall function
+
 ## 1.4.0
 
 - MSC: Fix integer overflows

--- a/usb/esp_tinyusb/CHANGELOG.md
+++ b/usb/esp_tinyusb/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.4.1
 
 - MSC: Fix maximum files open
-- CDC-ACM: Add uninstall function
+- Add uninstall function
 
 ## 1.4.0
 

--- a/usb/esp_tinyusb/CMakeLists.txt
+++ b/usb/esp_tinyusb/CMakeLists.txt
@@ -37,6 +37,7 @@ idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"
                        PRIV_INCLUDE_DIRS "include_private"
                        PRIV_REQUIRES usb
+                       REQUIRES fatfs vfs
                        REQUIRED_IDF_TARGETS esp32s2 esp32s3
                        )
 
@@ -51,15 +52,3 @@ endif()
 # Pass tusb_config.h from this component to TinyUSB
 idf_component_get_property(tusb_lib ${tinyusb_name} COMPONENT_LIB)
 target_include_directories(${tusb_lib} PRIVATE "include")
-
-# Link required libraries
-# This must be done after idf_component_register, because Kconfig values are not resolved before it
-if(CONFIG_TINYUSB_MSC_ENABLED)
-    idf_component_get_property(fatfs fatfs COMPONENT_LIB)
-    target_link_libraries(${COMPONENT_LIB} PRIVATE ${fatfs})
-endif()
-
-if((CONFIG_TINYUSB_CDC_ENABLED) AND (CONFIG_VFS_SUPPORT_IO))
-    idf_component_get_property(vfs vfs COMPONENT_LIB)
-    target_link_libraries(${COMPONENT_LIB} PUBLIC ${vfs})
-endif()

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,6 +1,6 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.4.0
+version: 1.4.1
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule

--- a/usb/esp_tinyusb/include/tusb_msc_storage.h
+++ b/usb/esp_tinyusb/include/tusb_msc_storage.h
@@ -59,7 +59,7 @@ typedef struct {
     sdmmc_card_t *card;                             /*!< Pointer to sdmmc card configuration structure */
     tusb_msc_callback_t callback_mount_changed;     /*!< Pointer to the function callback that will be delivered AFTER mount/unmount operation is successfully finished */
     tusb_msc_callback_t callback_premount_changed;  /*!< Pointer to the function callback that will be delivered BEFORE mount/unmount operation is started */
-    const esp_vfs_fat_mount_config_t *mount_config; /*!< Pointer to the FATFS mount config */
+    const esp_vfs_fat_mount_config_t mount_config; /*!< FATFS mount config */
 } tinyusb_msc_sdmmc_config_t;
 #endif
 
@@ -73,7 +73,7 @@ typedef struct {
     wl_handle_t wl_handle;                          /*!< Pointer to spiflash wera-levelling handle */
     tusb_msc_callback_t callback_mount_changed;     /*!< Pointer to the function callback that will be delivered AFTER mount/unmount operation is successfully finished */
     tusb_msc_callback_t callback_premount_changed;  /*!< Pointer to the function callback that will be delivered BEFORE mount/unmount operation is started */
-    const esp_vfs_fat_mount_config_t *mount_config; /*!< Pointer to the FATFS mount config */
+    const esp_vfs_fat_mount_config_t mount_config; /*!< FATFS mount config */
 } tinyusb_msc_spiflash_config_t;
 
 /**

--- a/usb/esp_tinyusb/include/tusb_msc_storage.h
+++ b/usb/esp_tinyusb/include/tusb_msc_storage.h
@@ -13,6 +13,7 @@ extern "C" {
 #include <stddef.h>
 #include "esp_err.h"
 #include "wear_levelling.h"
+#include "esp_vfs_fat.h"
 #if SOC_SDMMC_HOST_SUPPORTED
 #include "driver/sdmmc_host.h"
 #endif
@@ -58,6 +59,7 @@ typedef struct {
     sdmmc_card_t *card;                             /*!< Pointer to sdmmc card configuration structure */
     tusb_msc_callback_t callback_mount_changed;     /*!< Pointer to the function callback that will be delivered AFTER mount/unmount operation is successfully finished */
     tusb_msc_callback_t callback_premount_changed;  /*!< Pointer to the function callback that will be delivered BEFORE mount/unmount operation is started */
+    const esp_vfs_fat_mount_config_t *mount_config; /*!< Pointer to the FATFS mount config */
 } tinyusb_msc_sdmmc_config_t;
 #endif
 
@@ -71,6 +73,7 @@ typedef struct {
     wl_handle_t wl_handle;                          /*!< Pointer to spiflash wera-levelling handle */
     tusb_msc_callback_t callback_mount_changed;     /*!< Pointer to the function callback that will be delivered AFTER mount/unmount operation is successfully finished */
     tusb_msc_callback_t callback_premount_changed;  /*!< Pointer to the function callback that will be delivered BEFORE mount/unmount operation is started */
+    const esp_vfs_fat_mount_config_t *mount_config; /*!< Pointer to the FATFS mount config */
 } tinyusb_msc_spiflash_config_t;
 
 /**

--- a/usb/esp_tinyusb/tusb_msc_storage.c
+++ b/usb/esp_tinyusb/tusb_msc_storage.c
@@ -419,7 +419,7 @@ esp_err_t tinyusb_msc_storage_init_sdmmc(const tinyusb_msc_sdmmc_config_t *confi
     s_storage_handle->is_fat_mounted = false;
     s_storage_handle->base_path = NULL;
     s_storage_handle->card = config->card;
-    s_storage_handle->max_files = mount_config->max_files;
+    s_storage_handle->max_files = config->mount_config.max_files;
 
     /* Callbacks setting up*/
     if (config->callback_mount_changed) {

--- a/usb/esp_tinyusb/tusb_msc_storage.c
+++ b/usb/esp_tinyusb/tusb_msc_storage.c
@@ -387,7 +387,7 @@ esp_err_t tinyusb_msc_storage_init_spiflash(const tinyusb_msc_spiflash_config_t 
     s_storage_handle->is_fat_mounted = false;
     s_storage_handle->base_path = NULL;
     s_storage_handle->wl_handle = config->wl_handle;
-    s_storage_handle->max_files = mount_config->max_files;
+    s_storage_handle->max_files = config->mount_config.max_files;
 
     /* Callbacks setting up*/
     if (config->callback_mount_changed) {

--- a/usb/esp_tinyusb/tusb_msc_storage.c
+++ b/usb/esp_tinyusb/tusb_msc_storage.c
@@ -41,7 +41,7 @@ typedef struct {
     esp_err_t (*write)(size_t sector_size, size_t addr, uint32_t lba, uint32_t offset, size_t size, const void *src);
     tusb_msc_callback_t callback_mount_changed;
     tusb_msc_callback_t callback_premount_changed;
-    const esp_vfs_fat_mount_config_t *mount_config;
+    int max_files;
 } tinyusb_msc_storage_handle_s; /*!< MSC object */
 
 /* handle of tinyusb driver connected to application */
@@ -282,7 +282,7 @@ esp_err_t tinyusb_msc_storage_mount(const char *base_path)
     ESP_GOTO_ON_ERROR((s_storage_handle->mount)(pdrv), fail, TAG, "Failed pdrv=%d", pdrv);
 
     FATFS *fs = NULL;
-    ret = esp_vfs_fat_register(base_path, drv, s_storage_handle->mount_config->max_files, &fs);
+    ret = esp_vfs_fat_register(base_path, drv, s_storage_handle->max_files, &fs);
     if (ret == ESP_ERR_INVALID_STATE) {
         ESP_LOGD(TAG, "it's okay, already registered with VFS");
     } else if (ret != ESP_OK) {
@@ -387,7 +387,7 @@ esp_err_t tinyusb_msc_storage_init_spiflash(const tinyusb_msc_spiflash_config_t 
     s_storage_handle->is_fat_mounted = false;
     s_storage_handle->base_path = NULL;
     s_storage_handle->wl_handle = config->wl_handle;
-    s_storage_handle->mount_config = config->mount_config;
+    s_storage_handle->max_files = mount_config->max_files;
 
     /* Callbacks setting up*/
     if (config->callback_mount_changed) {
@@ -419,7 +419,7 @@ esp_err_t tinyusb_msc_storage_init_sdmmc(const tinyusb_msc_sdmmc_config_t *confi
     s_storage_handle->is_fat_mounted = false;
     s_storage_handle->base_path = NULL;
     s_storage_handle->card = config->card;
-    s_storage_handle->mount_config = config->mount_config;
+    s_storage_handle->max_files = mount_config->max_files;
 
     /* Callbacks setting up*/
     if (config->callback_mount_changed) {


### PR DESCRIPTION
This change makes maximum open files configurable. Currently it is set to 2.

Closes https://github.com/espressif/idf-extra-components/issues/217