### PR TITLE
change(esp_tinyusb): Update esp_tinyusb task affinity config type

### DIFF
--- a/usb/esp_tinyusb/Kconfig
+++ b/usb/esp_tinyusb/Kconfig
@@ -46,10 +46,10 @@ menu "TinyUSB Stack"
         endchoice
 
         config TINYUSB_TASK_AFFINITY
-            hex
+            int
+            default FREERTOS_CORE0_AFFINITY if TINYUSB_TASK_AFFINITY_CPU0
+            default FREERTOS_CORE1_AFFINITY if TINYUSB_TASK_AFFINITY_CPU1
             default FREERTOS_NO_AFFINITY if TINYUSB_TASK_AFFINITY_NO_AFFINITY
-            default 0x0 if TINYUSB_TASK_AFFINITY_CPU0
-            default 0x1 if TINYUSB_TASK_AFFINITY_CPU1
 
         config TINYUSB_INIT_IN_DEFAULT_TASK
             bool "Initialize TinyUSB stack within the default TinyUSB task"


### PR DESCRIPTION
# Change description
_Please describe your change here_

ESP-IDF updates the task affinity config option from hex to int, and provides constant values for each affinity value. This commit syncs `TINYUSB_TASK_AFFINITY` with those changes.

See internal MR !26701 for more details.