### PR TITLE
json_generator: Use consts wherever applicable (IEC-73)

### DIFF
--- a/json_generator/idf_component.yml
+++ b/json_generator/idf_component.yml
@@ -1,3 +1,3 @@
-version: "1.1.1"
+version: "1.1.2"
 description: A simple JSON (JavasScript Object Notation) generator with flushing capability
 url: https://github.com/espressif/json_generator

--- a/json_generator/include/json_generator.h
+++ b/json_generator/include/json_generator.h
@@ -174,7 +174,7 @@ int json_gen_end_array(json_gen_str_t *jstr);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_push_object(json_gen_str_t *jstr, char *name);
+int json_gen_push_object(json_gen_str_t *jstr, const char *name);
 
 /** Pop a named JSON object
  *
@@ -208,7 +208,7 @@ int json_gen_pop_object(json_gen_str_t *jstr);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that.
  */
-int json_gen_push_object_str(json_gen_str_t *jstr, char *name, char *object_str);
+int json_gen_push_object_str(json_gen_str_t *jstr, const char *name, const char *object_str);
 
 /** Push a named JSON array
  *
@@ -223,7 +223,7 @@ int json_gen_push_object_str(json_gen_str_t *jstr, char *name, char *object_str)
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_push_array(json_gen_str_t *jstr, char *name);
+int json_gen_push_array(json_gen_str_t *jstr, const char *name);
 
 /** Pop a named JSON array
  *
@@ -257,7 +257,7 @@ int json_gen_pop_array(json_gen_str_t *jstr);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that.
  */
-int json_gen_push_array_str(json_gen_str_t *jstr, char *name, char *array_str);
+int json_gen_push_array_str(json_gen_str_t *jstr, const char *name, const char *array_str);
 
 /** Add a boolean element to an object
  *
@@ -276,7 +276,7 @@ int json_gen_push_array_str(json_gen_str_t *jstr, char *name, char *array_str);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_obj_set_bool(json_gen_str_t *jstr, char *name, bool val);
+int json_gen_obj_set_bool(json_gen_str_t *jstr, const char *name, bool val);
 
 /** Add an integer element to an object
  *
@@ -295,7 +295,7 @@ int json_gen_obj_set_bool(json_gen_str_t *jstr, char *name, bool val);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_obj_set_int(json_gen_str_t *jstr, char *name, int val);
+int json_gen_obj_set_int(json_gen_str_t *jstr, const char *name, int val);
 
 /** Add a float element to an object
  *
@@ -314,7 +314,7 @@ int json_gen_obj_set_int(json_gen_str_t *jstr, char *name, int val);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_obj_set_float(json_gen_str_t *jstr, char *name, float val);
+int json_gen_obj_set_float(json_gen_str_t *jstr, const char *name, float val);
 
 /** Add a string element to an object
  *
@@ -333,7 +333,7 @@ int json_gen_obj_set_float(json_gen_str_t *jstr, char *name, float val);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_obj_set_string(json_gen_str_t *jstr, char *name, char *val);
+int json_gen_obj_set_string(json_gen_str_t *jstr, const char *name, const char *val);
 
 /** Add a NULL element to an object
  *
@@ -351,7 +351,7 @@ int json_gen_obj_set_string(json_gen_str_t *jstr, char *name, char *val);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_obj_set_null(json_gen_str_t *jstr, char *name);
+int json_gen_obj_set_null(json_gen_str_t *jstr, const char *name);
 
 /** Add a boolean element to an array
  *
@@ -415,7 +415,7 @@ int json_gen_arr_set_float(json_gen_str_t *jstr, float val);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_arr_set_string(json_gen_str_t *jstr, char *val);
+int json_gen_arr_set_string(json_gen_str_t *jstr, const char *val);
 
 /** Add a NULL element to an array
  *
@@ -452,7 +452,7 @@ int json_gen_arr_set_null(json_gen_str_t *jstr);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_obj_start_long_string(json_gen_str_t *jstr, char *name, char *val);
+int json_gen_obj_start_long_string(json_gen_str_t *jstr, const char *name, const char *val);
 
 /** Start a Long string in an array
  *
@@ -473,7 +473,7 @@ int json_gen_obj_start_long_string(json_gen_str_t *jstr, char *name, char *val);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_arr_start_long_string(json_gen_str_t *jstr, char *val);
+int json_gen_arr_start_long_string(json_gen_str_t *jstr, const char *val);
 
 /** Add to a JSON Long string
  *
@@ -489,7 +489,7 @@ int json_gen_arr_start_long_string(json_gen_str_t *jstr, char *val);
  * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
  * added after that
  */
