### PR TITLE
feat(esp_encrypted_img): feature added to get header size which helps… (IEC-45)

### DIFF
--- a/esp_encrypted_img/CHANGELOG.md
+++ b/esp_encrypted_img/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0
+
+### Enhancements:
+- Added an API to get the size of pre encrypted binary image header, this could be useful while computing entire decrypted image length: `esp_encrypted_img_get_header_size`
+
 ## 2.1.0
 
 ### Enhancements:

--- a/esp_encrypted_img/idf_component.yml
+++ b/esp_encrypted_img/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.1.0"
+version: "2.2.0"
 description: ESP Encrypted Image Abstraction Layer
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_encrypted_img
 dependencies:

--- a/esp_encrypted_img/include/esp_encrypted_img.h
+++ b/esp_encrypted_img/include/esp_encrypted_img.h
@@ -152,6 +152,16 @@ bool esp_encrypted_img_is_complete_data_received(esp_decrypt_handle_t ctx);
 */
 esp_err_t esp_encrypted_img_decrypt_abort(esp_decrypt_handle_t ctx);
 
+/**
+* @brief  Get the size of pre encrypted binary image header (`struct pre_enc_bin_header`). The initial header in
+*         the image contains magic, credentials (symmetric key) and few other parameters. This API could be useful
+*         for scenarios where the entire decrypted image length must be computed by the application including the 
+*         image header.  
+*
+* @return
+*    - Header size of pre encrypted image
+*/
+uint16_t esp_encrypted_img_get_header_size(void);
 
 #ifdef __cplusplus
 }

--- a/esp_encrypted_img/src/esp_encrypted_img.c
+++ b/esp_encrypted_img/src/esp_encrypted_img.c
@@ -474,3 +474,8 @@ esp_err_t esp_encrypted_img_decrypt_abort(esp_decrypt_handle_t ctx)
     free(handle);
     return ESP_OK;
 }
+
+uint16_t esp_encrypted_img_get_header_size(void)
+{
+    return HEADER_DATA_SIZE;
+}


### PR DESCRIPTION

# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)

# Change description
This MR added the API to get the header size which helps in decryption during pre_encrypted_ota. This header size is helpful to check whether the complete image has been received or not during pre_encypted_ota and partial HTTP download config is set. 
