### PR TITLE
ci: remove libtinfo5 installation

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -15,10 +15,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-      - name: Install libtinfo (esp-clang dependency)
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update && apt-get install -y libtinfo5
       - name: Install esp-clang
         run: |
           ${IDF_PATH}/tools/idf_tools.py --non-interactive install esp-clang


### PR DESCRIPTION
- Fix failing clang-tidy job due to `libtinfo5` package not being found. This package is not needed anymore for recent IDF clang toolchain versions.
- ~~Upgrade clang-tidy-sarif. This includes a feature added in clang-tidy-sarif v0.3.6, now "note" messages from clang-tidy will be included into SARIF output.~~ — fails due to duplicate entries in generated SARIF. Will fix this in clang-tidy-sarif and upgrade it later.