### PR TITLE
fix(usb/esp_tinyusb): Fix backward compatibility for MSC max_files

### DIFF
--- a/usb/esp_tinyusb/CHANGELOG.md
+++ b/usb/esp_tinyusb/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.1
+## 1.4.2
 
 - MSC: Fix maximum files open
 - Add uninstall function

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,6 +1,6 @@
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: 1.4.1
+version: 1.4.2
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule

--- a/usb/esp_tinyusb/tusb_msc_storage.c
+++ b/usb/esp_tinyusb/tusb_msc_storage.c
@@ -387,7 +387,11 @@ esp_err_t tinyusb_msc_storage_init_spiflash(const tinyusb_msc_spiflash_config_t 
     s_storage_handle->is_fat_mounted = false;
     s_storage_handle->base_path = NULL;
     s_storage_handle->wl_handle = config->wl_handle;
-    s_storage_handle->max_files = config->mount_config.max_files;
+    // In case the user does not set mount_config.max_files
+    // and for backward compatibility with versions <1.4.2
+    // max_files is set to 2
+    const int max_files = config->mount_config.max_files;
+    s_storage_handle->max_files = max_files > 0 ? max_files : 2;
 
     /* Callbacks setting up*/
     if (config->callback_mount_changed) {
@@ -419,7 +423,11 @@ esp_err_t tinyusb_msc_storage_init_sdmmc(const tinyusb_msc_sdmmc_config_t *confi
     s_storage_handle->is_fat_mounted = false;
     s_storage_handle->base_path = NULL;
     s_storage_handle->card = config->card;
-    s_storage_handle->max_files = config->mount_config.max_files;
+    // In case the user does not set mount_config.max_files
+    // and for backward compatibility with versions <1.4.2
+    // max_files is set to 2
+    const int max_files = config->mount_config.max_files;
+    s_storage_handle->max_files = max_files > 0 ? max_files : 2;
 
     /* Callbacks setting up*/
     if (config->callback_mount_changed) {


### PR DESCRIPTION
Fixes regression from #231 cc @pborcin 

Now we check if max_files is zero. If yes, we default to max_files = 2

Version 1.4.1  was deleted (not yanked) so we skip this version in the changelog