### PR TITLE
feat(ci): Build with IDF 5.1 and 5.2

### DIFF
--- a/.github/workflows/build_and_run_examples.yml
+++ b/.github/workflows/build_and_run_examples.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "latest"]
+        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         parallel_index: [1,2,3,4,5] # This must from 1 to 'parallel_count' defined in .idf_build_apps.toml
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "latest"]
+        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32"]
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}"]
     container:
@@ -76,7 +76,7 @@ jobs:
         # Hence, not considering IDF v4.x releases here. If we find a clean way
         # to let pytest know about IDF release dependency then we may reintroduce
         # the IDF v4.x in the list.
-        idf_ver: ["release-v5.0", "release-v5.1", "latest"]
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32"]
     runs-on: [self-hosted, ESP32-ETHERNET-KIT]
     container:

--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -12,11 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v4.3", "release-v4.4", "release-v5.0", "latest"]
+        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32", "esp32c3", "esp32s3"] # @todo ESP32S2 has less RAM and the test_app will not fit
-        exclude:
-          - idf_ver: "release-v4.3"
-            idf_target: esp32s3 # ESP32S3 support started with version 4.4
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
@@ -72,11 +69,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v4.3", "release-v4.4", "release-v5.0", "latest"]
+        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32", "esp32c3", "esp32s3"]
-        exclude:
-          - idf_ver: "release-v4.3"
-            idf_target: esp32s3 # ESP32S3 support started with version 4.4
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}"]
     container:
       image: python:3.7-buster

--- a/.github/workflows/build_and_run_test_app_usb.yml
+++ b/.github/workflows/build_and_run_test_app_usb.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, reopened, synchronize]
     paths:
       - 'usb/**'
+      - 'workflows/build_and_run_test_app_usb.yml'
 
 jobs:
   build:
@@ -14,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v4.4", "release-v5.0", "latest"]
+        idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32s2", "esp32s3"]
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
@@ -50,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.0", "latest"]
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32s2"]
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "usb_host"]
     container:


### PR DESCRIPTION
Add esp-idf release-v5.1 and release-v5.2 to CI build and test jobs.

Migrating to idf-build-apps will be done in a different PR
Related https://github.com/espressif/idf-extra-components/issues/16 and https://github.com/espressif/idf-extra-components/issues/149
