### PR TITLE
feat: Update expat to v2.6.2

### DIFF
--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.6.0"
+version: "2.6.2"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:

--- a/expat/port/include/expat_config.h
+++ b/expat/port/include/expat_config.h
@@ -67,7 +67,7 @@
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.6.0"
+#define PACKAGE_STRING "expat 2.6.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -76,13 +76,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.6.0"
+#define PACKAGE_VERSION "2.6.2"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.6.0"
+#define VERSION "2.6.2"
 
 /* whether byteorder is bigendian */
 /* #undef WORDS_BIGENDIAN */

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -1,7 +1,7 @@
 name: libexpat
-version: 2.6.0
+version: 2.6.2
 cpe: cpe:2.3:a:libexpat_project:libexpat:{}:*:*:*:*:*:*:*
 supplier: 'Organization: libexpat_project'
 description: Fast streaming XML parser written in C99
 url: https://github.com/libexpat/libexpat/
-hash: 849da3e3fe727fccef5e96ef35482d66447f06a2
+hash: fa75b96546c069d17b8f80d91e0f4ef0cde3790d


### PR DESCRIPTION
Update expat to v2.6.2
It includes some security fixes:
* CVE-2024-28757

Changelog: https://github.com/libexpat/libexpat/releases/tag/R_2_6_2
