### PR TITLE
fmt: fix readme link (IEC-53)

### DIFF
--- a/fmt/README.md
+++ b/fmt/README.md
@@ -5,6 +5,6 @@
 **fmt** is an open-source formatting library providing a fast and safe
 alternative to C stdio and C++ iostreams.
 
-See the project [README](/fmtlib/fmt/blob/master/README.rst) for details.
+See the project [README](https://github.com/fmtlib/fmt/blob/master/README.rst) for details.
 
 


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
"Fix" broken link in {fmt} doc, but I don't feel great about this fix. It's surely overly specific, but I couldn't work out the optimal short-form, relative links either.

