### PR TITLE
fix(coap): Add config option to enable/disable Q-Block option

### DIFF
--- a/coap/Kconfig
+++ b/coap/Kconfig
@@ -102,6 +102,12 @@ menu "CoAP Configuration"
 
             If this option is disabled, redundant CoAP Observe Persist code is removed.
 
+    config COAP_Q_BLOCK
+        bool "Enable Q-Block (RFC9177) support in CoAP"
+        default n
+        help
+            Enable Q-Block (RFC9177) fast block transfers using NON (instead of CON) support for CoAP
+
     config COAP_WEBSOCKETS
         bool "Enable WebSockets support within CoAP"
         default n

--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.4~1"
+version: "4.3.4~2"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:


### PR DESCRIPTION
Add config option to enable/disable Q-Block option

Fixes: https://github.com/espressif/idf-extra-components/issues/324