### PR TITLE
esp_jpeg: Fix BSP versions for using new version of button component (without warnings in new IDF).

### DIFF
--- a/esp_jpeg/examples/get_started/main/idf_component.yml
+++ b/esp_jpeg/examples/get_started/main/idf_component.yml
@@ -8,10 +8,10 @@ dependencies:
     rules:
       - if: "target == esp32s3"
   esp32_s2_kaluga_kit:
-    version: "^2.2"
+    version: "^3.0"
     rules:
       - if: "target == esp32s2"
   esp_wrover_kit:
-    version: "^1.4"
+    version: "^1.5"
     rules:
       - if: "target == esp32"

--- a/esp_jpeg/idf_component.yml
+++ b/esp_jpeg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.5~1"
+version: "1.0.5~2"
 description: "JPEG Decoder: TJpgDec"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_jpeg/
 dependencies:


### PR DESCRIPTION
# Checklist

- [x] CI passing

# Change description
Fix for this error: https://github.com/espressif/idf-extra-components/actions/runs/7004078689/job/19060622718?pr=271
