### PR TITLE
feat: add sbom manifest files for 3rd party libraries (IEC-50)

### DIFF
--- a/.github/workflows/test_sbom.yml
+++ b/.github/workflows/test_sbom.yml
@@ -1,4 +1,4 @@
-name: Run SBOM submodule test
+name: Run SBOM manifests validation test
 
 on:
   pull_request:
@@ -6,13 +6,11 @@ on:
 
 jobs:
   test_sbom:
-    name: Run SBOM submodule test
-    runs-on: ubuntu-20.04
-    container: espressif/idf:latest
+    name: Run SBOM manifests validation test
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: 'true'
       - run: |
           git config --global safe.directory $(pwd)
-          python3 ${IDF_PATH}/tools/test_sbom/test_submodules.py
+          pip install esp-idf-sbom
+          python3 -m esp_idf_sbom manifest validate

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,101 +1,50 @@
-# Submodules SBOM information
-# ---------------------------
-# Submodules, which are used directly and not forked into espressif namespace should
-# contain SBOM information here. Other submodules should have the SBOM manifest file
-# included in the root of their project's repository.
-#
-# The sbom-hash entry records the submodule's checkout SHA as presented in git-tree
-# commit object. For example expat submodule:
-#
-# $ git ls-tree HEAD expat/expat
-# 160000 commit 454c6105bc2d0ea2521b8f8f7a5161c2abd8c386	expat/expat
-#
-# The hash can be also obtained with git submodule command
-#
-# $ git submodule status expat/expat/
-# 454c6105bc2d0ea2521b8f8f7a5161c2abd8c386 expat/expat (R_2_4_9-49-g454c6105)
-#
-# The submodule SHA recorded here has to match with SHA, which is presented in git-tree.
-# This is checked by CI. Also please don't forget to update the submodule version
-# if you are changing the sbom-hash. This is important for SBOM generation.
-
 [submodule "libsodium/libsodium"]
 	path = libsodium/libsodium
 	url = https://github.com/jedisct1/libsodium.git
+
 [submodule "cbor/tinycbor"]
 	path = cbor/tinycbor
 	url = https://github.com/intel/tinycbor.git
+
 [submodule "nghttp/nghttp2"]
 	path = nghttp/nghttp2
 	url = https://github.com/nghttp2/nghttp2.git
-	sbom-version = 1.52.0
-	sbom-cpe = cpe:2.3:a:nghttp2:nghttp2:{}:*:*:*:*:*:*:*
-	sbom-supplier = Organization: nghttp2 <https://nghttp2.org/
-	sbom-url = https://github.com/nghttp2/nghttp2
-	sbom-description = nghttp2 - HTTP/2 C Library and tools
-	sbom-hash = be0491294a63d891bd12b6b1b7e372a45a5d0ffe
 
 [submodule "expat/expat"]
 	path = expat/expat
 	url = https://github.com/libexpat/libexpat.git
-	sbom-version = 2.5.0
-	sbom-cpe = cpe:2.3:a:libexpat_project:libexpat:{}:*:*:*:*:*:*:*
-	sbom-supplier = Organization: libexpat_project
-	sbom-url = https://github.com/libexpat/libexpat/
-	sbom-description = Fast streaming XML parser written in C99
-	sbom-hash = 454c6105bc2d0ea2521b8f8f7a5161c2abd8c386
 
 [submodule "coap/libcoap"]
 	path = coap/libcoap
 	url = https://github.com/obgm/libcoap.git
-	sbom-version = 4.3.2
-	sbom-cpe = cpe:2.3:a:libcoap:libcoap:{}:*:*:*:*:*:*:*
-	sbom-supplier = Organization: libcoap <https://libcoap.net/>
-	sbom-url = https://github.com/obgm/libcoap
-	sbom-description = A CoAP (RFC 7252) implementation in C
-	sbom-hash = 3f8bb33807f521e9a5bbddddb0fe002f60b78a68
 
 [submodule "usb/usb_host_uvc/libuvc"]
 	path = usb/usb_host_uvc/libuvc
 	url = https://github.com/libuvc/libuvc.git
