### PR TITLE
fix(freetype): Remove system lib dependencies (IEC-103)

### DIFF
--- a/freetype/CMakeLists.txt
+++ b/freetype/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register()
 
+set(CMAKE_SYSTEM_IGNORE_PATH "/usr/include;/usr/lib/x86_64-linux-gnu")
 set(BUILD_SHARED_LIBS OFF)
-option(BUILD_TESTING OFF)
 
 function(install)
 endfunction()

--- a/freetype/idf_component.yml
+++ b/freetype/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.13.0~1"
+version: "2.13.0~2"
 description: freetype C library
 url: https://github.com/espressif/idf-extra-components/tree/master/freetype
 repository: "https://github.com/espressif/idf-extra-components.git"


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

1. Remove system lib dependencies: If the package required by `find_package` (such as `BrotliDec`, `HarfBuzz`) exists locally on Linux, the local lib will be used, causing compilation failure.
`-- Found BrotliDec: /usr/include (found version "1.0.9")`
`-- HarfBuzz (required): /usr/lib/x86_64-linux-gnu/libharfbuzz.so`
`/usr/include/stdlib.h:258:25: error: '_Float64x' is not supported on this target`