-int json_gen_add_to_long_string(json_gen_str_t *jstr, char *val);
+int json_gen_add_to_long_string(json_gen_str_t *jstr, const char *val);
 
 /** End a JSON Long string
  *

--- a/json_generator/src/json_generator.c
+++ b/json_generator/src/json_generator.c
@@ -34,7 +34,7 @@ static inline int json_gen_get_empty_len(json_gen_str_t *jstr)
  * flushed out will always be equal to the size of the buffer unless
  * this is the last chunk being flushed out on json_gen_end_str()
  */
-static int json_gen_add_to_str(json_gen_str_t *jstr, char *str)
+static int json_gen_add_to_str(json_gen_str_t *jstr, const char *str)
 {
     if (!str) {
         return 0;
@@ -44,7 +44,7 @@ static int json_gen_add_to_str(json_gen_str_t *jstr, char *str)
     if (jstr->buf == NULL) {
         return 0;
     }
-    char *cur_ptr = str;
+    const char *cur_ptr = str;
     while (1) {
         int len_remaining = json_gen_get_empty_len(jstr);
         int copy_len = len_remaining > len ? len : len_remaining;
@@ -102,7 +102,7 @@ static inline void json_gen_handle_comma(json_gen_str_t *jstr)
 }
 
 
-static int json_gen_handle_name(json_gen_str_t *jstr, char *name)
+static int json_gen_handle_name(json_gen_str_t *jstr, const char *name)
 {
     json_gen_add_to_str(jstr, "\"");
     json_gen_add_to_str(jstr, name);
@@ -137,7 +137,7 @@ int json_gen_end_array(json_gen_str_t *jstr)
     return json_gen_add_to_str(jstr, "]");
 }
 
-int json_gen_push_object(json_gen_str_t *jstr, char *name)
+int json_gen_push_object(json_gen_str_t *jstr, const char *name)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
@@ -151,7 +151,7 @@ int json_gen_pop_object(json_gen_str_t *jstr)
     return json_gen_add_to_str(jstr, "}");
 }
 
-int json_gen_push_object_str(json_gen_str_t *jstr, char *name, char *object_str)
+int json_gen_push_object_str(json_gen_str_t *jstr, const char *name, const char *object_str)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
@@ -159,7 +159,7 @@ int json_gen_push_object_str(json_gen_str_t *jstr, char *name, char *object_str)
     return json_gen_add_to_str(jstr, object_str);
 }
 
-int json_gen_push_array(json_gen_str_t *jstr, char *name)
+int json_gen_push_array(json_gen_str_t *jstr, const char *name)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
@@ -172,7 +172,7 @@ int json_gen_pop_array(json_gen_str_t *jstr)
     return json_gen_add_to_str(jstr, "]");
 }
 
-int json_gen_push_array_str(json_gen_str_t *jstr, char *name, char *array_str)
+int json_gen_push_array_str(json_gen_str_t *jstr, const char *name, const char *array_str)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
@@ -189,7 +189,7 @@ static int json_gen_set_bool(json_gen_str_t *jstr, bool val)
         return json_gen_add_to_str(jstr, "false");
     }
 }
