### PR TITLE
change(1wire): bump up version to 1.0.2

### DIFF
--- a/onewire_bus/CHANGELOG.md
+++ b/onewire_bus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- raise recovery time to support more sensor on longer wire (d0b2b52)
+
 ## 1.0.0
 
 - Initial driver version, with the RMT driver as backend controller

--- a/onewire_bus/idf_component.yml
+++ b/onewire_bus/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: Driver for Dalas 1-Wire bus
 url: https://github.com/espressif/idf-extra-components/tree/master/onewire_bus
 issues: "https://github.com/espressif/idf-extra-components/issues"


### PR DESCRIPTION
Thanks to https://github.com/espressif/idf-extra-components/pull/329

let's bump up version to 1.0.2
