### PR TITLE
usb_host_hid v1.0.2: Refactor HID Interfaces parsing

### DIFF
--- a/usb/usb_host_hid/test/hid_mock_device.c
+++ b/usb/usb_host_hid/test/hid_mock_device.c
@@ -68,7 +68,7 @@ static const uint8_t hid_configuration_descriptor_two_ifaces[] = {
 
     // Interface number, string index, boot protocol, report descriptor len, EP In address, size & polling interval
     TUD_HID_DESCRIPTOR(0, 4, HID_ITF_PROTOCOL_KEYBOARD, sizeof(hid_keyboard_report_descriptor), 0x81, 16, 10),
-    TUD_HID_DESCRIPTOR(1, 4, HID_ITF_PROTOCOL_MOUSE, sizeof(hid_mouse_report_descriptor), 0x82, 16, 10),
+    TUD_HID_DESCRIPTOR(2, 4, HID_ITF_PROTOCOL_MOUSE, sizeof(hid_mouse_report_descriptor), 0x82, 16, 10),
 };
 
 static const uint8_t *hid_configuration_descriptor_list[TUSB_IFACE_COUNT_MAX] = {


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
- Refactored parsing Interfaces descriptor of the USB HID device. Fixed the crash, when USB HID device has two interfaces with inconsistent numbers (e.g. Device has two Interfaces with bInterfaceNumber=0 and bInterfaceNumber=2). 
