### PR TITLE
feat(network_prov): Add wifi_prov or thread_prov in provision capabilities (IEC-105)

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 23-April-2024
+
+- Add `wifi_prov` or `thread_prov` in provision capabilities in the network provisioning manager for the provisioner to distinguish Thread or Wi-Fi devices
+
 # 16-April-2024
 
 - Move wifi_provisioning component from ESP-IDF at commit 5a40bb8746 and rename it to network_provisioning with the addition of Thread provisioning support.

--- a/network_provisioning/examples/thread_prov/README.md
+++ b/network_provisioning/examples/thread_prov/README.md
@@ -74,12 +74,12 @@ Make sure to note down the Bluetooth LE device name (starting with `PROV_`) disp
 In a separate terminal run the `esp_prov.py` script under [directory](../../tool/esp_prov/) (make sure to replace `dataset_tlvs` with the dataset of the Thread network to which the device is supposed to connect to after provisioning). Assuming default example configuration, which uses the protocomm security version 2:
 
 ```
-python esp_prov.py --network_proto thread --transport ble --service_name PROV_F72E6B --sec_ver 2 --sec2_username threadprov --sec2_pwd abcd1234 --dataset_tlvs <dataset_tlvs>
+python esp_prov.py --transport ble --service_name PROV_F72E6B --sec_ver 2 --sec2_username threadprov --sec2_pwd abcd1234 --dataset_tlvs <dataset_tlvs>
 ```
 
 For security scheme 1 with PoP-based (proof-of-possession) authentication, the following command can be used:
 ```
-python esp_prov.py --network_proto thread --transport ble --service_name PROV_F72E6B --sec_ver 1 --pop abcd1234 --dataset_tlvs <dataset_tlvs>
+python esp_prov.py --transport ble --service_name PROV_F72E6B --sec_ver 1 --pop abcd1234 --dataset_tlvs <dataset_tlvs>
 ```
 
 Above command will perform the provisioning steps, and the monitor log should display something like this :
@@ -114,7 +114,7 @@ I (55355) app: Hello World!
 The config option `CONFIG_EXAMPLE_PROV_SEC2_DEV_MODE` should be enabled for the example and in `main/app_main.c`, the macro `EXAMPLE_PROV_SEC2_USERNAME` should be set to the same username used in the salt-verifier generation.
 
 ```log
-$ python esp_prov.py --network_proto thread --transport ble --sec_ver 2 --sec2_gen_cred --sec2_username threadprov --sec2_pwd abcd1234
+$ python esp_prov.py --transport ble --sec_ver 2 --sec2_gen_cred --sec2_username threadprov --sec2_pwd abcd1234
 ==== Salt-verifier for security scheme 2 (SRP6a) ====
 static const char sec2_salt[] = {
     0x1f, 0xff, 0x29, 0xf5, 0xc7, 0x7e, 0x07, 0x48, 0x02, 0xe9, 0x93, 0x3e, 0xa3, 0xa2, 0x26, 0x73
@@ -179,7 +179,7 @@ Provisioning manager also supports providing real-time Thread scan results (perf
 When using the scan based provisioning, we don't need to specify the `--dataset_tlvs` fields explicitly:
 
 ```
-python esp_prov.py --network_proto thread --transport ble --service_name PROV_F72E6B --pop abcd1234
+python esp_prov.py --transport ble --service_name PROV_F72E6B --pop abcd1234
 ```
 
 See below the sample output from `esp_prov` tool on running above command:
@@ -238,7 +238,7 @@ Enter Thread network key string :
 `esp_prov` supports interactive provisioning. You can trigger the script with a simplified command and input the necessary details
 (`Proof-of-possession` for security scheme 1 and `SRP6a username`, `SRP6a password` for security scheme 2) as the provisioning process advances.
 
-The command `python esp_prov.py --network_proto thread --transport ble --sec_ver 2` gives out the following sample output:
+The command `python esp_prov.py --transport ble --sec_ver 2` gives out the following sample output:
 
 ```
 Discovering...

