### PR TITLE
USB Host MSC v1.1.1

### DIFF
--- a/usb/usb_host_msc/CHANGELOG.md
+++ b/usb/usb_host_msc/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix `msc_host_get_device_info` for devices without Serial Number string descriptor https://github.com/espressif/esp-idf/issues/12163
 - Fix regression from version 1.1.0 that files could not be opened in PSRAM https://github.com/espressif/idf-extra-components/issues/202
+- Fix MSC driver event handling without background task
 
 ## 1.1.0 - yanked
 

--- a/usb/usb_host_msc/CHANGELOG.md
+++ b/usb/usb_host_msc/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.1
 
 - Fix `msc_host_get_device_info` for devices without Serial Number string descriptor https://github.com/espressif/esp-idf/issues/12163
+- Fix regression from version 1.1.0 that files could not be opened in PSRAM https://github.com/espressif/idf-extra-components/issues/202
 
 ## 1.1.0 - yanked
 

--- a/usb/usb_host_msc/CHANGELOG.md
+++ b/usb/usb_host_msc/CHANGELOG.md
@@ -1,23 +1,27 @@
-## 1.0.0
+## 1.1.1
 
-- Initial version
+- Fix `msc_host_get_device_info` for devices without Serial Number string descriptor https://github.com/espressif/esp-idf/issues/12163
 
-## 1.0.1
-
-- Fix compatibility with IDF v4.4
-
-## 1.0.2
-
-- Increase transfer timeout to 5 seconds to handle slower flash disks
-
-## 1.0.4
-
-- Claim support for USB composite devices
-
-## 1.1.0
+## 1.1.0 - yanked
 
 - Significantly increase performance with Virtual File System by allowing longer transfers
 - Optimize used heap memory by reusing the Virtual File System buffer
 - Optimize CPU usage by putting the background MSC task to 'Blocked' state indefinitely when there is nothing to do
 - Fix MSC commands for devices on interface numbers other than zero
 - Replace unsafe debug functions for direct access of MSC sectors with private SCSI commands
+
+## 1.0.4
+
+- Claim support for USB composite devices
+
+## 1.0.2
+
+- Increase transfer timeout to 5 seconds to handle slower flash disks
+
+## 1.0.1
+
+- Fix compatibility with IDF v4.4
+
+## 1.0.0
+
+- Initial version

--- a/usb/usb_host_msc/CMakeLists.txt
+++ b/usb/usb_host_msc/CMakeLists.txt
@@ -6,7 +6,8 @@ set(sources src/msc_scsi_bot.c
 idf_component_register( SRCS ${sources}
                         INCLUDE_DIRS include include/usb # 'include/usb' is here for backwards compatibility
                         PRIV_INCLUDE_DIRS private_include include/esp_private
-                        REQUIRES usb fatfs )
+                        REQUIRES usb fatfs
+                        PRIV_REQUIRES heap )
 
 # We access packeted USB string descriptor via pointers. The memory used for storing the descritptors
 # allows unaligned access, so this is not an issue

--- a/usb/usb_host_msc/README.md
+++ b/usb/usb_host_msc/README.md
@@ -4,7 +4,7 @@
 
 This directory contains an implementation of a USB Mass Storage Class Driver implemented on top of the [USB Host Library](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_host.html).
 
-MSC driver allows access to USB flash drivers using the BOT “Bulk-Only Transport” protocol and the Transparent SCSI command set.
+MSC driver allows access to USB flash drivers using the BOT (Bulk-Only Transport) protocol and the Transparent SCSI command set.
 
 ## Usage
 
@@ -22,12 +22,21 @@ MSC driver allows access to USB flash drivers using the BOT “Bulk-Only Transpo
   with `from usb_msc_get_device_info` function.
 - Obtained device handle is then used in helper function `usb_msc_vfs_register` mounting USB Disk to Virtual filesystem.
 - At this point, standard C functions for accessing storage (`fopen`, `fwrite`, `fread`, `mkdir` etc.) can be carried out.
