### PR TITLE
fix(ccomp_timer): require perfmon only on xtensa

### DIFF
--- a/ccomp_timer/CMakeLists.txt
+++ b/ccomp_timer/CMakeLists.txt
@@ -1,3 +1,5 @@
+idf_build_get_property(arch IDF_TARGET_ARCH)
+
 set(srcs "ccomp_timer.c")
 
 if(CONFIG_IDF_TARGET_ARCH_RISCV)
@@ -8,7 +10,13 @@ if(CONFIG_IDF_TARGET_ARCH_XTENSA)
     list(APPEND srcs "ccomp_timer_impl_xtensa.c")
 endif()
 
+if("${arch}" STREQUAL "xtensa")
+    set(priv_requires perfmon driver)
+else()
+    set(priv_requires driver)
+endif()
+
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS include
                        PRIV_INCLUDE_DIRS private_include
-                       PRIV_REQUIRES perfmon driver)
+                       PRIV_REQUIRES "${priv_requires}")

--- a/ccomp_timer/idf_component.yml
+++ b/ccomp_timer/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.0~1"
 description: Cache Compensated Timer
 url: https://github.com/espressif/idf-extra-components/tree/master/ccomp_timer
 issues: "https://github.com/espressif/idf-extra-components/issues"


### PR DESCRIPTION
The perfmon component is supported[1] only on xtensa arch, so it should not be in requires for other archs.

[1] https://github.com/espressif/esp-idf/blob/master/components/perfmon/CMakeLists.txt#L9-L11

Fixes: 5d61b5047f37 ("test_utils: implement performance timer")