+
 [submodule "eigen/eigen"]
 	path = eigen/eigen
 	url = https://gitlab.com/libeigen/eigen.git
+
 [submodule "fmt/fmt"]
 	path = fmt/fmt
 	url = https://github.com/fmtlib/fmt.git
-	sbom-version = 10.1.0
-	sbom-cpe = cpe:2.3:a:fmt:fmt:{}:*:*:*:*:*:*:*
-	sbom-supplier = Organization: fmt <https://fmt.dev/latest/index.html>
-	sbom-url = https://github.com/fmtlib/fmt/
-	sbom-description = A modern formatting library
-	sbom-hash = e57ca2e3685b160617d3d95fcd9e789c4e06ca88
 
 [submodule "esp_delta_ota/detools"]
 	path = esp_delta_ota/detools
 	url = https://github.com/eerimoq/detools.git
+
 [submodule "quirc/quirc"]
 	path = quirc/quirc
 	url = https://github.com/dlbeer/quirc.git
+
 [submodule "zlib/zlib"]
 	path = zlib/zlib
 	url = https://github.com/madler/zlib.git
-	sbom-version = 1.2.13
-	sbom-cpe = cpe:2.3:a:zlib:zlib:{}:*:*:*:*:*:*:*
-	sbom-supplier = Organization: zlib <http://www.zlib.net/>
-	sbom-url = https://github.com/madler/zlib.git
-	sbom-description = A massively spiffy yet delicately unobtrusive compression library
-	sbom-hash = 04f42ceca40f73e2978b50e93806c2a18c1281fc
 
 [submodule "libpng/libpng"]
 	path = libpng/libpng
 	url = https://github.com/glennrp/libpng.git
-	sbom-version = 1.6.39
-	sbom-cpe = cpe:2.3:a:libpng:libpng:{}:*:*:*:*:*:*:*
-	sbom-supplier = Organization: libpng
-	sbom-url = https://github.com/glennrp/libpng.git
-	sbom-description = Portable Network Graphics support, official PNG reference library
-	sbom-hash = 07b8803110da160b158ebfef872627da6c85cbdf
 
 [submodule "coremark/coremark"]
 	path = coremark/coremark
@@ -104,20 +53,7 @@
 [submodule "freetype/freetype"]
 	path = freetype/freetype
 	url = https://github.com/freetype/freetype.git
-	sbom-version = 2.13.0
-	sbom-cpe = cpe:2.3:a:freetype:freetype:{}:*:*:*:*:*:*:*
-	sbom-supplier = Organization: freetype <https://www.freetype.org>
-	sbom-url = https://github.com/freetype/freetype.git
-	sbom-description = FreeType is a software font engine
-	sbom-hash = de8b92dd7ec634e9e2b25ef534c54a3537555c11
 
 [submodule "catch2/Catch2"]
 	path = catch2/Catch2
 	url = https://github.com/catchorg/Catch2.git
-	sbom-version = 3.4.0
-	sbom-cpe = cpe:2.3:a:catchorg:catch2:{}:*:*:*:*:*:*:*
-	sbom-supplier = Organization: catchorg <https://github.com/catchorg>
-	sbom-url = https://github.com/catchorg/Catch2
-	sbom-description = A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
-	sbom-hash = 6e79e682b726f524310d55dec8ddac4e9c52fb5f
-

--- a/catch2/idf_component.yml
+++ b/catch2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.4.0"
+version: "3.4.0~1"
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/espressif/idf-extra-components/tree/master/catch2
 repository: https://github.com/espressif/idf-extra-components.git
@@ -8,3 +8,7 @@ dependencies:
   # Mostly because in older IDF versions there was no WHOLE_ARCHIVE component property,
   # so linking all the test cases in a component was a bit hard.
   idf: ">=5.0.0"
+sbom:
+  manifests:
+    - path: sbom_catch2.yml
+      dest: Catch2

