### PR TITLE
fix(pre-commit): update astyle_py to 1.0.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/igrr/astyle_py.git
-    rev: v0.9.0
+    rev: v1.0.5
     hooks:
     -   id: astyle_py
         args: ['--style=otbs', '--attach-namespaces', '--attach-classes', '--indent=spaces=4', '--convert-tabs', '--align-pointer=name', '--align-reference=name', '--keep-one-line-statements', '--pad-header', '--pad-oper']


### PR DESCRIPTION
Fixes Pyyaml and Cython version incompatibility (https://github.com/espressif/idf-extra-components/actions/runs/6665480199/job/18115381366?pr=262)
