### PR TITLE
esp_tinyusb v1.4.3:  ESP32P4 HS only support

### DIFF
--- a/usb/esp_tinyusb/CHANGELOG.md
+++ b/usb/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.3
+- esp_tinyusb: ESP32P4 HS only support
+
 ## 1.4.2
 
 - MSC: Fix maximum files open

--- a/usb/esp_tinyusb/Kconfig
+++ b/usb/esp_tinyusb/Kconfig
@@ -6,6 +6,17 @@ menu "TinyUSB Stack"
         help
             Specify verbosity of TinyUSB log output.
 
+    choice TINYUSB_RHPORT
+        depends on IDF_TARGET_ESP32P4
+        prompt "TinyUSB PHY"
+        default TINYUSB_RHPORT_HS
+        help
+            Allows set the USB PHY Controller for TinyUSB: HS (USB OTG2.0 PHY for HighSpeed)
+             
+        config TINYUSB_RHPORT_HS
+            bool "HS"
+    endchoice
+
     menu "TinyUSB task configuration"
         config TINYUSB_NO_DEFAULT_TASK
             bool "Do not create a TinyUSB task"

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.4.2~2"
+version: "1.4.3"
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule

--- a/usb/esp_tinyusb/include/tusb_config.h
+++ b/usb/esp_tinyusb/include/tusb_config.h
@@ -82,7 +82,12 @@ extern "C" {
 #   define CONFIG_TINYUSB_DEBUG_LEVEL 0
 #endif
 
-#define CFG_TUSB_RHPORT0_MODE       OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED
+#ifdef CONFIG_TINYUSB_RHPORT_HS
+#   define CFG_TUSB_RHPORT1_MODE    OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED
+#else
+#   define CFG_TUSB_RHPORT0_MODE    OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED
+#endif
+
 #define CFG_TUSB_OS                 OPT_OS_FREERTOS
 
 /* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [X] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [X] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [X] _Optional:_ Component contains unit tests
- [ ] CI passing

# Changes
- Added USB OTG PHY HS configuration in KConfig for ESP32P4

Hint: For better experience and verification use TinyUSB v0.15.0~4