### PR TITLE
esp_tinyusb v1.4.4: Refactor External USB PHY dependencies

### DIFF
--- a/usb/esp_tinyusb/CHANGELOG.md
+++ b/usb/esp_tinyusb/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.4
+- esp_tinyusb: Make usb_phy available only for ESP32S2 and ESP32S3
+
 ## 1.4.3
 - esp_tinyusb: ESP32P4 HS only support
 

--- a/usb/esp_tinyusb/CMakeLists.txt
+++ b/usb/esp_tinyusb/CMakeLists.txt
@@ -4,6 +4,10 @@ set(srcs
     "usb_descriptors.c"
     )
 
+if(CONFIG_IDF_TARGET_ESP32S2 OR CONFIG_IDF_TARGET_ESP32S3)
+    list(APPEND srcs "tinyusb_ext_phy.c")
+endif()
+
 if(NOT CONFIG_TINYUSB_NO_DEFAULT_TASK)
     list(APPEND srcs "tusb_tasks.c")
 endif() # CONFIG_TINYUSB_NO_DEFAULT_TASK
@@ -37,7 +41,7 @@ idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include"
                        PRIV_INCLUDE_DIRS "include_private"
                        PRIV_REQUIRES usb
-                       REQUIRES fatfs vfs                 
+                       REQUIRES fatfs vfs
                        )
 
 # Determine whether tinyusb is fetched from component registry or from local path

--- a/usb/esp_tinyusb/idf_component.yml
+++ b/usb/esp_tinyusb/idf_component.yml
@@ -1,10 +1,10 @@
 ## IDF Component Manager Manifest File
 description: Espressif's additions to TinyUSB
 documentation: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html"
-version: "1.4.3"
+version: "1.4.4"
 url: https://github.com/espressif/idf-extra-components/tree/master/usb/esp_tinyusb
 dependencies:
   idf: '>=5.0' # IDF 4.x contains TinyUSB as submodule
   tinyusb:
     version: '>=0.14.2'
-    public: true    
+    public: true

--- a/usb/esp_tinyusb/include_private/tinyusb_ext_phy.h
+++ b/usb/esp_tinyusb/include_private/tinyusb_ext_phy.h
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include "esp_private/usb_phy.h"
+#include "soc/usb_pins.h"
+#include "tinyusb.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configure and install new USB PHY
+ *
+ * @param[in] config tinyusb stack specific configuration
+ */
+esp_err_t tinyusb_ext_phy_new(const tinyusb_config_t *config);
+
+/**
+ * @brief Delete previously installed USB PHY
+ *
+ */
+esp_err_t tinyusb_ext_phy_delete(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/usb/esp_tinyusb/tinyusb_ext_phy.c
+++ b/usb/esp_tinyusb/tinyusb_ext_phy.c
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "tinyusb_ext_phy.h"
+
+static usb_phy_handle_t phy_hdl;
+
+esp_err_t tinyusb_ext_phy_new(const tinyusb_config_t *config)
+{
+    // Configure USB PHY
+    usb_phy_config_t phy_conf = {0};
+
+    phy_conf.controller = USB_PHY_CTRL_OTG;
+    phy_conf.otg_mode = USB_OTG_MODE_DEVICE;
+
+    if (config->external_phy) {
+        // External PHY IOs config
+        usb_phy_ext_io_conf_t ext_io_conf = { 0 };
+        ext_io_conf.vp_io_num = USBPHY_VP_NUM;
+        ext_io_conf.vm_io_num = USBPHY_VM_NUM;
+        ext_io_conf.rcv_io_num = USBPHY_RCV_NUM;
+        ext_io_conf.oen_io_num = USBPHY_OEN_NUM;
+        ext_io_conf.vpo_io_num = USBPHY_VPO_NUM;
+        ext_io_conf.vmo_io_num = USBPHY_VMO_NUM;
+
+        phy_conf.target = USB_PHY_TARGET_EXT;
+        phy_conf.ext_io_conf = &ext_io_conf;
+    } else {
+        phy_conf.target = USB_PHY_TARGET_INT;
+    }
+
+    // OTG IOs config
+    const usb_phy_otg_io_conf_t otg_io_conf = USB_PHY_SELF_POWERED_DEVICE(config->vbus_monitor_io);
+    if (config->self_powered) {
+        phy_conf.otg_io_conf = &otg_io_conf;
+    }
+    return usb_new_phy(&phy_conf, &phy_hdl);
+}
+
+esp_err_t tinyusb_ext_phy_delete(void)
+{
+    return usb_del_phy(phy_hdl);
+}


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
- Add dependency for usb_phy for ESP32S2 and ESP32S3. ESP32P4 doesn't require usb_phy and as the result the usb component itself from esp-idf. 
