### PR TITLE
led_strip: Support for IDF4.4

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -1,7 +1,4 @@
 led_strip/examples/led_strip_rmt_ws2812:
-  enable:
-    - if: IDF_VERSION_MAJOR > 4
-      reason: Example uses the new RMT driver which was introduced in IDF v5.0
   disable:
     - if: CONFIG_SOC_RMT_SUPPORTED != 1
       reason: Relevant only for RMT enabled targets

--- a/led_strip/CHANGELOG.md
+++ b/led_strip/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.5.0
+
+- Enabled support for IDF4.4 and above
+    - only with RMT backend
+- Added API `led_strip_set_pixel_hsv`
+
 ## 2.4.0
 
 - Support configurable SPI mode to control leds

--- a/led_strip/CMakeLists.txt
+++ b/led_strip/CMakeLists.txt
@@ -2,8 +2,12 @@ include($ENV{IDF_PATH}/tools/cmake/version.cmake)
 
 set(srcs "src/led_strip_api.c")
 
-if(CONFIG_SOC_RMT_SUPPORTED)
-    list(APPEND srcs "src/led_strip_rmt_dev.c" "src/led_strip_rmt_encoder.c")
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.0")
+    if(CONFIG_SOC_RMT_SUPPORTED)
+        list(APPEND srcs "src/led_strip_rmt_dev.c" "src/led_strip_rmt_encoder.c")
+    endif()
+else() 
+    list(APPEND srcs "src/led_strip_rmt_dev_idf4.c")
 endif()
 
 # the SPI backend driver relies on something that was added in IDF 5.1