-int json_gen_obj_set_bool(json_gen_str_t *jstr, char *name, bool val)
+int json_gen_obj_set_bool(json_gen_str_t *jstr, const char *name, bool val)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
@@ -210,7 +210,7 @@ static int json_gen_set_int(json_gen_str_t *jstr, int val)
     return json_gen_add_to_str(jstr, str);
 }
 
-int json_gen_obj_set_int(json_gen_str_t *jstr, char *name, int val)
+int json_gen_obj_set_int(json_gen_str_t *jstr, const char *name, int val)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
@@ -231,7 +231,7 @@ static int json_gen_set_float(json_gen_str_t *jstr, float val)
     snprintf(str, MAX_FLOAT_IN_STR, "%.*f", JSON_FLOAT_PRECISION, val);
     return json_gen_add_to_str(jstr, str);
 }
-int json_gen_obj_set_float(json_gen_str_t *jstr, char *name, float val)
+int json_gen_obj_set_float(json_gen_str_t *jstr, const char *name, float val)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
@@ -243,7 +243,7 @@ int json_gen_arr_set_float(json_gen_str_t *jstr, float val)
     return json_gen_set_float(jstr, val);
 }
 
-static int json_gen_set_string(json_gen_str_t *jstr, char *val)
+static int json_gen_set_string(json_gen_str_t *jstr, const char *val)
 {
     jstr->comma_req = true;
     json_gen_add_to_str(jstr, "\"");
@@ -251,40 +251,40 @@ static int json_gen_set_string(json_gen_str_t *jstr, char *val)
     return json_gen_add_to_str(jstr, "\"");
 }
 
-int json_gen_obj_set_string(json_gen_str_t *jstr, char *name, char *val)
+int json_gen_obj_set_string(json_gen_str_t *jstr, const char *name, const char *val)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
     return json_gen_set_string(jstr, val);
 }
 
-int json_gen_arr_set_string(json_gen_str_t *jstr, char *val)
+int json_gen_arr_set_string(json_gen_str_t *jstr, const char *val)
 {
     json_gen_handle_comma(jstr);
     return json_gen_set_string(jstr, val);
 }
 
-static int json_gen_set_long_string(json_gen_str_t *jstr, char *val)
+static int json_gen_set_long_string(json_gen_str_t *jstr, const char *val)
 {
     jstr->comma_req = true;
     json_gen_add_to_str(jstr, "\"");
     return json_gen_add_to_str(jstr, val);
 }
 
-int json_gen_obj_start_long_string(json_gen_str_t *jstr, char *name, char *val)
+int json_gen_obj_start_long_string(json_gen_str_t *jstr, const char *name, const char *val)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);
     return json_gen_set_long_string(jstr, val);
 }
 
-int json_gen_arr_start_long_string(json_gen_str_t *jstr, char *val)
+int json_gen_arr_start_long_string(json_gen_str_t *jstr, const char *val)
 {
     json_gen_handle_comma(jstr);
     return json_gen_set_long_string(jstr, val);
 }
 
-int json_gen_add_to_long_string(json_gen_str_t *jstr, char *val)
+int json_gen_add_to_long_string(json_gen_str_t *jstr, const char *val)
 {
     return json_gen_add_to_str(jstr, val);
 }
@@ -298,7 +298,7 @@ static int json_gen_set_null(json_gen_str_t *jstr)
     jstr->comma_req = true;
     return json_gen_add_to_str(jstr, "null");
 }
-int json_gen_obj_set_null(json_gen_str_t *jstr, char *name)
+int json_gen_obj_set_null(json_gen_str_t *jstr, const char *name)
 {
     json_gen_handle_comma(jstr);
     json_gen_handle_name(jstr, name);


### PR DESCRIPTION
# Change description
The latest commit from the source repository (https://github.com/espressif/json_generator/commit/17507cce331e8e2056593dc01f5adf0a8b6f63ef) was missing here
