### PR TITLE
docs(essl): add missing @brief in the header file (IEC-62)

### DIFF
--- a/esp_serial_slave_link/include/esp_serial_slave_link/essl.h
+++ b/esp_serial_slave_link/include/esp_serial_slave_link/essl.h
@@ -29,7 +29,8 @@ typedef struct essl_dev_t *essl_handle_t;
  */
 esp_err_t essl_init(essl_handle_t handle, uint32_t wait_ms);
 
-/** Wait for interrupt of an ESSL slave device.
+/**
+ * @brief Wait for interrupt of an ESSL slave device.
  *
  * @param handle Handle of an ESSL device.
  * @param wait_ms Millisecond to wait before timeout, will not wait at all if set to 0-9.
@@ -41,7 +42,8 @@ esp_err_t essl_init(essl_handle_t handle, uint32_t wait_ms);
  */
 esp_err_t essl_wait_for_ready(essl_handle_t handle, uint32_t wait_ms);
 
-/** Get buffer num for the host to send data to the slave. The buffers are size of ``buffer_size``.
+/**
+ * @brief Get buffer num for the host to send data to the slave. The buffers are size of ``buffer_size``.
  *
  * @param handle Handle of a ESSL device.
  * @param out_tx_num Output of buffer num that host can send data to ESSL slave.
@@ -54,7 +56,8 @@ esp_err_t essl_wait_for_ready(essl_handle_t handle, uint32_t wait_ms);
  */
 esp_err_t essl_get_tx_buffer_num(essl_handle_t handle, uint32_t *out_tx_num, uint32_t wait_ms);
 
-/** Get the size, in bytes, of the data that the ESSL slave is ready to send
+/**
+ * @brief Get the size, in bytes, of the data that the ESSL slave is ready to send
  *
  * @param handle Handle of an ESSL device.
  * @param out_rx_size Output of data size to read from slave, in bytes
@@ -68,7 +71,8 @@ esp_err_t essl_get_tx_buffer_num(essl_handle_t handle, uint32_t *out_tx_num, uin
 esp_err_t essl_get_rx_data_size(essl_handle_t handle, uint32_t *out_rx_size, uint32_t wait_ms);
 
 
-/** Reset the counters of this component. Usually you don't need to do this unless you know the slave is reset.
+/**
+ * @brief Reset the counters of this component. Usually you don't need to do this unless you know the slave is reset.
  *
  * @param handle Handle of an ESSL device.
  *
@@ -79,7 +83,8 @@ esp_err_t essl_get_rx_data_size(essl_handle_t handle, uint32_t *out_rx_size, uin
  */
 esp_err_t essl_reset_cnt(essl_handle_t handle);
 
-/** Send a packet to the ESSL Slave. The Slave receives the packet into buffers whose size is ``buffer_size`` (configured during initialization).
+/**
+ * @brief Send a packet to the ESSL Slave. The Slave receives the packet into buffers whose size is ``buffer_size`` (configured during initialization).
  *
  * @param handle Handle of an ESSL device.
  * @param start Start address of the packet to send
@@ -96,7 +101,8 @@ esp_err_t essl_reset_cnt(essl_handle_t handle);
  */
 esp_err_t essl_send_packet(essl_handle_t handle, const void *start, size_t length, uint32_t wait_ms);
 
-/** Get a packet from ESSL slave.
+/**
+ * @brief Get a packet from ESSL slave.
  *
  * @param handle Handle of an ESSL device.
  * @param[out] out_data Data output address
@@ -114,7 +120,8 @@ esp_err_t essl_send_packet(essl_handle_t handle, const void *start, size_t lengt
  */
 esp_err_t essl_get_packet(essl_handle_t handle, void *out_data, size_t size, size_t *out_length, uint32_t wait_ms);
 
-/** Write general purpose R/W registers (8-bit) of ESSL slave.
+/**
+ * @brief Write general purpose R/W registers (8-bit) of ESSL slave.
  *
  * @param handle Handle of an ESSL device.
  * @param addr Address of register to write. For SDIO, valid address: 0-59. For SPI, see ``essl_spi.h``
@@ -130,7 +137,8 @@ esp_err_t essl_get_packet(essl_handle_t handle, void *out_data, size_t size, siz
  */
 esp_err_t essl_write_reg(essl_handle_t handle, uint8_t addr, uint8_t value, uint8_t *value_o, uint32_t wait_ms);
 