--- a/led_strip/README.md
+++ b/led_strip/README.md
@@ -27,9 +27,13 @@ led_strip_config_t strip_config = {
 };
 
 led_strip_rmt_config_t rmt_config = {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+    .rmt_channel = 0,
+#else
     .clk_src = RMT_CLK_SRC_DEFAULT, // different clock source can lead to different power consumption
     .resolution_hz = 10 * 1000 * 1000, // 10MHz
     .flags.with_dma = false, // whether to enable the DMA feature
+#endif
 };
 ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip));
 ```

--- a/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
+++ b/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
@@ -32,9 +32,13 @@ led_strip_handle_t configure_led(void)
 
     // LED strip backend configuration: RMT
     led_strip_rmt_config_t rmt_config = {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+        .rmt_channel = 0,
+#else
         .clk_src = RMT_CLK_SRC_DEFAULT,        // different clock source can lead to different power consumption
         .resolution_hz = LED_STRIP_RMT_RES_HZ, // RMT counter clock frequency
         .flags.with_dma = false,               // DMA feature is available on ESP target like ESP32-S3
+#endif
     };
 
     // LED Strip object handle

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,5 +1,5 @@
-version: "2.4.3"
+version: "2.5.0"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 dependencies:
-  idf: ">=5.0"
+  idf: ">=4.4"

--- a/led_strip/include/led_strip.h
+++ b/led_strip/include/led_strip.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +8,11 @@
 #include <stdint.h>
 #include "esp_err.h"
 #include "led_strip_rmt.h"
+#include "esp_idf_version.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
 #include "led_strip_spi.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,6 +53,22 @@ esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index, uint32_t
  *      - ESP_FAIL: Set RGBW color for a specific pixel failed because other error occurred
  */
 esp_err_t led_strip_set_pixel_rgbw(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white);
+
+/**
+ * @brief Set HSV for a specific pixel
+ *
+ * @param strip: LED strip
+ * @param index: index of pixel to set
+ * @param hue: hue part of color (0 - 360)
+ * @param saturation: saturation part of color (0 - 255)
+ * @param value: value part of color (0 - 255)
+ *
+ * @return
+ *      - ESP_OK: Set HSV color for a specific pixel successfully
+ *      - ESP_ERR_INVALID_ARG: Set HSV color for a specific pixel failed because of an invalid argument
+ *      - ESP_FAIL: Set HSV color for a specific pixel failed because other error occurred
+ */
+esp_err_t led_strip_set_pixel_hsv(led_strip_handle_t strip, uint32_t index, uint16_t hue, uint8_t saturation, uint8_t value);
 
 /**
  * @brief Refresh memory colors to LEDs

--- a/led_strip/include/led_strip_rmt.h
+++ b/led_strip/include/led_strip_rmt.h
@@ -7,8 +7,13 @@
 
 #include <stdint.h>
 #include "esp_err.h"
-#include "driver/rmt_types.h"
 #include "led_strip_types.h"
+#include "esp_idf_version.h"
+
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#include "driver/rmt_types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,12 +23,17 @@ extern "C" {
  * @brief LED Strip RMT specific configuration
  */
 typedef struct {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+    uint8_t rmt_channel;
+    size_t mem_block_symbols;   /*!< How many RMT symbols can one RMT channel hold at one time. Set to 0 will fallback to use the default size. */
+#else
     rmt_clock_source_t clk_src; /*!< RMT clock source */
     uint32_t resolution_hz;     /*!< RMT tick resolution, if set to zero, a default resolution (10MHz) will be applied */
     size_t mem_block_symbols;   /*!< How many RMT symbols can one RMT channel hold at one time. Set to 0 will fallback to use the default size. */
     struct {
         uint32_t with_dma: 1;   /*!< Use DMA to transmit data */
     } flags;
+#endif
 } led_strip_rmt_config_t;
 
 /**

--- a/led_strip/src/led_strip_api.c
+++ b/led_strip/src/led_strip_api.c
@@ -16,6 +16,59 @@ esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index, uint32_t
     return strip->set_pixel(strip, index, red, green, blue);
 }
 
+esp_err_t led_strip_set_pixel_hsv(led_strip_handle_t strip, uint32_t index, uint16_t hue, uint8_t saturation, uint8_t value)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+
+    uint32_t red = 0;
+    uint32_t green = 0;
+    uint32_t blue = 0;
+
+    uint32_t rgb_max = value;
+    uint32_t rgb_min = rgb_max * (255 - saturation) / 255.0f;
+
+    uint32_t i = hue / 60;
+    uint32_t diff = hue % 60;
+
+    // RGB adjustment amount by hue
+    uint32_t rgb_adj = (rgb_max - rgb_min) * diff / 60;
+
+    switch (i) {
+    case 0:
+        red = rgb_max;
+        green = rgb_min + rgb_adj;
+        blue = rgb_min;
+        break;
+    case 1:
+        red = rgb_max - rgb_adj;
+        green = rgb_max;
+        blue = rgb_min;
+        break;
+    case 2:
+        red = rgb_min;
+        green = rgb_max;
+        blue = rgb_min + rgb_adj;
+        break;
+    case 3:
+        red = rgb_min;
+        green = rgb_max - rgb_adj;
+        blue = rgb_max;
+        break;
+    case 4:
+        red = rgb_min + rgb_adj;
+        green = rgb_min;
+        blue = rgb_max;
+        break;
+    default:
+        red = rgb_max;
+        green = rgb_min;
+        blue = rgb_max - rgb_adj;
+        break;
+    }
+
+    return strip->set_pixel(strip, index, red, green, blue);
+}
+
 esp_err_t led_strip_set_pixel_rgbw(led_strip_handle_t strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white)
 {
     ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");

--- a/led_strip/src/led_strip_rmt_dev_idf4.c
+++ b/led_strip/src/led_strip_rmt_dev_idf4.c
@@ -1,0 +1,171 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <sys/cdefs.h>
+#include "esp_log.h"
+#include "esp_check.h"
+#include "driver/rmt.h"
+#include "led_strip.h"
+#include "led_strip_interface.h"
+
+static const char *TAG = "led_strip_rmt";
+
+#define WS2812_T0H_NS   (350)
+#define WS2812_T0L_NS   (1000)
+#define WS2812_T1H_NS   (1000)
+#define WS2812_T1L_NS   (350)
+#define WS2812_DELAY_MS (100)
+
+// the memory size of each RMT channel, in words (4 bytes)
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#define LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS 8
+#else
+#define LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS 6
+#endif
+
+static uint32_t ws2812_t0h_ticks = 0;
+static uint32_t ws2812_t1h_ticks = 0;
+static uint32_t ws2812_t0l_ticks = 0;
+static uint32_t ws2812_t1l_ticks = 0;
+
+typedef struct {
+    led_strip_t base;
+    rmt_channel_t rmt_channel;
+    uint32_t strip_len;
+    uint8_t bytes_per_pixel;
+    uint8_t buffer[0];
+} led_strip_rmt_obj;
+
+static void IRAM_ATTR ws2812_rmt_adapter(const void *src, rmt_item32_t *dest, size_t src_size,
+        size_t wanted_num, size_t *translated_size, size_t *item_num)
+{
+    if (src == NULL || dest == NULL) {
+        *translated_size = 0;
+        *item_num = 0;
+        return;
+    }
+    const rmt_item32_t bit0 = {{{ ws2812_t0h_ticks, 1, ws2812_t0l_ticks, 0 }}}; //Logical 0
+    const rmt_item32_t bit1 = {{{ ws2812_t1h_ticks, 1, ws2812_t1l_ticks, 0 }}}; //Logical 1
+    size_t size = 0;
+    size_t num = 0;
+    uint8_t *psrc = (uint8_t *)src;
+    rmt_item32_t *pdest = dest;
+    while (size < src_size && num < wanted_num) {
+        for (int i = 0; i < 8; i++) {
+            // MSB first
+            if (*psrc & (1 << (7 - i))) {
+                pdest->val =  bit1.val;
+            } else {
+                pdest->val =  bit0.val;
+            }
+            num++;
+            pdest++;
+        }
+        size++;
+        psrc++;
+    }
+    *translated_size = size;
+    *item_num = num;
+}
+
+static esp_err_t led_strip_rmt_set_pixel(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    ESP_RETURN_ON_FALSE(index < rmt_strip->strip_len, ESP_ERR_INVALID_ARG, TAG, "index out of the maximum number of leds");
+    uint32_t start = index * rmt_strip->bytes_per_pixel;
+    // In thr order of GRB
+    rmt_strip->buffer[start + 0] = green & 0xFF;
+    rmt_strip->buffer[start + 1] = red & 0xFF;
+    rmt_strip->buffer[start + 2] = blue & 0xFF;
+    if (rmt_strip->bytes_per_pixel > 3) {
+        rmt_strip->buffer[start + 3] = 0;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_rmt_refresh(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    ESP_RETURN_ON_ERROR(rmt_write_sample(rmt_strip->rmt_channel, rmt_strip->buffer, rmt_strip->strip_len * rmt_strip->bytes_per_pixel, true), TAG,
+                        "transmit RMT samples failed");
+    return rmt_wait_tx_done(rmt_strip->rmt_channel, pdMS_TO_TICKS(WS2812_DELAY_MS));
+}
+
+static esp_err_t led_strip_rmt_clear(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    // Write zero to turn off all leds
+    memset(rmt_strip->buffer, 0, rmt_strip->strip_len * rmt_strip->bytes_per_pixel);
+    return led_strip_rmt_refresh(strip);
+}
+
+static esp_err_t led_strip_rmt_del(led_strip_t *strip)
+{
+    led_strip_rmt_obj *rmt_strip = __containerof(strip, led_strip_rmt_obj, base);
+    free(rmt_strip);
+    return ESP_OK;
+}
+
+esp_err_t led_strip_new_rmt_device(const led_strip_config_t *led_config, const led_strip_rmt_config_t *dev_config, led_strip_handle_t *ret_strip)
+{
+    led_strip_rmt_obj *rmt_strip = NULL;
+    ESP_RETURN_ON_FALSE(led_config && dev_config && ret_strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    ESP_RETURN_ON_FALSE(led_config->led_pixel_format < LED_PIXEL_FORMAT_INVALID, ESP_ERR_INVALID_ARG, TAG, "invalid led_pixel_format");
+
+    uint8_t bytes_per_pixel = 3;
+    if (led_config->led_pixel_format == LED_PIXEL_FORMAT_GRBW) {
+        bytes_per_pixel = 4;
+    } else if (led_config->led_pixel_format == LED_PIXEL_FORMAT_GRB) {
+        bytes_per_pixel = 3;
+    } else {
+        assert(false);
+    }
+
+    rmt_config_t config = RMT_DEFAULT_CONFIG_TX(led_config->strip_gpio_num, dev_config->rmt_channel);
+    // set counter clock to 40MHz
+    config.clk_div = 2;
+
+    size_t mem_block_symbols = LED_STRIP_RMT_DEFAULT_MEM_BLOCK_SYMBOLS;
+    // override the default value if the user sets it
+    if (dev_config->mem_block_symbols) {
+        mem_block_symbols = dev_config->mem_block_symbols;
+    }
+    config.mem_block_num = mem_block_symbols;
+
+    ESP_RETURN_ON_ERROR(rmt_config(&config), TAG, "RMT config failed");
+    ESP_RETURN_ON_ERROR(rmt_driver_install(config.channel, 0, 0), TAG, "RMT install failed");
+
+    rmt_strip = calloc(1, sizeof(led_strip_rmt_obj) + led_config->max_leds * bytes_per_pixel);
+    ESP_RETURN_ON_FALSE(rmt_strip, ESP_ERR_NO_MEM, TAG, "request memory for ws2812 failed");
+
+    uint32_t counter_clk_hz = 0;
+    ESP_RETURN_ON_ERROR(rmt_get_counter_clock((rmt_channel_t)dev_config->rmt_channel, &counter_clk_hz), TAG, "get rmt counter clock failed");
+    // ns -> ticks
+    float ratio = (float)counter_clk_hz / 1e9;
+    ws2812_t0h_ticks = (uint32_t)(ratio * WS2812_T0H_NS);
+    ws2812_t0l_ticks = (uint32_t)(ratio * WS2812_T0L_NS);
+    ws2812_t1h_ticks = (uint32_t)(ratio * WS2812_T1H_NS);
+    ws2812_t1l_ticks = (uint32_t)(ratio * WS2812_T1L_NS);
+
+    // set ws2812 to rmt adapter
+    rmt_translator_init((rmt_channel_t)dev_config->rmt_channel, ws2812_rmt_adapter);
+
+    rmt_strip->bytes_per_pixel = bytes_per_pixel;
+    rmt_strip->rmt_channel = (rmt_channel_t)dev_config->rmt_channel;
+    rmt_strip->strip_len = led_config->max_leds;
+    rmt_strip->base.set_pixel = led_strip_rmt_set_pixel;
+    rmt_strip->base.refresh = led_strip_rmt_refresh;
+    rmt_strip->base.clear = led_strip_rmt_clear;
+    rmt_strip->base.del = led_strip_rmt_del;
+
+    *ret_strip = &rmt_strip->base;
+
+    // Clear LED strip (turn off all LEDs)
+    ESP_RETURN_ON_ERROR((*ret_strip)->clear(*ret_strip), TAG, "LED strip clear failed");
+
+    return ESP_OK;
+}

--- a/qrcode/idf_component.yml
+++ b/qrcode/idf_component.yml
@@ -1,5 +1,5 @@
-version: "0.1.0"
+version: "0.1.0~1"
 description: QR Code generator
-url: https://github.com/espressif/idf-extra-components/tree/master/qr_code
+url: https://github.com/espressif/idf-extra-components/tree/master/qrcode
 dependencies:
   idf: ">=4.3"


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
Updated LED Strip component for working with IDF4.4 (only with RMT)