--- a/catch2/sbom_catch2.yml
+++ b/catch2/sbom_catch2.yml
@@ -1,0 +1,8 @@
+name: catch2
+version: 3.4.0
+cpe: cpe:2.3:a:catchorg:catch2:{}:*:*:*:*:*:*:*
+supplier: 'Organization: catchorg <https://github.com/catchorg>'
+description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
+url: https://github.com/catchorg/Catch2
+hash: 6e79e682b726f524310d55dec8ddac4e9c52fb5f
+

--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,5 +1,9 @@
-version: "4.3.2~1-rc.1"
+version: "4.3.2~1-rc.2"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:
   idf: ">=4.4"
+sbom:
+  manifests:
+    - path: sbom_libcoap.yml
+      dest: libcoap

--- a/coap/sbom_libcoap.yml
+++ b/coap/sbom_libcoap.yml
@@ -1,0 +1,9 @@
+name: libcoap
+version: 4.3.2
+cpe: cpe:2.3:a:libcoap:libcoap:{}:*:*:*:*:*:*:*
+supplier: 'Organization: libcoap <https://libcoap.net/>'
+description: A CoAP (RFC 7252) implementation in C
+url: https://github.com/obgm/libcoap
+hash: 3f8bb33807f521e9a5bbddddb0fe002f60b78a68
+
+

--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,5 +1,9 @@
-version: "2.5.0"
+version: "2.5.0~1"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:
   idf: ">=4.3"
+sbom:
+  manifests:
+    - path: sbom_libexpat.yml
+      dest: expat

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -1,0 +1,7 @@
+name: libexpat
+version: 2.5.0
+cpe: cpe:2.3:a:libexpat_project:libexpat:{}:*:*:*:*:*:*:*
+supplier: 'Organization: libexpat_project'
+description: Fast streaming XML parser written in C99
+url: https://github.com/libexpat/libexpat/
+hash: 454c6105bc2d0ea2521b8f8f7a5161c2abd8c386

--- a/fmt/idf_component.yml
+++ b/fmt/idf_component.yml
@@ -1,5 +1,9 @@
-version: "10.1.0"
+version: "10.1.0~1"
 description: Formatting library providing a fast and safe alternative to C stdio and C++ iostreams.
 url: https://github.com/espressif/idf-extra-components/tree/master/fmt
 dependencies:
   idf: ">=4.1"
+sbom:
+  manifests:
+    - path: sbom_fmt.yml
+      dest: fmt

--- a/fmt/sbom_fmt.yml
+++ b/fmt/sbom_fmt.yml
@@ -1,0 +1,7 @@
+name: fmt
+version: 10.1.0
+cpe: cpe:2.3:a:fmt:fmt:{}:*:*:*:*:*:*:*
+supplier: 'Organization: fmt <https://fmt.dev/latest/index.html>'
+description: A modern formatting library
+url: https://github.com/fmtlib/fmt/
+hash: e57ca2e3685b160617d3d95fcd9e789c4e06ca88

--- a/freetype/idf_component.yml
+++ b/freetype/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.13.0"
+version: "2.13.0~1"
 description: freetype C library
 url: https://github.com/espressif/idf-extra-components/tree/master/freetype
 repository: "https://github.com/espressif/idf-extra-components.git"
@@ -6,3 +6,7 @@ documentation: "https://freetype.org/freetype2/docs/documentation.html"
 issues: "https://github.com/espressif/idf-extra-components/issues" # URL of the issue tracker
 dependencies:
   idf: ">=4.4"
+sbom:
+  manifests:
+    - path: sbom_freetype.yml
+      dest: freetype

--- a/freetype/sbom_freetype.yml
+++ b/freetype/sbom_freetype.yml
@@ -1,0 +1,7 @@
+name: freetype
+version: 2.13.0
+cpe: cpe:2.3:a:freetype:freetype:{}:*:*:*:*:*:*:*
+supplier: 'Organization: freetype <https://www.freetype.org>'
+description: FreeType is a software font engine
+url: https://github.com/freetype/freetype
+hash: de8b92dd7ec634e9e2b25ef534c54a3537555c11

--- a/libpng/idf_component.yml
+++ b/libpng/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.6.39"
+version: "1.6.39~1"
 description: Portable Network Graphics(png) C library
 url: https://github.com/espressif/idf-extra-components/tree/master/libpng
 repository: "https://github.com/espressif/idf-extra-components.git"
