### PR TITLE
feat: use esp-idf-sbom-action for vulnerability scan

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -2,8 +2,9 @@ name: Vulnerability scan
 
 on:
   schedule:
-     - cron: '0 0 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
+
 
 jobs:
   vulnerability-scan:
@@ -12,24 +13,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Install esp-idf-sbom
-        run: pip3 install esp-idf-sbom
+        with:
+          submodules: recursive
 
       - name: Vulnerability scan
-        id: scan
-        run: python3 -m esp_idf_sbom manifest check
-
-      - name: Send result
-        if: ${{ !cancelled() && github.repository_owner == 'espressif' }}
         env:
-          MATTERMOST_WEBHOOK: ${{ secrets.MATTERMOST_WEBHOOK }}
-          # Uses ternary operator. The double quotes are needed because of the colons
-          # for mattermost markup, which are confusing the yaml parser.
-          MSG: "${{ steps.scan.outcome == 'success' && ':large_green_circle: No vulnerabilities found' || ':red_circle: New vulnerabilities found' }}"
-          JOB_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
-          USER_NAME: ${{ 'idf-extra-components' }}
-        run: |
-          curl --no-progress-meter -i -X POST -H 'Content-Type: application/json'\
-               -d "{\"username\": \"${USER_NAME}\", \"text\": \"${MSG} ${JOB_URL}\"}"\
-               "$MATTERMOST_WEBHOOK"
+          SBOM_MATTERMOST_WEBHOOK: ${{ secrets.SBOM_MATTERMOST_WEBHOOK }}
+          NVDAPIKEY: ${{ secrets.NVDAPIKEY }}
+        uses: espressif/esp-idf-sbom-action@master


### PR DESCRIPTION
This replaces the current approach to use the new esp-idf-sbom-action.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
