### PR TITLE
expat: Update version to v2.6.0

### DIFF
--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.5.0~1"
+version: "2.6.0"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:

--- a/expat/port/include/expat_config.h
+++ b/expat/port/include/expat_config.h
@@ -14,6 +14,10 @@
 
 /* Define to 1 if you have the `getpagesize' function. */
 #define HAVE_GETPAGESIZE 1
+
+/* Define to 1 if you have the `getrandom' function. */
+#define HAVE_GETRANDOM 1
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
 
@@ -63,7 +67,7 @@
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.5.0"
+#define PACKAGE_STRING "expat 2.6.0"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -72,13 +76,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.5.0"
+#define PACKAGE_VERSION "2.6.0"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.5.0"
+#define VERSION "2.6.0"
 
 /* whether byteorder is bigendian */
 /* #undef WORDS_BIGENDIAN */
@@ -89,6 +93,9 @@
 
 /* Define to make parameter entity parsing functionality available. */
 #define XML_DTD 1
+
+/* Define as 1/0 to enable/disable support for general entities. */
+#define XML_GE 1
 
 /* Define to make XML Namespaces functionality available. */
 #define XML_NS 1

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -1,7 +1,7 @@
 name: libexpat
-version: 2.5.0
+version: 2.6.0
 cpe: cpe:2.3:a:libexpat_project:libexpat:{}:*:*:*:*:*:*:*
 supplier: 'Organization: libexpat_project'
 description: Fast streaming XML parser written in C99
 url: https://github.com/libexpat/libexpat/
-hash: 454c6105bc2d0ea2521b8f8f7a5161c2abd8c386
+hash: 849da3e3fe727fccef5e96ef35482d66447f06a2


### PR DESCRIPTION
Update expat to v2.6.0
This update includes some security fixes:
* CVE-2023-52425
* CVE-2023-52426

Release Notes: https://github.com/libexpat/libexpat/releases/tag/R_2_6_0