-- In order to uninstall the whole USB stack, deinitializing counterparts to functions above has to be called in reverse order. 
+- In order to uninstall the whole USB stack, deinitializing counterparts to functions above has to be called in reverse order.
+
+## Performance tuning
+
+The following performance tuning options have significant impact on data throughput in USB HighSpeed implementations.
+For original FullSpeed implementations, the effects are negligible.
+- By default, Newlib (the implementation of C Standard Library) creates cache for each opened file
+- The greater the cache, the better performance for the cost of RAM
+- Size of the cache can be set with C STD library function `setvbuf()`
+- Sizes over 16kB do not improve the performance any more
 
 ## Known issues
 
-- Driver only supports USB 2.0 flash drives using the BOT “Bulk-Only Transport” protocol and the Transparent SCSI command set
+- Driver only supports flash drives using the BOT (Bulk-Only Transport) protocol and the Transparent SCSI command set
 
 ## Examples
 
-- For an example, refer to [msc_host_example](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/msc)
+- For an example, refer to [msc_host_example](https://github.com/espressif/esp-idf/tree/master/examples/peripherals/usb/host/msc) in ESP-IDF

--- a/usb/usb_host_msc/idf_component.yml
+++ b/usb/usb_host_msc/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.1"
 description: USB Host MSC driver
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/usb_host_msc
 

--- a/usb/usb_host_msc/include/usb/msc_host.h
+++ b/usb/usb_host_msc/include/usb/msc_host.h
@@ -142,10 +142,17 @@ __attribute__((deprecated("use API from esp_private/msc_scsi_bot.h")));
 /**
  * @brief Handle MSC HOST events.
  *
- * @param[in]  timeout_ms  Timeout in miliseconds
- * @return esp_err_t
+ * If MSC Host install was called with create_background_task=false configuration,
+ * application needs to handle USB Host events itself.
+ * Do not call this function if MSC host install was called with create_background_task=true configuration
+ *
+ * @param[in]  timeout  Timeout in FreeRTOS tick
+ * @return
+ *     - ESP_OK:          All events handled
+ *     - ESP_ERR_TIMEOUT: No events handled within the timeout
+ *     - ESP_FAIL:        Event handling finished, driver uninstalled. You do not have to call this function further
  */
-esp_err_t msc_host_handle_events(uint32_t timeout_ms);
+esp_err_t msc_host_handle_events(uint32_t timeout);
 
 /**
  * @brief Gets devices information.
@@ -171,8 +178,8 @@ esp_err_t msc_host_print_descriptors(msc_host_device_handle_t device);
  *
  * @param[in] device Handle of MSC device
  * @return
- *       - ESP_OK:  The device was recovered from reset
- *       - ESP_FAI: Recovery unsuccessful, might indicate broken device
+ *       - ESP_OK:   The device was recovered from reset
+ *       - ESP_FAIL: Recovery unsuccessful, might indicate broken device
  */
 esp_err_t msc_host_reset_recovery(msc_host_device_handle_t device);
 

--- a/usb/usb_host_msc/private_include/msc_common.h
+++ b/usb/usb_host_msc/private_include/msc_common.h
@@ -45,14 +45,15 @@ typedef struct msc_host_device {
  * @brief Trigger a BULK transfer to device: zero copy
  *
  * Data buffer ownership is transferred to the MSC driver and the application cannot access it before the transfer finishes.
- * The buffer must be DMA capable, as it is going to be accessed by USB DMA.
+ * This function is true zero-copy only if the passed data buffer is in DMA capable memory, as the USB Host uses DMA transfers.
+ * If the buffer is NOT DMA capable, an intermediate DMA capable buffer is allocated and used for the transfer, resulting in memory coping.
  *
- * This function significantly improves performance with usage of Virtual File System, which creates a intermediate buffer for each opened file.
- * The intermediate VFS buffer is then used for USB transfers too, which eliminates need of 2 large buffers and unnecessary copying of the data.
- * The user can set size of the VFS buffer with setvbuf() function.
+ * This function significantly improves performance with C Standard Library, which creates its own buffer for each opened file.
+ * The STD lib buffer is then used for USB transfers too, which eliminates need of 2 large buffers and unnecessary copying of the data.
+ * The user can set size of the buffer with setvbuf() function.
  *
  * @param[in]    device_handle MSC device handle
- * @param[inout] data          Data buffer. Direction depends on 'ep'. Must be DMA capable.
+ * @param[inout] data          Data buffer. Direction depends on 'ep'.
  * @param[in]    size          Size of buffer in bytes
  * @param[in]    ep            Direction of the transfer
  * @return esp_err_t
@@ -70,6 +71,13 @@ esp_err_t msc_bulk_transfer_zcpy(msc_device_t *device_handle, uint8_t *data, siz
  */
 esp_err_t msc_control_transfer(msc_device_t *device_handle, size_t len);
 
+/**
+ * @brief Reset endpoint and clear feature
+ *
+ * @param[in] device   MSC device handle
+ * @param[in] endpoint Endpoint number
+ * @return esp_err_t
+ */
 esp_err_t clear_feature(msc_device_t *device, uint8_t endpoint);
 
 #define MSC_GOTO_ON_ERROR(exp) ESP_GOTO_ON_ERROR(exp, fail, TAG, "")

--- a/usb/usb_host_msc/test/msc_device.c
+++ b/usb/usb_host_msc/test/msc_device.c
@@ -82,8 +82,9 @@ static char const *string_desc_arr[] = {
     (const char[]) { 0x09, 0x04 },  // 0: is supported language is English (0x0409)
     "TinyUSB",                      // 1: Manufacturer
     "TinyUSB Device",               // 2: Product
-    "123456",                       // 3: Serials
-    "Test MSC",                  // 4. MSC
+    // We intentionally do not implement Serial String descriptor to make sure that the driver can handle it
+    //"123456",                       // 3: Serials
+    //"Test MSC",                  // 4. MSC
 };
 #endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) */
 /*********************************************************************** TinyUSB descriptors*/

--- a/usb/usb_host_msc/test/test_msc.c
+++ b/usb/usb_host_msc/test/test_msc.c
@@ -8,6 +8,7 @@
 #include "unity.h"
 #include <string.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include "esp_private/usb_phy.h"
 #include "esp_private/msc_scsi_bot.h"
 #include "usb/usb_host.h"
@@ -418,6 +419,38 @@ TEST_CASE("can_be_formated", "[usb_msc]")
     TEST_ASSERT_FALSE(file_exists(FILE_NAME));
     msc_teardown();
     mount_config.format_if_mount_failed = false;
+}
+
+static void print_device_info(msc_host_device_info_t *info)
+{
+    const size_t megabyte = 1024 * 1024;
+    uint64_t capacity = ((uint64_t)info->sector_size * info->sector_count) / megabyte;
+
+    printf("Device info:\n");
+    printf("\t Capacity: %llu MB\n", capacity);
+    printf("\t Sector size: %"PRIu32"\n", info->sector_size);
+    printf("\t Sector count: %"PRIu32"\n", info->sector_count);
+    printf("\t PID: 0x%4X \n", info->idProduct);
+    printf("\t VID: 0x%4X \n", info->idVendor);
+    wprintf(L"\t iProduct: %S \n", info->iProduct);
+    wprintf(L"\t iManufacturer: %S \n", info->iManufacturer);
+    wprintf(L"\t iSerialNumber: %S \n", info->iSerialNumber);
+}
+
+/**
+ * @brief USB MSC device_info testcase
+ *
+ * Simple testcase that only runs msc_host_get_device_info()
+ * To make sure that we correctly handle missing string descriptors
+ */
+TEST_CASE("device_info", "[usb_msc]")
+{
+    msc_setup();
+    msc_host_device_info_t info;
+    esp_err_t err = msc_host_get_device_info(device, &info);
+    msc_teardown();
+    TEST_ASSERT_EQUAL(ESP_OK, err);
+    print_device_info(&info);
 }
 
 /**


### PR DESCRIPTION
# Change description

* Correctly handle empty string descriptors
* Move data buffer to DMA capable memory, if non-capable memory is passed to the driver

PTAL @Dazza0 @roma-jam 
cc @leeebo @lijunru-hub @Maldus512 @0727fqh @f1andrew

Closes https://github.com/espressif/esp-idf/issues/12163
Closes https://github.com/espressif/idf-extra-components/issues/202
Closes https://github.com/espressif/esp-idf/issues/12142