### PR TITLE
nghttp2: update library to v1.58.0

### DIFF
--- a/nghttp/CMakeLists.txt
+++ b/nghttp/CMakeLists.txt
@@ -17,11 +17,14 @@ set(srcs
     "nghttp2/lib/nghttp2_pq.c"
     "nghttp2/lib/nghttp2_priority_spec.c"
     "nghttp2/lib/nghttp2_queue.c"
+    "nghttp2/lib/nghttp2_ratelim.c"
     "nghttp2/lib/nghttp2_rcbuf.c"
     "nghttp2/lib/nghttp2_session.c"
     "nghttp2/lib/nghttp2_stream.c"
     "nghttp2/lib/nghttp2_submit.c"
-    "nghttp2/lib/nghttp2_version.c")
+    "nghttp2/lib/nghttp2_time.c"
+    "nghttp2/lib/nghttp2_version.c"
+    "nghttp2/lib/sfparse.c")
 
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS port/include nghttp2/lib/includes

--- a/nghttp/idf_component.yml
+++ b/nghttp/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.52.0~1"
+version: "1.58.0"
 description: "nghttp2 - HTTP/2 C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/nghttp
 dependencies:

--- a/nghttp/port/include/nghttp2/nghttp2ver.h
+++ b/nghttp/port/include/nghttp2/nghttp2ver.h
@@ -29,7 +29,7 @@
  * @macro
  * Version number of the nghttp2 library release
  */
-#define NGHTTP2_VERSION "1.52.0"
+#define NGHTTP2_VERSION "1.58.0"
 
 /**
  * @macro
@@ -37,6 +37,6 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define NGHTTP2_VERSION_NUM 0x015200
+#define NGHTTP2_VERSION_NUM 0x013a00
 
 #endif /* NGHTTP2VER_H */

--- a/nghttp/port/private_include/config.h
+++ b/nghttp/port/private_include/config.h
@@ -9,6 +9,12 @@
 #include "stdlib.h"
 #include "string.h"
 
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+
+/* Define to 1 if you have the <time.h> header file. */
+#define HAVE_TIME_H 1
+
 #if (!defined(nghttp_unlikely))
 #define nghttp_unlikely(Expression) !!(Expression)
 #endif

--- a/nghttp/sbom_nghttp2.yml
+++ b/nghttp/sbom_nghttp2.yml
@@ -1,7 +1,7 @@
 name: nghttp2
-version: 1.52.0
+version: 1.58.0
 cpe: cpe:2.3:a:nghttp2:nghttp2:{}:*:*:*:*:*:*:*
 supplier: 'Organization: nghttp2 <https://nghttp2.org/'
 description: nghttp2 - HTTP/2 C Library and tools
 url: https://github.com/nghttp2/nghttp2
-hash: be0491294a63d891bd12b6b1b7e372a45a5d0ffe
+hash: e2bc59bec9004bca47df961cbbad20664d7e53b2


### PR DESCRIPTION
For detailed release notes please refer to:
https://github.com/nghttp2/nghttp2/releases/tag/v1.58.0

Security related:

- Release v1.57.0 fixes CVE-2023-44487
- Release v1.55.1 fixes CVE-2023-35945

# Checklist

- [ ] CI passing

# Change description
_Please describe your change here_
