### PR TITLE
feat(catch2): update to 3.5.2

### DIFF
--- a/catch2/idf_component.yml
+++ b/catch2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.4.0~4"
+version: "3.5.2"
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/espressif/idf-extra-components/tree/master/catch2
 repository: https://github.com/espressif/idf-extra-components.git

--- a/catch2/sbom_catch2.yml
+++ b/catch2/sbom_catch2.yml
@@ -1,8 +1,7 @@
 name: catch2
-version: 3.4.0
+version: 3.5.2
 cpe: cpe:2.3:a:catchorg:catch2:{}:*:*:*:*:*:*:*
 supplier: 'Organization: catchorg <https://github.com/catchorg>'
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/catchorg/Catch2
-hash: 6e79e682b726f524310d55dec8ddac4e9c52fb5f
-
+hash: 05e10dfccc28c7f973727c54f850237d07d5e10f


### PR DESCRIPTION
This PR updates Catch2 from 3.4.0 to 3.5.2. I have tested that both examples still work.