@@ -9,3 +9,7 @@ dependencies:
   zlib:
     version: "^1.2.13"
     override_path: "../zlib"
+sbom:
+  manifests:
+    - path: sbom_libpng.yml
+      dest: libpng

--- a/libpng/sbom_libpng.yml
+++ b/libpng/sbom_libpng.yml
@@ -1,0 +1,7 @@
+name: libpng
+version: 1.6.39
+cpe: cpe:2.3:a:libpng:libpng:{}:*:*:*:*:*:*:*
+supplier: 'Organization: libpng'
+description: Portable Network Graphics support, official PNG reference library
+url: https://github.com/glennrp/libpng
+hash: 07b8803110da160b158ebfef872627da6c85cbdf

--- a/nghttp/idf_component.yml
+++ b/nghttp/idf_component.yml
@@ -1,5 +1,9 @@
-version: "1.52.0"
+version: "1.52.0~1"
 description: "nghttp2 - HTTP/2 C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/nghttp
 dependencies:
   idf: ">=5.0"
+sbom:
+  manifests:
+    - path: sbom_nghttp2.yml
+      dest: nghttp2

--- a/nghttp/sbom_nghttp2.yml
+++ b/nghttp/sbom_nghttp2.yml
@@ -1,0 +1,7 @@
+name: nghttp2
+version: 1.52.0
+cpe: cpe:2.3:a:nghttp2:nghttp2:{}:*:*:*:*:*:*:*
+supplier: 'Organization: nghttp2 <https://nghttp2.org/'
+description: nghttp2 - HTTP/2 C Library and tools
+url: https://github.com/nghttp2/nghttp2
+hash: be0491294a63d891bd12b6b1b7e372a45a5d0ffe

--- a/zlib/idf_component.yml
+++ b/zlib/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.13"
+version: "1.2.13~1"
 description: zlib C library
 url: https://github.com/espressif/idf-extra-components/tree/master/zlib
 repository: "https://github.com/espressif/idf-extra-components.git"
@@ -6,3 +6,7 @@ documentation: "https://www.zlib.net/manual.html"
 issues: "https://github.com/espressif/idf-extra-components/issues" # URL of the issue tracker
 dependencies:
   idf: ">=4.4"
+sbom:
+  manifests:
+    - path: sbom_zlib.yml
+      dest: zlib

--- a/zlib/sbom_zlib.yml
+++ b/zlib/sbom_zlib.yml
@@ -1,0 +1,7 @@
+name: zlib
+version: 1.2.13
+cpe: cpe:2.3:a:zlib:zlib:{}:*:*:*:*:*:*:*
+supplier: 'Organization: zlib <http://www.zlib.net/>'
+description: A massively spiffy yet delicately unobtrusive compression library
+url: https://github.com/madler/zlib
+hash: 04f42ceca40f73e2978b50e93806c2a18c1281fc


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
The esp-idf-sbom tool now supports "referenced" manifests allowing to add sbom files for libraries, which we do not have control over. IOW submodules not managed by Espressif. This adds sbom manifests for such libraries.

Since we are moving away from keeping sbom information in `.gitmodules`, this PR removes sbom related variables from `.gitmodules`. We also need a different approach for `hash` checking and sbom manifest validation, because till now it was all based on the info in `.gitmodules` only. Latest `esp-idf-sbom` has a new command, which allows to validate specific sbom manifest files, .gitmodules and also directories, which are searched for any possible sbom manifest file(sbom.yml, referenced manifests, idf_component.yml, .gitmodules.) This allows to simply validate all manifests in a repository. This command, `esp-idf-sbom manifest validate`, is now used in the CI instead of the `test_sbom.py` from `esp-idf`.

Along with `esp-idf-sbom manifest validate`, there is also `esp-idf-sbom manifest check`, which behaves the same as the former, but it checks CPEs found in the manifest files against NVD. Meaning we can simply check the whole repository for possible vulnerabilities without actually generating the SBOM SPDX file.