### PR TITLE
feat(usb/esp_tinyusb): Add AUDIO Device Class configuration to Konfig

### DIFF
--- a/usb/esp_tinyusb/CHANGELOG.md
+++ b/usb/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.3
+- esp_tinyusb: Add AUDIO class driver configuration or tinyUSB
+
 ## 1.4.2
 
 - MSC: Fix maximum files open

--- a/usb/esp_tinyusb/Kconfig
+++ b/usb/esp_tinyusb/Kconfig
@@ -184,6 +184,14 @@ menu "TinyUSB Stack"
                 CDC FIFO size of TX channel.
     endmenu # "Communication Device Class"
 
+    menu "Audio Device Class (ADC)"
+        config TINYUSB_AUDIO_ENABLED
+            bool "Enable TinyUSB AUDIO feature"
+            default n
+            help
+                Enable TinyUSB Audio feature.
+    endmenu # "Audio Device Class"
+
     menu "Musical Instrument Digital Interface (MIDI)"
         config TINYUSB_MIDI_COUNT
             int "TinyUSB MIDI interfaces count"

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.4.2~2"
+version: "1.4.3"
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule

--- a/usb/esp_tinyusb/include/tusb_config.h
+++ b/usb/esp_tinyusb/include/tusb_config.h
@@ -49,6 +49,10 @@ extern "C" {
 #   define CONFIG_TINYUSB_HID_COUNT 0
 #endif
 
+#ifndef CONFIG_TINYUSB_AUDIO_ENABLED
+#   define CONFIG_TINYUSB_AUDIO_ENABLED 0
+#endif
+
 #ifndef CONFIG_TINYUSB_MIDI_COUNT
 #   define CONFIG_TINYUSB_MIDI_COUNT 0
 #endif
@@ -114,6 +118,17 @@ extern "C" {
 // MSC Buffer size of Device Mass storage
 #define CFG_TUD_MSC_BUFSIZE         CONFIG_TINYUSB_MSC_BUFSIZE
 
+// AUDIO macros
+#define CFG_TUD_AUDIO_FUNC_1_DESC_LEN                                 TUD_AUDIO_MIC_ONE_CH_DESC_LEN
+#define CFG_TUD_AUDIO_FUNC_1_N_AS_INT                                 1
+#define CFG_TUD_AUDIO_FUNC_1_CTRL_BUF_SZ                              64
+#define CFG_TUD_AUDIO_ENABLE_EP_IN                                    1
+#define CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX                    2
+#define CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX                            1
+#define CFG_TUD_AUDIO_EP_SZ_IN                                        (48+1) * CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX
+#define CFG_TUD_AUDIO_FUNC_1_EP_IN_SZ_MAX                             CFG_TUD_AUDIO_EP_SZ_IN
+#define CFG_TUD_AUDIO_FUNC_1_EP_IN_SW_BUF_SZ                          CFG_TUD_AUDIO_EP_SZ_IN + 1
+
 // MIDI macros
 #define CFG_TUD_MIDI_EP_BUFSIZE     64
 #define CFG_TUD_MIDI_EPSIZE         CFG_TUD_MIDI_EP_BUFSIZE
@@ -135,6 +150,7 @@ extern "C" {
 #define CFG_TUD_CDC                 CONFIG_TINYUSB_CDC_COUNT
 #define CFG_TUD_MSC                 CONFIG_TINYUSB_MSC_ENABLED
 #define CFG_TUD_HID                 CONFIG_TINYUSB_HID_COUNT
+#define CFG_TUD_AUDIO               CONFIG_TINYUSB_AUDIO_ENABLED
 #define CFG_TUD_MIDI                CONFIG_TINYUSB_MIDI_COUNT
 #define CFG_TUD_CUSTOM_CLASS        CONFIG_TINYUSB_CUSTOM_CLASS_ENABLED
 #define CFG_TUD_ECM_RNDIS           CONFIG_TINYUSB_NET_MODE_ECM_RNDIS


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# v1.4.3 Change description
- Adding the possibility to config the tinyUSB Audio Device Class with KConfig


Closes https://github.com/espressif/esp-idf/issues/12774