### PR TITLE
feat(ci): add periodic and ad hoc vulnerability scan

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -1,0 +1,35 @@
+name: Vulnerability scan
+
+on:
+  schedule:
+     - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  vulnerability-scan:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install esp-idf-sbom
+        run: pip3 install esp-idf-sbom
+
+      - name: Vulnerability scan
+        id: scan
+        run: python3 -m esp_idf_sbom manifest check
+
+      - name: Send result
+        if: ${{ !cancelled() }}
+        env:
+          MATTERMOST_WEBHOOK: ${{ secrets.MATTERMOST_WEBHOOK }}
+          # Uses ternary operator. The double quotes are needed because of the colons
+          # for mattermost markup, which are confusing the yaml parser.
+          MSG: "${{ steps.scan.outcome == 'success' && ':large_green_circle: No vulnerabilities found' || ':red_circle: New vulnerabilities found' }}"
+          JOB_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+          USER_NAME: ${{ 'idf-extra-components' }}
+        run: |
+          curl --no-progress-meter -i -X POST -H 'Content-Type: application/json'\
+               -d "{\"username\": \"${USER_NAME}\", \"text\": \"${MSG} ${JOB_URL}\"}"\
+               "$MATTERMOST_WEBHOOK"


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

esp-idf-sbom allows to scan whole repository/directory for all possible manifest files(idf_component.yml, sbom.yml and its referenced manifests, .gitmodules) and check them for possible vulnerabilities based on the cpe variable in manifest.

This adds scheduled scan at every midnight and also ad hoc(dispatch workflow) allowing to scan on demand.
