### PR TITLE
fix(thorvg): build static library without -fPIC

### DIFF
--- a/thorvg/CMakeLists.txt
+++ b/thorvg/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 
 file(APPEND ${TVG_CROSS_CFG} "
 [host_machine]
-system = 'freertos'
+system = 'android'
 cpu_family = '${CMAKE_SYSTEM}'
 cpu = 'esp'
 endian = 'little'
@@ -94,14 +94,15 @@ ExternalProject_Add(${TVG_LIB}_target
     --cross-file ${TVG_CROSS_CFG}
     -Dbindings=capi
     -Dextra=
-    -Ddefault_library=static
-    -Dthreads=false
+    -Ddefault_library=static # build static library
+    -Db_staticpic=false # no -fPIC
+    -Dthreads=true # allow multi-threading
     BUILD_COMMAND ninja -C ${TVG_BUILD_DIR}
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${TVG_BUILD_DIR}/src/${TVG_LIB}.a
 )
 
-add_prebuilt_library(${TVG_LIB} ${TVG_BUILD_DIR}/src/${TVG_LIB}.a PRIV_REQUIRES esp_rom)
+add_prebuilt_library(${TVG_LIB} ${TVG_BUILD_DIR}/src/${TVG_LIB}.a PRIV_REQUIRES pthread)
 add_dependencies(${TVG_LIB} ${TVG_LIB}_target)
 
 target_link_libraries(${COMPONENT_LIB} INTERFACE ${TVG_LIB})

--- a/thorvg/idf_component.yml
+++ b/thorvg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.13.6~1"
+version: "0.13.8"
 description: "ThorVG is an open-source graphics library designed for creating vector-based scenes and animations"
 url: https://github.com/espressif/idf-extra-components/tree/master/thorvg
 repository: "https://github.com/espressif/idf-extra-components.git"

--- a/thorvg/sbom_thorvg.yml
+++ b/thorvg/sbom_thorvg.yml
@@ -1,7 +1,7 @@
 name: thorvg
-version: 0.13.6
+version: 0.13.8
 cpe: cpe:2.3:a:thorvg:thorvg:{}:*:*:*:*:*:*:*
 supplier: 'Organization: thorvg <https://github.com/thorvg/thorvg>'
 description: ThorVG is an open-source graphics library designed for creating vector-based scenes and animations.
 url: https://github.com/thorvg/thorvg
-hash: 20f82982b096425800e1f7d40f1c17a5c17baac2
+hash: 30aa742b26e35e170f927c8e5ebdaa68dea6f48f


### PR DESCRIPTION
ESP-IDF only use static library, and the thorvg library won't be linked into a dynamic library.

This PR also enables the multi-threading feature in thorvg.

```
Summary:
    ThorVG version:             0.13.6
    Build Type:                 debugoptimized
    Prefix:                     /usr/local
    Multi-Tasking:              true                        <------------- Enabled in this PR
    SIMD Instruction:           none
    Raster Engine (SW):         true
    Raster Engine (GL_BETA):    false
    Raster Engine (WG_BETA):    false
    Loader (TVG):               true
    Loader (SVG):               true
    Loader (TTF):               false
    Loader (LOTTIE):            true
    Loader (PNG):               false
    Loader (JPG):               false
    Loader (WEBP):              false
    Saver (TVG):                false
    Saver (GIF):                false
    Binding (CAPI):             true
    Binding (WASM_BETA):        false
    Log Message:                false
    Tests:                      false
    Examples:                   false
    Tool (Svg2Tvg):             false
    Tool (Svg2Png):             false
    Tool (Lottie2Gif):          false
    Extra (Lottie Expressions): true
```