-/** Read general purpose R/W registers (8-bit) of ESSL slave.
+/**
+ * @brief Read general purpose R/W registers (8-bit) of ESSL slave.
  *
  * @param handle Handle of a ``essl`` device.
  * @param add Address of register to read. For SDIO, Valid address: 0-27, 32-63 (28-31 reserved, return interrupt bits on read). For SPI, see ``essl_spi.h``
@@ -143,7 +151,8 @@ esp_err_t essl_write_reg(essl_handle_t handle, uint8_t addr, uint8_t value, uint
  */
 esp_err_t essl_read_reg(essl_handle_t handle, uint8_t add, uint8_t *value_o, uint32_t wait_ms);
 
-/** wait for an interrupt of the slave
+/**
+ * @brief wait for an interrupt of the slave
  *
  * @param handle Handle of an ESSL device.
  * @param wait_ms Millisecond to wait before timeout, will not wait at all if set to 0-9.
@@ -155,7 +164,8 @@ esp_err_t essl_read_reg(essl_handle_t handle, uint8_t add, uint8_t *value_o, uin
  */
 esp_err_t essl_wait_int(essl_handle_t handle, uint32_t wait_ms);
 
-/** Clear interrupt bits of ESSL slave. All the bits set in the mask will be cleared, while other bits will stay the same.
+/**
+ * @brief Clear interrupt bits of ESSL slave. All the bits set in the mask will be cleared, while other bits will stay the same.
  *
  * @param handle Handle of an ESSL device.
  * @param intr_mask Mask of interrupt bits to clear.
@@ -168,7 +178,8 @@ esp_err_t essl_wait_int(essl_handle_t handle, uint32_t wait_ms);
  */
 esp_err_t essl_clear_intr(essl_handle_t handle, uint32_t intr_mask, uint32_t wait_ms);
 
-/** Get interrupt bits of ESSL slave.
+/**
+ * @brief Get interrupt bits of ESSL slave.
  *
  * @param handle Handle of an ESSL device.
  * @param intr_raw Output of the raw interrupt bits. Set to NULL if only masked bits are read.
@@ -183,7 +194,8 @@ esp_err_t essl_clear_intr(essl_handle_t handle, uint32_t intr_mask, uint32_t wai
  */
 esp_err_t essl_get_intr(essl_handle_t handle, uint32_t *intr_raw, uint32_t *intr_st, uint32_t wait_ms);
 
-/** Set interrupt enable bits of ESSL slave. The slave only sends interrupt on the line when there is a bit both the raw status and the enable are set.
+/**
+ * @brief Set interrupt enable bits of ESSL slave. The slave only sends interrupt on the line when there is a bit both the raw status and the enable are set.
  *
  * @param handle Handle of an ESSL device.
  * @param ena_mask Mask of the interrupt bits to enable.
@@ -196,7 +208,8 @@ esp_err_t essl_get_intr(essl_handle_t handle, uint32_t *intr_raw, uint32_t *intr
  */
 esp_err_t essl_set_intr_ena(essl_handle_t handle, uint32_t ena_mask, uint32_t wait_ms);
 
-/** Get interrupt enable bits of ESSL slave.
+/**
+ * @brief Get interrupt enable bits of ESSL slave.
  *
  * @param handle Handle of an ESSL device.
  * @param ena_mask_o Output of interrupt bit enable mask.
@@ -208,7 +221,8 @@ esp_err_t essl_set_intr_ena(essl_handle_t handle, uint32_t ena_mask, uint32_t wa
  */
 esp_err_t essl_get_intr_ena(essl_handle_t handle, uint32_t *ena_mask_o, uint32_t wait_ms);
 
