### PR TITLE
fix(test): correctly declare ccomp_timer test_app dependencies

### DIFF
--- a/ccomp_timer/test/CMakeLists.txt
+++ b/ccomp_timer/test/CMakeLists.txt
@@ -1,3 +1,10 @@
+idf_build_get_property(arch IDF_TARGET_ARCH)
+
+set(priv_requires esp_timer ccomp_timer unity)
+if("${arch}" STREQUAL "xtensa")
+    list(APPEND priv_requires perfmon)
+endif()
+
 idf_component_register(SRC_DIRS "."
                        PRIV_INCLUDE_DIRS "."
-                       PRIV_REQUIRES perfmon esp_timer ccomp_timer unity)
+                       PRIV_REQUIRES ${priv_requires})


### PR DESCRIPTION
See https://github.com/espressif/esp-idf/commit/fbe8bf89ee4431c72631bc227bf7008cb3aa024e for more info

Fixes https://github.com/espressif/idf-extra-components/actions/runs/9350549394/job/25734263046?pr=332