### PR TITLE
feat(usb/esp_tinyusb): Update manifest file

### DIFF
--- a/usb/esp_tinyusb/CMakeLists.txt
+++ b/usb/esp_tinyusb/CMakeLists.txt
@@ -37,8 +37,7 @@ idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"
                        PRIV_INCLUDE_DIRS "include_private"
                        PRIV_REQUIRES usb
-                       REQUIRES fatfs vfs
-                       REQUIRED_IDF_TARGETS esp32s2 esp32s3
+                       REQUIRES fatfs vfs                 
                        )
 
 # Determine whether tinyusb is fetched from component registry or from local path

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,14 +1,10 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.4.2~1"
+version: "1.4.2~2"
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
     version: '>=0.14.2'
-    public: true
-targets:
-  - esp32s2
-  - esp32s3
-  - esp32p4
+    public: true    


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Changes in version 1.4.2~2
Changes required for future extension of supported targets. 

- Removed `REQUIRED_IDF_TARGETS` from CMakeLists.txt to handle supported targets only with manifest file. 
- Removed targets from idf_component.yml. Now the target dependency will be handled only by the dependency components. 