--- a/network_provisioning/examples/thread_prov/main/app_main.c
+++ b/network_provisioning/examples/thread_prov/main/app_main.c
@@ -112,7 +112,7 @@ static esp_err_t example_get_sec2_verifier(const char **verifier, uint16_t *veri
 const int THREAD_ATTACHED_EVENT = BIT0;
 static EventGroupHandle_t thread_event_group;
 
-#define PROV_QR_VERSION         "v2"
+#define PROV_QR_VERSION         "v1"
 #define PROV_TRANSPORT_BLE      "ble"
 #define QRCODE_BASE_URL         "https://espressif.github.io/esp-jumpstart/qrcode.html"
 
@@ -206,17 +206,16 @@ static void network_prov_print_qr(const char *name, const char *username, const 
     if (pop) {
 #if CONFIG_EXAMPLE_PROV_SECURITY_VERSION_1
         snprintf(payload, sizeof(payload), "{\"ver\":\"%s\",\"name\":\"%s\"" \
-                 ",\"pop\":\"%s\",\"transport\":\"%s\",\"network\":\"thread\"}",
+                 ",\"pop\":\"%s\",\"transport\":\"%s\"}",
                  PROV_QR_VERSION, name, pop, transport);
 #elif CONFIG_EXAMPLE_PROV_SECURITY_VERSION_2
         snprintf(payload, sizeof(payload), "{\"ver\":\"%s\",\"name\":\"%s\"" \
-                 ",\"username\":\"%s\",\"pop\":\"%s\",\"transport\":\"%s\"" \
-                 ",\"network\":\"thread\"}",
+                 ",\"username\":\"%s\",\"pop\":\"%s\",\"transport\":\"%s\"}",
                  PROV_QR_VERSION, name, username, pop, transport);
 #endif
     } else {
         snprintf(payload, sizeof(payload), "{\"ver\":\"%s\",\"name\":\"%s\"" \
-                 ",\"transport\":\"%s\",\"network\":\"thread\"}",
+                 ",\"transport\":\"%s\"}",
                  PROV_QR_VERSION, name, transport);
     }
 #ifdef CONFIG_EXAMPLE_PROV_SHOW_QR

--- a/network_provisioning/examples/thread_prov/main/idf_component.yml
+++ b/network_provisioning/examples/thread_prov/main/idf_component.yml
@@ -3,6 +3,6 @@ dependencies:
   espressif/qrcode:
       version: "^0.1.0"
   espressif/network_provisioning:
-      version: "^0.1.0"
+      version: "^0.2.0"
       override_path: '../../../'
 

--- a/network_provisioning/examples/wifi_prov/README.md
+++ b/network_provisioning/examples/wifi_prov/README.md
@@ -73,12 +73,12 @@ Make sure to note down the Bluetooth LE device name (starting with `PROV_`) disp
 In a separate terminal run the `esp_prov.py` script under [directory](../../tool/esp_prov) (make sure to replace `myssid` and `mypassword` with the credentials of the AP to which the device is supposed to connect to after provisioning). Assuming default example configuration, which uses the protocomm security version 2 with username and password authentication:
 
 ```
-python esp_prov.py --network_proto wifi --transport ble --service_name PROV_01B1E8 --sec_ver 2 --sec2_username wifiprov --sec2_pwd abcd1234 --ssid myssid --passphrase mypassword
+python esp_prov.py --transport ble --service_name PROV_01B1E8 --sec_ver 2 --sec2_username wifiprov --sec2_pwd abcd1234 --ssid myssid --passphrase mypassword
 ```
 
 For security scheme 1 with PoP-based (proof-of-possession) authentication, the following command can be used:
 ```
-python esp_prov.py --network_proto wifi --transport ble --service_name PROV_01B1E8 --sec_ver 1 --pop abcd1234 --ssid myssid --passphrase mypassword
+python esp_prov.py --transport ble --service_name PROV_01B1E8 --sec_ver 1 --pop abcd1234 --ssid myssid --passphrase mypassword
 ```
 
 Above command will perform the provisioning steps, and the monitor log should display something like this :
@@ -115,7 +115,7 @@ I (55355) app: Hello World!
 The config option `CONFIG_EXAMPLE_PROV_SEC2_DEV_MODE` should be enabled for the example and in `main/app_main.c`, the macro `EXAMPLE_PROV_SEC2_USERNAME` should be set to the same username used in the salt-verifier generation.
 
 ```log
-$ python esp_prov.py --network_proto wifi --transport softap --sec_ver 2 --sec2_gen_cred --sec2_username wifiprov --sec2_pwd abcd1234
+$ python esp_prov.py --transport softap --sec_ver 2 --sec2_gen_cred --sec2_username wifiprov --sec2_pwd abcd1234
 ==== Salt-verifier for security scheme 2 (SRP6a) ====
 static const char sec2_salt[] = {
     0x03, 0x6e, 0xe0, 0xc7, 0xbc, 0xb9, 0xed, 0xa8, 0x4c, 0x9e, 0xac, 0x97, 0xd9, 0x3d, 0xec, 0xf4
@@ -177,7 +177,7 @@ Provisioning manager also supports providing real-time Wi-Fi scan results (perfo
 When using the scan based provisioning, we don't need to specify the `--ssid` and `--passphrase` fields explicitly:
 
 ```
-python esp_prov.py --network_proto wifi --transport ble --service_name PROV_01B1E8 --pop abcd1234
+python esp_prov.py --transport ble --service_name PROV_01B1E8 --pop abcd1234
 ```
 
 See below the sample output from `esp_prov` tool on running above command:
@@ -223,7 +223,7 @@ Enter passphrase for MyHomeWiFiAP :
 `esp_prov` supports interactive provisioning. You can trigger the script with a simplified command and input the necessary details
 (`Proof-of-possession` for security scheme 1 and `SRP6a username`, `SRP6a password` for security scheme 2) as the provisioning process advances.
 
-The command `python esp_prov.py --network_proto wifi --transport ble --sec_ver 1` gives out the following sample output:
+The command `python esp_prov.py --transport ble --sec_ver 1` gives out the following sample output:
 
 ```
 Discovering...

--- a/network_provisioning/examples/wifi_prov/main/app_main.c
+++ b/network_provisioning/examples/wifi_prov/main/app_main.c
@@ -104,7 +104,7 @@ static esp_err_t example_get_sec2_verifier(const char **verifier, uint16_t *veri
 const int WIFI_CONNECTED_EVENT = BIT0;
 static EventGroupHandle_t wifi_event_group;
 
-#define PROV_QR_VERSION         "v2"
+#define PROV_QR_VERSION         "v1"
 #define PROV_TRANSPORT_SOFTAP   "softap"
 #define PROV_TRANSPORT_BLE      "ble"
 #define QRCODE_BASE_URL         "https://espressif.github.io/esp-jumpstart/qrcode.html"
@@ -262,12 +262,11 @@ static void wifi_prov_print_qr(const char *name, const char *username, const cha
     if (pop) {
 #if CONFIG_EXAMPLE_PROV_SECURITY_VERSION_1
         snprintf(payload, sizeof(payload), "{\"ver\":\"%s\",\"name\":\"%s\"" \
-                 ",\"pop\":\"%s\",\"transport\":\"%s\",\"network\":\"wifi\"}",
+                 ",\"pop\":\"%s\",\"transport\":\"%s\"}",
                  PROV_QR_VERSION, name, pop, transport);
 #elif CONFIG_EXAMPLE_PROV_SECURITY_VERSION_2
         snprintf(payload, sizeof(payload), "{\"ver\":\"%s\",\"name\":\"%s\"" \
-                 ",\"username\":\"%s\",\"pop\":\"%s\",\"transport\":\"%s\"" \
-                 ",\"network\":\"wifi\"}",
+                 ",\"username\":\"%s\",\"pop\":\"%s\",\"transport\":\"%s\"}",
                  PROV_QR_VERSION, name, username, pop, transport);
 #endif
     } else {

--- a/network_provisioning/examples/wifi_prov/main/idf_component.yml
+++ b/network_provisioning/examples/wifi_prov/main/idf_component.yml
@@ -3,6 +3,6 @@ dependencies:
   espressif/qrcode:
       version: "^0.1.0"
   espressif/network_provisioning:
-      version: "^0.1.0"
+      version: "^0.2.0"
       override_path: '../../../'
 

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "0.2.0"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:

--- a/network_provisioning/proto/CMakeLists.txt
+++ b/network_provisioning/proto/CMakeLists.txt
@@ -4,7 +4,7 @@ set(PROTO_COMPILER "protoc")
 set(PROTO_C_COMPILER "protoc-c")
 set(C_OUT_PATH "${CMAKE_CURRENT_LIST_DIR}/../proto-c")
 set(PY_OUT_PATH "${CMAKE_CURRENT_LIST_DIR}/../python")
-set(PROTOCOMM_INCL_PATH "${CMAKE_CURRENT_LIST_DIR}/../../protocomm/proto")
+set(PROTOCOMM_INCL_PATH "${IDF_PATH}/component/protocomm/proto")
 
 set(PROTO_SRCS "network_constants.proto"
                "network_config.proto"

--- a/network_provisioning/src/manager.c
+++ b/network_provisioning/src/manager.c
@@ -31,7 +31,7 @@
 #include <openthread/thread.h>
 #endif // CONFIG_OPENTHREAD_ENABLED
 
-#define NETWORK_PROV_MGR_VERSION      "v1.2"
+#define NETWORK_PROV_MGR_VERSION      "netprov-v1.2"
 #define WIFI_PROV_STORAGE_BIT       BIT0
 #define WIFI_PROV_SETTING_BIT       BIT1
 #define MAX_SCAN_RESULTS           CONFIG_NETWORK_PROV_SCAN_MAX_ENTRIES
@@ -298,10 +298,14 @@ static cJSON *network_prov_get_info_json(void)
     }
 
 #if CONFIG_ESP_WIFI_ENABLED
+    /* Indicate capability for performing Wi-Fi provision */
+    cJSON_AddItemToArray(prov_capabilities, cJSON_CreateString("wifi_prov"));
     /* Indicate capability for performing Wi-Fi scan */
     cJSON_AddItemToArray(prov_capabilities, cJSON_CreateString("wifi_scan"));
 #endif
 #if CONFIG_OPENTHREAD_ENABLED
+    /* Indicate capability for performing Thread provision */
+    cJSON_AddItemToArray(prov_capabilities, cJSON_CreateString("thread_prov"));
     /* Indicate capability for performing Thread scan */
     cJSON_AddItemToArray(prov_capabilities, cJSON_CreateString("thread_scan"));
 #endif

--- a/network_provisioning/tool/esp_prov/esp_prov.py
+++ b/network_provisioning/tool/esp_prov/esp_prov.py
@@ -456,10 +456,6 @@ async def main():
                         help=desc_format(
                             'Mode of transport over which provisioning is to be performed.',
                             'This should be one of "softap", "ble", "console" (or "httpd" which is an alias of softap)'))
-    parser.add_argument('--network_proto', required=True, type=str,
-                        help=desc_format(
-                            'Protocol of network to which the device is to be provisioned.',
-                            'This should be one of "wifi", "thread"'))
 
     parser.add_argument('--service_name', dest='name', type=str,
                         help=desc_format(
@@ -595,7 +591,7 @@ async def main():
             raise RuntimeError('Error in establishing session')
         print('==== Session Established ====')
 
-        if args.network_proto == 'wifi':
+        if await has_capability(obj_transport, 'wifi_prov'):
             if args.reset:
                 print('==== Reseting WiFi====')
                 await reset_wifi(obj_transport, obj_security)
@@ -666,7 +662,7 @@ async def main():
 
             await wait_wifi_connected(obj_transport, obj_security)
 
-        elif args.network_proto == 'thread':
+        elif await has_capability(obj_transport, 'thread_prov'):
             if args.reset:
                 print('==== Reseting Thread====')
                 await reset_thread(obj_transport, obj_security)
@@ -728,6 +724,9 @@ async def main():
             print('==== Apply config sent successfully ====')
 
             await wait_thread_connected(obj_transport, obj_security)
+
+        else:
+            raise RuntimeError('The device should support Wi-Fi prov or Thread prov')
     finally:
         await obj_transport.disconnect()
 


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] CI passing

# Change description
Add `wifi_prov` or `thread_prov` in provision capabilities for the provisioner to distinguish Thread or Wi-Fi devices.
