### PR TITLE
added support for Micron MT29F nand flash (IEC-110)

### DIFF
--- a/spi_nand_flash/examples/nand_flash/main/spi_nand_flash_example_main.c
+++ b/spi_nand_flash/examples/nand_flash/main/spi_nand_flash_example_main.c
@@ -121,6 +121,7 @@ static spi_nand_flash_device_t *example_init_nand_flash(void)
         .sclk_io_num = PIN_CLK,
         .quadhd_io_num = PIN_HD,
         .quadwp_io_num = PIN_WP,
+        .max_transfer_sz = 4096 * 2,
     };
 
     // Initialize the SPI bus

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "0.2.0"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/src/nand.c
+++ b/spi_nand_flash/src/nand.c
@@ -139,9 +139,9 @@ static esp_err_t spi_nand_micron_init(spi_nand_flash_device_t *dev)
         .miso_data = &device_id
     };
     spi_nand_execute_transaction(dev->config.device_handle, &t);
-    dev->read_page_delay_us = 25;
-    dev->erase_block_delay_us = 10000;
-    dev->program_page_delay_us = 600;
+    dev->read_page_delay_us = 115;
+    dev->erase_block_delay_us = 2000;
+    dev->program_page_delay_us = 240;
     switch (device_id) {
     case MICRON_DI_34:
         dev->dhara_nand.num_blocks = 2048;

--- a/spi_nand_flash/src/nand_flash_devices.h
+++ b/spi_nand_flash/src/nand_flash_devices.h
@@ -10,6 +10,7 @@
 #define SPI_NAND_FLASH_GIGADEVICE_MI  0xC8
 #define SPI_NAND_FLASH_ALLIANCE_MI    0x52
 #define SPI_NAND_FLASH_WINBOND_MI     0xEF
+#define SPI_NAND_FLASH_MICRON_MI      0x2C
 
 //Device ID (DI) for supported nand flash devices
 
@@ -39,3 +40,5 @@
 #define WINBOND_DI_AA21               0xAA21
 #define WINBOND_DI_BA21               0xBA21
 #define WINBOND_DI_BC21               0xBC21
+
+#define MICRON_DI_34                  0x34

--- a/spi_nand_flash/test_app/main/idf_component.yml
+++ b/spi_nand_flash/test_app/main/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
   espressif/spi_nand_flash:
-    version: '0.1.0'
+    version: '*'
     override_path: '../../'


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
Add support for the Micron MT29F nand chip, tested specifically on `MT29F4G01ABAFDWB`
