### PR TITLE
fix(catch2): work around ranlib warning when building on macOS

### DIFF
--- a/catch2/cmd_catch2.cpp
+++ b/catch2/cmd_catch2.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSL-1.0
  * Note: same license as Catch2
  */
+#include "esp_err.h"
 #if WITH_CONSOLE
 #include "Catch2/src/catch2/catch_config.hpp"
 #include "esp_console.h"
@@ -30,4 +31,11 @@ extern "C" esp_err_t register_catch2(const char *cmd_name)
     return esp_console_cmd_register(&cmd);
 }
 
+#else // WITH_CONSOLE
+// Defined to avoid ranlib warning on macOS
+// (the table of contents is empty (no object file members in the library define global symbols))
+extern "C" esp_err_t register_catch2(const char *cmd_name)
+{
+    return ESP_OK;
+}
 #endif // WITH_CONSOLE

--- a/catch2/idf_component.yml
+++ b/catch2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.4.0~1"
+version: "3.4.0~2"
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/espressif/idf-extra-components/tree/master/catch2
 repository: https://github.com/espressif/idf-extra-components.git


### PR DESCRIPTION
This PR fixes a warning issued when catch2 component was used with IDF_TARGET=linux on a macOS host.

macOS version of ranlib issues a warning when it encounters a static library with no extern symbols.
When building catch2 component with IDF_TARGET=linux, the only object file in the library (cmd_catch2.cpp.obj) would indeed define no symbols, so libespressif__catch2.a would define no symbols as well, resulting in this warning.

Fix this by defining a dummy register_catch2 function even when building for IDF_TARGET=linux.