-/** Send interrupts to slave. Each bit of the interrupt will be triggered.
+/**
+ * @brief Send interrupts to slave. Each bit of the interrupt will be triggered.
  *
  * @param handle Handle of an ESSL device.
  * @param intr_mask Mask of interrupt bits to send to slave.

--- a/esp_serial_slave_link/include/esp_serial_slave_link/essl_sdio.h
+++ b/esp_serial_slave_link/include/esp_serial_slave_link/essl_sdio.h
@@ -47,10 +47,10 @@ esp_err_t essl_sdio_init_dev(essl_handle_t *out_handle, const essl_sdio_config_t
  */
 esp_err_t essl_sdio_deinit_dev(essl_handle_t handle);
 
-//Please call `essl_` functions witout `sdio` instead of calling these functions directly.
+// Please call `essl_` functions without `sdio` instead of calling these functions directly.
 /** @cond */
 /**
- * SDIO Initialize process of an ESSL SDIO slave device.
+ * @brief SDIO Initialize process of an ESSL SDIO slave device.
  *
  * @param arg Context of the ``essl`` component. Send to other functions later.
  * @param wait_ms Time to wait before operation is done, in ms.
@@ -62,7 +62,7 @@ esp_err_t essl_sdio_deinit_dev(essl_handle_t handle);
 esp_err_t essl_sdio_init(void *arg, uint32_t wait_ms);
 
 /**
- * Wait for interrupt of an ESSL SDIO slave device.
+ * @brief Wait for interrupt of an ESSL SDIO slave device.
  *
  * @param arg Context of the ``essl`` component.
  * @param wait_ms Time to wait before operation is done, in ms.
@@ -74,7 +74,7 @@ esp_err_t essl_sdio_init(void *arg, uint32_t wait_ms);
 esp_err_t essl_sdio_wait_for_ready(void *arg, uint32_t wait_ms);
 
 /**
- * Get buffer num for the host to send data to the slave. The buffers are size of ``buffer_size``.
+ * @brief Get buffer num for the host to send data to the slave. The buffers are size of ``buffer_size``.
  *
  * @param arg Context of the component.
  *
@@ -84,7 +84,8 @@ esp_err_t essl_sdio_wait_for_ready(void *arg, uint32_t wait_ms);
  */
 uint32_t essl_sdio_get_tx_buffer_num(void *arg);
 
