### PR TITLE
coap: Remove compile option to disable format warning

### DIFF
--- a/coap/CMakeLists.txt
+++ b/coap/CMakeLists.txt
@@ -43,5 +43,4 @@ endif()
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS "${include_dirs}"
                     REQUIRES lwip mbedtls)
-target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-format")
 


### PR DESCRIPTION
Format warnings have been fixed in coap in https://github.com/obgm/libcoap/commit/8c15b896ef30a0a440ee00aa68678a4f2c051bf4

Remove compile option which disables format warnings

Related to https://github.com/espressif/idf-extra-components/issues/65