### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/usb/esp_modem_usb_dte/CMakeLists.txt
+++ b/usb/esp_modem_usb_dte/CMakeLists.txt
@@ -15,5 +15,5 @@ endif()
 
 # esp_modem_usb_dte includes some files from private includes of esp_modem
 idf_component_get_property(esp_modem_dir ${esp_modem_name} COMPONENT_DIR)
-idf_component_get_property(esp_modem_private_include ${esp_modem_name} PRIV_INCLUDE_DIRS)
-target_include_directories(${COMPONENT_LIB} PRIVATE "${esp_modem_dir}/${esp_modem_private_include}")
+idf_component_get_property(esp_modem_include ${esp_modem_name} INCLUDE_DIRS)
+target_include_directories(${COMPONENT_LIB} PRIVATE "${esp_modem_dir}/${esp_modem_include}")


### PR DESCRIPTION
esp_modem_config.h is in Folder "include" not in folder private_include

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