-/** Get amount of data the ESSL SDIO slave preparing to send to host.
+/**
+ * @brief Get amount of data the ESSL SDIO slave preparing to send to host.
  *
  * @param arg Context of the component.
  *
@@ -95,7 +96,7 @@ uint32_t essl_sdio_get_tx_buffer_num(void *arg);
 uint32_t essl_sdio_get_rx_data_size(void *arg);
 
 /**
- * Send a packet to the ESSL SDIO slave. The slave receive the packet into buffers whose size is ``buffer_size`` in the arg.
+ * @brief Send a packet to the ESSL SDIO slave. The slave receive the packet into buffers whose size is ``buffer_size`` in the arg.
  *
  * @param arg Context of the component.
  * @param start Start address of the packet to send
@@ -110,7 +111,7 @@ uint32_t essl_sdio_get_rx_data_size(void *arg);
 esp_err_t essl_sdio_send_packet(void *arg, const void *start, size_t length, uint32_t wait_ms);
 
 /**
- * Get a packet from an ESSL SDIO slave.
+ * @brief Get a packet from an ESSL SDIO slave.
  *
  * @param arg Context of the component.
  * @param[out] out_data Data output address
@@ -125,7 +126,7 @@ esp_err_t essl_sdio_send_packet(void *arg, const void *start, size_t length, uin
 esp_err_t essl_sdio_get_packet(void *arg, void *out_data, size_t size, uint32_t wait_ms);
 
 /**
- * Wait for the interrupt from the SDIO slave.
+ * @brief Wait for the interrupt from the SDIO slave.
  *
  * @param arg Context of the component.
  * @param wait_ms Time to wait before timeout, in ms.
@@ -138,7 +139,7 @@ esp_err_t essl_sdio_get_packet(void *arg, void *out_data, size_t size, uint32_t 
 esp_err_t essl_sdio_wait_int(void *arg, uint32_t wait_ms);
 
 /**
- * Clear interrupt bits of an ESSL SDIO slave. All the bits set in the mask will be cleared, while other bits will stay the same.
+ * @brief Clear interrupt bits of an ESSL SDIO slave. All the bits set in the mask will be cleared, while other bits will stay the same.
  *
  * @param arg Context of the component.
  * @param intr_mask Mask of interrupt bits to clear.
@@ -151,7 +152,7 @@ esp_err_t essl_sdio_wait_int(void *arg, uint32_t wait_ms);
 esp_err_t essl_sdio_clear_intr(void *arg, uint32_t intr_mask, uint32_t wait_ms);
 
 /**
- * Get interrupt bits of an ESSL SDIO slave.
+ * @brief Get interrupt bits of an ESSL SDIO slave.
  *
  * @param arg Context of the component.
  * @param intr_raw Output of the raw interrupt bits. Set to NULL if only masked bits are read.
@@ -166,7 +167,7 @@ esp_err_t essl_sdio_clear_intr(void *arg, uint32_t intr_mask, uint32_t wait_ms);
 esp_err_t essl_sdio_get_intr(void *arg, uint32_t *intr_raw, uint32_t *intr_st, uint32_t wait_ms);
 
 /**
- * Set interrupt enable bits of an ESSL SDIO slave. The slave only sends interrupt on the line when there is a bit both the raw status and the enable are set.
+ * @brief Set interrupt enable bits of an ESSL SDIO slave. The slave only sends interrupt on the line when there is a bit both the raw status and the enable are set.
  *
  * @param arg Context of the component.
  * @param ena_mask Mask of the interrupt bits to enable.
@@ -179,7 +180,7 @@ esp_err_t essl_sdio_get_intr(void *arg, uint32_t *intr_raw, uint32_t *intr_st, u
 esp_err_t essl_sdio_set_intr_ena(void *arg, uint32_t ena_mask, uint32_t wait_ms);
 
 /**
- * Get interrupt enable bits of an ESSL SDIO slave.
+ * @brief Get interrupt enable bits of an ESSL SDIO slave.
  *
  * @param arg Context of the component.
  * @param ena_mask_o Output of interrupt bit enable mask.
@@ -192,7 +193,7 @@ esp_err_t essl_sdio_set_intr_ena(void *arg, uint32_t ena_mask, uint32_t wait_ms)
 esp_err_t essl_sdio_get_intr_ena(void *arg, uint32_t *ena_mask_o, uint32_t wait_ms);
 
 /**
- * Write general purpose R/W registers (8-bit) of an ESSL SDIO slave.
+ * @brief Write general purpose R/W registers (8-bit) of an ESSL SDIO slave.
  *
  * @param arg Context of the component.
  * @param addr Address of register to write. Valid address: 0-27, 32-63 (28-31 reserved).
@@ -207,7 +208,7 @@ esp_err_t essl_sdio_get_intr_ena(void *arg, uint32_t *ena_mask_o, uint32_t wait_
 esp_err_t essl_sdio_write_reg(void *arg, uint8_t addr, uint8_t value, uint8_t *value_o, uint32_t wait_ms);
 
 /**
- * Read general purpose R/W registers (8-bit) of an ESSL SDIO slave.
+ * @brief Read general purpose R/W registers (8-bit) of an ESSL SDIO slave.
  *
  * @param arg Context of the component.
  * @param add Address of register to read. Valid address: 0-27, 32-63 (28-31 reserved, return interrupt bits on read).
@@ -222,7 +223,7 @@ esp_err_t essl_sdio_write_reg(void *arg, uint8_t addr, uint8_t value, uint8_t *v
 esp_err_t essl_sdio_read_reg(void *arg, uint8_t add, uint8_t *value_o, uint32_t wait_ms);
 
 /**
- * Send interrupts to slave. Each bit of the interrupt will be triggered.
+ * @brief Send interrupts to slave. Each bit of the interrupt will be triggered.
  *
  * @param arg Context of the component.
  * @param intr_mask Mask of interrupt bits to send to slave.


### PR DESCRIPTION
added missing `@brief` in the header file

