### PR TITLE
fix(sh2lib): Deinit SNTP correctly with IDF>=5.1 (IEC-68)

### DIFF
--- a/sh2lib/examples/http2_request/main/http2_request_example_main.c
+++ b/sh2lib/examples/http2_request/main/http2_request_example_main.c
@@ -104,7 +104,7 @@ static void set_time(void)
     if (esp_netif_sntp_sync_wait(pdMS_TO_TICKS(10000)) != ESP_OK) {
         printf("Failed to update system time, continuing");
     }
-    esp_netif_deinit();
+    esp_netif_sntp_deinit();
 #endif
 }
 


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

Fixes a regression from https://github.com/espressif/esp-idf/commit/a71fa821 where we introduce `esp_netif_sntp_init()`, but didn't correctly deinit in some examples