### PR TITLE
led_strip: Add support for WS2812B-V5  (IEC-84)

### DIFF
--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.5.2"
+version: "2.5.3"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 dependencies:

--- a/led_strip/src/led_strip_rmt_encoder.c
+++ b/led_strip/src/led_strip_rmt_encoder.c
@@ -123,7 +123,7 @@ esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rm
     rmt_copy_encoder_config_t copy_encoder_config = {};
     ESP_GOTO_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_config, &led_encoder->copy_encoder), err, TAG, "create copy encoder failed");
 
-    uint32_t reset_ticks = config->resolution / 1000000 * 50 / 2; // reset code duration defaults to 50us
+    uint32_t reset_ticks = config->resolution / 1000000 * 280 / 2; // reset code duration defaults to 280us to accomodate WS2812B-V5
     led_encoder->reset_code = (rmt_symbol_word_t) {
         .level0 = 0,
         .duration0 = reset_ticks,


### PR DESCRIPTION
WS2812B-V5 requires >280 microsecond reset time.

When led_strip with 50 microsecond reset time is used with WS2812B-V5 LEDs, most will handle reset correctly, but about 1/3 of certain transmission patterns would cause 1-2 LEDs in a long strip to fail to reset, leading to duplicated colors further down the led strip. Increase the reset time to 280 microseconds, which is compatible with led pixels requiring 50+ microsecond reset time as well.

![image](https://github.com/espressif/idf-extra-components/assets/146753361/1ca61fd3-109f-4a38-a4e6-cf7e5bf235cf)

