### PR TITLE
feat(libsodium): use latest 1.0.19 upstream release

### DIFF
--- a/libsodium/CMakeLists.txt
+++ b/libsodium/CMakeLists.txt
@@ -2,8 +2,8 @@ set(SRC libsodium/src/libsodium)
 # Derived from libsodium/src/libsodium/Makefile.am
 # (ignoring the !MINIMAL set)
 set(srcs
-    "${SRC}/crypto_aead/chacha20poly1305/sodium/aead_chacha20poly1305.c"
-    "${SRC}/crypto_aead/xchacha20poly1305/sodium/aead_xchacha20poly1305.c"
+    "${SRC}/crypto_aead/chacha20poly1305/aead_chacha20poly1305.c"
+    "${SRC}/crypto_aead/xchacha20poly1305/aead_xchacha20poly1305.c"
     "${SRC}/crypto_auth/crypto_auth.c"
     "${SRC}/crypto_auth/hmacsha256/auth_hmacsha256.c"
     "${SRC}/crypto_auth/hmacsha512/auth_hmacsha512.c"
@@ -102,7 +102,7 @@ set(srcs
     "${SRC}/crypto_stream/salsa208/stream_salsa208.c"
     "${SRC}/crypto_stream/xchacha20/stream_xchacha20.c"
     "${SRC}/crypto_stream/xsalsa20/stream_xsalsa20.c"
-    "${SRC}/crypto_verify/sodium/verify.c"
+    "${SRC}/crypto_verify/verify.c"
     "${SRC}/randombytes/randombytes.c"
     "${SRC}/sodium/codecs.c"
     "${SRC}/sodium/core.c"

--- a/libsodium/idf_component.yml
+++ b/libsodium/idf_component.yml
@@ -1,5 +1,4 @@
-
-version: "1.0.20"
+version: "1.0.20~1"
 description: libsodium port to ESP
 url: https://github.com/espressif/idf-extra-components/tree/master/libsodium
 dependencies:

--- a/libsodium/port_include/sodium/version.h
+++ b/libsodium/port_include/sodium/version.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2023 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,12 +13,12 @@
    updated if we change submodules. They need to be changed manually.
 */
 
-#define SODIUM_VERSION_STRING "1.0.18-idf"
+#define SODIUM_VERSION_STRING "1.0.19"
 
 /* Note: these are not the same as the overall version, see
    configure.ac for the relevant macros */
-#define SODIUM_LIBRARY_VERSION_MAJOR 10
-#define SODIUM_LIBRARY_VERSION_MINOR 3
+#define SODIUM_LIBRARY_VERSION_MAJOR 26
+#define SODIUM_LIBRARY_VERSION_MINOR 1
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,6 +32,9 @@ int         sodium_library_version_major(void);
 
 SODIUM_EXPORT
 int         sodium_library_version_minor(void);
+
+SODIUM_EXPORT
+int         sodium_library_minimal(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# Change description

- There is an inconsistency in the component and upstream version. This is because, the upstream libsodium had stopped creating new releases sometimes back and used to update same revision. This time around they created new semantic version but the IDF version was already updated earlier. Hence, in this change, only the `revision` field is added for the component.

- Synced the version.h file with upstream

Closes https://github.com/espressif/idf-extra-components/issues/257

# Checklist

- [ ] CI passing

