### PR TITLE
feat(network_prov): Change the proto file to make the network_provisioning stay backward compatible with wifi_provisioning (IEC-125)

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 19-June-2024
+
+- Change the proto files to make the network provisioning component stay backward compatible with the wifi_provisioing
+
 # 23-April-2024
 
 - Add `wifi_prov` or `thread_prov` in provision capabilities in the network provisioning manager for the provisioner to distinguish Thread or Wi-Fi devices

--- a/network_provisioning/examples/thread_prov/main/idf_component.yml
+++ b/network_provisioning/examples/thread_prov/main/idf_component.yml
@@ -3,6 +3,6 @@ dependencies:
   espressif/qrcode:
       version: "^0.1.0"
   espressif/network_provisioning:
-      version: "^0.2.0"
+      version: "^1.0.0"
       override_path: '../../../'
 

--- a/network_provisioning/examples/wifi_prov/main/idf_component.yml
+++ b/network_provisioning/examples/wifi_prov/main/idf_component.yml
@@ -3,6 +3,6 @@ dependencies:
   espressif/qrcode:
       version: "^0.1.0"
   espressif/network_provisioning:
-      version: "^0.2.0"
+      version: "^1.0.0"
       override_path: '../../../'
 

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "1.0.0"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:

--- a/network_provisioning/proto-c/network_config.pb-c.c
+++ b/network_provisioning/proto-c/network_config.pb-c.c
@@ -7,364 +7,544 @@
 #endif
 
 #include "network_config.pb-c.h"
-void   cmd_get_status__init
-                     (CmdGetStatus         *message)
+void   cmd_get_wifi_status__init
+                     (CmdGetWifiStatus         *message)
 {
-  static const CmdGetStatus init_value = CMD_GET_STATUS__INIT;
+  static const CmdGetWifiStatus init_value = CMD_GET_WIFI_STATUS__INIT;
   *message = init_value;
 }
-size_t cmd_get_status__get_packed_size
-                     (const CmdGetStatus *message)
+size_t cmd_get_wifi_status__get_packed_size
+                     (const CmdGetWifiStatus *message)
 {
-  assert(message->base.descriptor == &cmd_get_status__descriptor);
+  assert(message->base.descriptor == &cmd_get_wifi_status__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t cmd_get_status__pack
-                     (const CmdGetStatus *message,
+size_t cmd_get_wifi_status__pack
+                     (const CmdGetWifiStatus *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &cmd_get_status__descriptor);
+  assert(message->base.descriptor == &cmd_get_wifi_status__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t cmd_get_status__pack_to_buffer
-                     (const CmdGetStatus *message,
+size_t cmd_get_wifi_status__pack_to_buffer
+                     (const CmdGetWifiStatus *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &cmd_get_status__descriptor);
+  assert(message->base.descriptor == &cmd_get_wifi_status__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-CmdGetStatus *
-       cmd_get_status__unpack
+CmdGetWifiStatus *
+       cmd_get_wifi_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (CmdGetStatus *)
-     protobuf_c_message_unpack (&cmd_get_status__descriptor,
+  return (CmdGetWifiStatus *)
+     protobuf_c_message_unpack (&cmd_get_wifi_status__descriptor,
                                 allocator, len, data);
 }
-void   cmd_get_status__free_unpacked
-                     (CmdGetStatus *message,
+void   cmd_get_wifi_status__free_unpacked
+                     (CmdGetWifiStatus *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &cmd_get_status__descriptor);
+  assert(message->base.descriptor == &cmd_get_wifi_status__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   resp_get_status__init
-                     (RespGetStatus         *message)
+void   resp_get_wifi_status__init
+                     (RespGetWifiStatus         *message)
 {
-  static const RespGetStatus init_value = RESP_GET_STATUS__INIT;
+  static const RespGetWifiStatus init_value = RESP_GET_WIFI_STATUS__INIT;
   *message = init_value;
 }
-size_t resp_get_status__get_packed_size
-                     (const RespGetStatus *message)
+size_t resp_get_wifi_status__get_packed_size
+                     (const RespGetWifiStatus *message)
 {
-  assert(message->base.descriptor == &resp_get_status__descriptor);
+  assert(message->base.descriptor == &resp_get_wifi_status__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t resp_get_status__pack
-                     (const RespGetStatus *message,
+size_t resp_get_wifi_status__pack
+                     (const RespGetWifiStatus *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &resp_get_status__descriptor);
+  assert(message->base.descriptor == &resp_get_wifi_status__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t resp_get_status__pack_to_buffer
-                     (const RespGetStatus *message,
+size_t resp_get_wifi_status__pack_to_buffer
+                     (const RespGetWifiStatus *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &resp_get_status__descriptor);
+  assert(message->base.descriptor == &resp_get_wifi_status__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-RespGetStatus *
-       resp_get_status__unpack
+RespGetWifiStatus *
+       resp_get_wifi_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (RespGetStatus *)
-     protobuf_c_message_unpack (&resp_get_status__descriptor,
+  return (RespGetWifiStatus *)
+     protobuf_c_message_unpack (&resp_get_wifi_status__descriptor,
                                 allocator, len, data);
 }
-void   resp_get_status__free_unpacked
-                     (RespGetStatus *message,
+void   resp_get_wifi_status__free_unpacked
+                     (RespGetWifiStatus *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &resp_get_status__descriptor);
+  assert(message->base.descriptor == &resp_get_wifi_status__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   wifi_set_config__init
-                     (WifiSetConfig         *message)
+void   cmd_get_thread_status__init
+                     (CmdGetThreadStatus         *message)
 {
-  static const WifiSetConfig init_value = WIFI_SET_CONFIG__INIT;
+  static const CmdGetThreadStatus init_value = CMD_GET_THREAD_STATUS__INIT;
   *message = init_value;
 }
-size_t wifi_set_config__get_packed_size
-                     (const WifiSetConfig *message)
+size_t cmd_get_thread_status__get_packed_size
+                     (const CmdGetThreadStatus *message)
 {
-  assert(message->base.descriptor == &wifi_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_get_thread_status__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t wifi_set_config__pack
-                     (const WifiSetConfig *message,
+size_t cmd_get_thread_status__pack
+                     (const CmdGetThreadStatus *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &wifi_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_get_thread_status__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t wifi_set_config__pack_to_buffer
-                     (const WifiSetConfig *message,
+size_t cmd_get_thread_status__pack_to_buffer
+                     (const CmdGetThreadStatus *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &wifi_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_get_thread_status__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-WifiSetConfig *
-       wifi_set_config__unpack
+CmdGetThreadStatus *
+       cmd_get_thread_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (WifiSetConfig *)
-     protobuf_c_message_unpack (&wifi_set_config__descriptor,
+  return (CmdGetThreadStatus *)
+     protobuf_c_message_unpack (&cmd_get_thread_status__descriptor,
                                 allocator, len, data);
 }
-void   wifi_set_config__free_unpacked
-                     (WifiSetConfig *message,
+void   cmd_get_thread_status__free_unpacked
+                     (CmdGetThreadStatus *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &wifi_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_get_thread_status__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   thread_set_config__init
-                     (ThreadSetConfig         *message)
+void   resp_get_thread_status__init
+                     (RespGetThreadStatus         *message)
 {
-  static const ThreadSetConfig init_value = THREAD_SET_CONFIG__INIT;
+  static const RespGetThreadStatus init_value = RESP_GET_THREAD_STATUS__INIT;
   *message = init_value;
 }
-size_t thread_set_config__get_packed_size
-                     (const ThreadSetConfig *message)
+size_t resp_get_thread_status__get_packed_size
+                     (const RespGetThreadStatus *message)
 {
-  assert(message->base.descriptor == &thread_set_config__descriptor);
+  assert(message->base.descriptor == &resp_get_thread_status__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t thread_set_config__pack
-                     (const ThreadSetConfig *message,
+size_t resp_get_thread_status__pack
+                     (const RespGetThreadStatus *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &thread_set_config__descriptor);
+  assert(message->base.descriptor == &resp_get_thread_status__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t thread_set_config__pack_to_buffer
-                     (const ThreadSetConfig *message,
+size_t resp_get_thread_status__pack_to_buffer
+                     (const RespGetThreadStatus *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &thread_set_config__descriptor);
+  assert(message->base.descriptor == &resp_get_thread_status__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-ThreadSetConfig *
-       thread_set_config__unpack
+RespGetThreadStatus *
+       resp_get_thread_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (ThreadSetConfig *)
-     protobuf_c_message_unpack (&thread_set_config__descriptor,
+  return (RespGetThreadStatus *)
+     protobuf_c_message_unpack (&resp_get_thread_status__descriptor,
                                 allocator, len, data);
 }
-void   thread_set_config__free_unpacked
-                     (ThreadSetConfig *message,
+void   resp_get_thread_status__free_unpacked
+                     (RespGetThreadStatus *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &thread_set_config__descriptor);
+  assert(message->base.descriptor == &resp_get_thread_status__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   cmd_set_config__init
-                     (CmdSetConfig         *message)
+void   cmd_set_wifi_config__init
+                     (CmdSetWifiConfig         *message)
 {
-  static const CmdSetConfig init_value = CMD_SET_CONFIG__INIT;
+  static const CmdSetWifiConfig init_value = CMD_SET_WIFI_CONFIG__INIT;
   *message = init_value;
 }
-size_t cmd_set_config__get_packed_size
-                     (const CmdSetConfig *message)
+size_t cmd_set_wifi_config__get_packed_size
+                     (const CmdSetWifiConfig *message)
 {
-  assert(message->base.descriptor == &cmd_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_set_wifi_config__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t cmd_set_config__pack
-                     (const CmdSetConfig *message,
+size_t cmd_set_wifi_config__pack
+                     (const CmdSetWifiConfig *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &cmd_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_set_wifi_config__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t cmd_set_config__pack_to_buffer
-                     (const CmdSetConfig *message,
+size_t cmd_set_wifi_config__pack_to_buffer
+                     (const CmdSetWifiConfig *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &cmd_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_set_wifi_config__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-CmdSetConfig *
-       cmd_set_config__unpack
+CmdSetWifiConfig *
+       cmd_set_wifi_config__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (CmdSetConfig *)
-     protobuf_c_message_unpack (&cmd_set_config__descriptor,
+  return (CmdSetWifiConfig *)
+     protobuf_c_message_unpack (&cmd_set_wifi_config__descriptor,
                                 allocator, len, data);
 }
-void   cmd_set_config__free_unpacked
-                     (CmdSetConfig *message,
+void   cmd_set_wifi_config__free_unpacked
+                     (CmdSetWifiConfig *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &cmd_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_set_wifi_config__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   resp_set_config__init
-                     (RespSetConfig         *message)
+void   cmd_set_thread_config__init
+                     (CmdSetThreadConfig         *message)
 {
-  static const RespSetConfig init_value = RESP_SET_CONFIG__INIT;
+  static const CmdSetThreadConfig init_value = CMD_SET_THREAD_CONFIG__INIT;
   *message = init_value;
 }
-size_t resp_set_config__get_packed_size
-                     (const RespSetConfig *message)
+size_t cmd_set_thread_config__get_packed_size
+                     (const CmdSetThreadConfig *message)
 {
-  assert(message->base.descriptor == &resp_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_set_thread_config__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t resp_set_config__pack
-                     (const RespSetConfig *message,
+size_t cmd_set_thread_config__pack
+                     (const CmdSetThreadConfig *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &resp_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_set_thread_config__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t resp_set_config__pack_to_buffer
-                     (const RespSetConfig *message,
+size_t cmd_set_thread_config__pack_to_buffer
+                     (const CmdSetThreadConfig *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &resp_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_set_thread_config__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-RespSetConfig *
-       resp_set_config__unpack
+CmdSetThreadConfig *
+       cmd_set_thread_config__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (RespSetConfig *)
-     protobuf_c_message_unpack (&resp_set_config__descriptor,
+  return (CmdSetThreadConfig *)
+     protobuf_c_message_unpack (&cmd_set_thread_config__descriptor,
                                 allocator, len, data);
 }
-void   resp_set_config__free_unpacked
-                     (RespSetConfig *message,
+void   cmd_set_thread_config__free_unpacked
+                     (CmdSetThreadConfig *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &resp_set_config__descriptor);
+  assert(message->base.descriptor == &cmd_set_thread_config__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   cmd_apply_config__init
-                     (CmdApplyConfig         *message)
+void   resp_set_wifi_config__init
+                     (RespSetWifiConfig         *message)
 {
-  static const CmdApplyConfig init_value = CMD_APPLY_CONFIG__INIT;
+  static const RespSetWifiConfig init_value = RESP_SET_WIFI_CONFIG__INIT;
   *message = init_value;
 }
-size_t cmd_apply_config__get_packed_size
-                     (const CmdApplyConfig *message)
+size_t resp_set_wifi_config__get_packed_size
+                     (const RespSetWifiConfig *message)
 {
-  assert(message->base.descriptor == &cmd_apply_config__descriptor);
+  assert(message->base.descriptor == &resp_set_wifi_config__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t cmd_apply_config__pack
-                     (const CmdApplyConfig *message,
+size_t resp_set_wifi_config__pack
+                     (const RespSetWifiConfig *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &cmd_apply_config__descriptor);
+  assert(message->base.descriptor == &resp_set_wifi_config__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t cmd_apply_config__pack_to_buffer
-                     (const CmdApplyConfig *message,
+size_t resp_set_wifi_config__pack_to_buffer
+                     (const RespSetWifiConfig *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &cmd_apply_config__descriptor);
+  assert(message->base.descriptor == &resp_set_wifi_config__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-CmdApplyConfig *
-       cmd_apply_config__unpack
+RespSetWifiConfig *
+       resp_set_wifi_config__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (CmdApplyConfig *)
-     protobuf_c_message_unpack (&cmd_apply_config__descriptor,
+  return (RespSetWifiConfig *)
+     protobuf_c_message_unpack (&resp_set_wifi_config__descriptor,
                                 allocator, len, data);
 }
-void   cmd_apply_config__free_unpacked
-                     (CmdApplyConfig *message,
+void   resp_set_wifi_config__free_unpacked
+                     (RespSetWifiConfig *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &cmd_apply_config__descriptor);
+  assert(message->base.descriptor == &resp_set_wifi_config__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   resp_apply_config__init
-                     (RespApplyConfig         *message)
+void   resp_set_thread_config__init
+                     (RespSetThreadConfig         *message)
 {
-  static const RespApplyConfig init_value = RESP_APPLY_CONFIG__INIT;
+  static const RespSetThreadConfig init_value = RESP_SET_THREAD_CONFIG__INIT;
   *message = init_value;
 }
-size_t resp_apply_config__get_packed_size
-                     (const RespApplyConfig *message)
+size_t resp_set_thread_config__get_packed_size
+                     (const RespSetThreadConfig *message)
 {
-  assert(message->base.descriptor == &resp_apply_config__descriptor);
+  assert(message->base.descriptor == &resp_set_thread_config__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t resp_apply_config__pack
-                     (const RespApplyConfig *message,
+size_t resp_set_thread_config__pack
+                     (const RespSetThreadConfig *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &resp_apply_config__descriptor);
+  assert(message->base.descriptor == &resp_set_thread_config__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t resp_apply_config__pack_to_buffer
-                     (const RespApplyConfig *message,
+size_t resp_set_thread_config__pack_to_buffer
+                     (const RespSetThreadConfig *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &resp_apply_config__descriptor);
+  assert(message->base.descriptor == &resp_set_thread_config__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-RespApplyConfig *
-       resp_apply_config__unpack
+RespSetThreadConfig *
+       resp_set_thread_config__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (RespApplyConfig *)
-     protobuf_c_message_unpack (&resp_apply_config__descriptor,
+  return (RespSetThreadConfig *)
+     protobuf_c_message_unpack (&resp_set_thread_config__descriptor,
                                 allocator, len, data);
 }
-void   resp_apply_config__free_unpacked
-                     (RespApplyConfig *message,
+void   resp_set_thread_config__free_unpacked
+                     (RespSetThreadConfig *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &resp_apply_config__descriptor);
+  assert(message->base.descriptor == &resp_set_thread_config__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   cmd_apply_wifi_config__init
+                     (CmdApplyWifiConfig         *message)
+{
+  static const CmdApplyWifiConfig init_value = CMD_APPLY_WIFI_CONFIG__INIT;
+  *message = init_value;
+}
+size_t cmd_apply_wifi_config__get_packed_size
+                     (const CmdApplyWifiConfig *message)
+{
+  assert(message->base.descriptor == &cmd_apply_wifi_config__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t cmd_apply_wifi_config__pack
+                     (const CmdApplyWifiConfig *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &cmd_apply_wifi_config__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t cmd_apply_wifi_config__pack_to_buffer
+                     (const CmdApplyWifiConfig *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &cmd_apply_wifi_config__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+CmdApplyWifiConfig *
+       cmd_apply_wifi_config__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (CmdApplyWifiConfig *)
+     protobuf_c_message_unpack (&cmd_apply_wifi_config__descriptor,
+                                allocator, len, data);
+}
+void   cmd_apply_wifi_config__free_unpacked
+                     (CmdApplyWifiConfig *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &cmd_apply_wifi_config__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   cmd_apply_thread_config__init
+                     (CmdApplyThreadConfig         *message)
+{
+  static const CmdApplyThreadConfig init_value = CMD_APPLY_THREAD_CONFIG__INIT;
+  *message = init_value;
+}
+size_t cmd_apply_thread_config__get_packed_size
+                     (const CmdApplyThreadConfig *message)
+{
+  assert(message->base.descriptor == &cmd_apply_thread_config__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t cmd_apply_thread_config__pack
+                     (const CmdApplyThreadConfig *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &cmd_apply_thread_config__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t cmd_apply_thread_config__pack_to_buffer
+                     (const CmdApplyThreadConfig *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &cmd_apply_thread_config__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+CmdApplyThreadConfig *
+       cmd_apply_thread_config__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (CmdApplyThreadConfig *)
+     protobuf_c_message_unpack (&cmd_apply_thread_config__descriptor,
+                                allocator, len, data);
+}
+void   cmd_apply_thread_config__free_unpacked
+                     (CmdApplyThreadConfig *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &cmd_apply_thread_config__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   resp_apply_wifi_config__init
+                     (RespApplyWifiConfig         *message)
+{
+  static const RespApplyWifiConfig init_value = RESP_APPLY_WIFI_CONFIG__INIT;
+  *message = init_value;
+}
+size_t resp_apply_wifi_config__get_packed_size
+                     (const RespApplyWifiConfig *message)
+{
+  assert(message->base.descriptor == &resp_apply_wifi_config__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t resp_apply_wifi_config__pack
+                     (const RespApplyWifiConfig *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &resp_apply_wifi_config__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t resp_apply_wifi_config__pack_to_buffer
+                     (const RespApplyWifiConfig *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &resp_apply_wifi_config__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+RespApplyWifiConfig *
+       resp_apply_wifi_config__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (RespApplyWifiConfig *)
+     protobuf_c_message_unpack (&resp_apply_wifi_config__descriptor,
+                                allocator, len, data);
+}
+void   resp_apply_wifi_config__free_unpacked
+                     (RespApplyWifiConfig *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &resp_apply_wifi_config__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   resp_apply_thread_config__init
+                     (RespApplyThreadConfig         *message)
+{
+  static const RespApplyThreadConfig init_value = RESP_APPLY_THREAD_CONFIG__INIT;
+  *message = init_value;
+}
+size_t resp_apply_thread_config__get_packed_size
+                     (const RespApplyThreadConfig *message)
+{
+  assert(message->base.descriptor == &resp_apply_thread_config__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t resp_apply_thread_config__pack
+                     (const RespApplyThreadConfig *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &resp_apply_thread_config__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t resp_apply_thread_config__pack_to_buffer
+                     (const RespApplyThreadConfig *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &resp_apply_thread_config__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+RespApplyThreadConfig *
+       resp_apply_thread_config__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (RespApplyThreadConfig *)
+     protobuf_c_message_unpack (&resp_apply_thread_config__descriptor,
+                                allocator, len, data);
+}
+void   resp_apply_thread_config__free_unpacked
+                     (RespApplyThreadConfig *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &resp_apply_thread_config__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
 void   network_config_payload__init
@@ -412,65 +592,33 @@ void   network_config_payload__free_unpacked
   assert(message->base.descriptor == &network_config_payload__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-static const ProtobufCFieldDescriptor cmd_get_status__field_descriptors[1] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(CmdGetStatus, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned cmd_get_status__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-};
-static const ProtobufCIntRange cmd_get_status__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor cmd_get_status__descriptor =
+#define cmd_get_wifi_status__field_descriptors NULL
+#define cmd_get_wifi_status__field_indices_by_name NULL
+#define cmd_get_wifi_status__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_get_wifi_status__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "CmdGetStatus",
-  "CmdGetStatus",
-  "CmdGetStatus",
+  "CmdGetWifiStatus",
+  "CmdGetWifiStatus",
+  "CmdGetWifiStatus",
   "",
-  sizeof(CmdGetStatus),
-  1,
-  cmd_get_status__field_descriptors,
-  cmd_get_status__field_indices_by_name,
-  1,  cmd_get_status__number_ranges,
-  (ProtobufCMessageInit) cmd_get_status__init,
+  sizeof(CmdGetWifiStatus),
+  0,
+  cmd_get_wifi_status__field_descriptors,
+  cmd_get_wifi_status__field_indices_by_name,
+  0,  cmd_get_wifi_status__number_ranges,
+  (ProtobufCMessageInit) cmd_get_wifi_status__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor resp_get_status__field_descriptors[8] =
+static const ProtobufCFieldDescriptor resp_get_wifi_status__field_descriptors[4] =
 {
   {
-    "net_type",
+    "status",
     1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
     0,   /* quantifier_offset */
-    offsetof(RespGetStatus, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "status",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(RespGetStatus, status),
+    offsetof(RespGetWifiStatus, status),
     &status__descriptor,
     NULL,
     0,             /* flags */
@@ -478,35 +626,23 @@ static const ProtobufCFieldDescriptor resp_get_status__field_descriptors[8] =
   },
   {
     "wifi_sta_state",
-    10,
+    2,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
-    offsetof(RespGetStatus, payload_case),
-    offsetof(RespGetStatus, wifi_sta_state),
+    0,   /* quantifier_offset */
+    offsetof(RespGetWifiStatus, wifi_sta_state),
     &wifi_station_state__descriptor,
     NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "thread_state",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    offsetof(RespGetStatus, payload_case),
-    offsetof(RespGetStatus, thread_state),
-    &thread_network_state__descriptor,
-    NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
     "wifi_fail_reason",
-    20,
+    10,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
-    offsetof(RespGetStatus, state_case),
-    offsetof(RespGetStatus, wifi_fail_reason),
+    offsetof(RespGetWifiStatus, state_case),
+    offsetof(RespGetWifiStatus, wifi_fail_reason),
     &wifi_connect_failed_reason__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
@@ -514,23 +650,95 @@ static const ProtobufCFieldDescriptor resp_get_status__field_descriptors[8] =
   },
   {
     "wifi_connected",
-    21,
+    11,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(RespGetStatus, state_case),
-    offsetof(RespGetStatus, wifi_connected),
+    offsetof(RespGetWifiStatus, state_case),
+    offsetof(RespGetWifiStatus, wifi_connected),
     &wifi_connected_state__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+};
+static const unsigned resp_get_wifi_status__field_indices_by_name[] = {
+  0,   /* field[0] = status */
+  3,   /* field[3] = wifi_connected */
+  2,   /* field[2] = wifi_fail_reason */
+  1,   /* field[1] = wifi_sta_state */
+};
+static const ProtobufCIntRange resp_get_wifi_status__number_ranges[2 + 1] =
+{
+  { 1, 0 },
+  { 10, 2 },
+  { 0, 4 }
+};
+const ProtobufCMessageDescriptor resp_get_wifi_status__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "RespGetWifiStatus",
+  "RespGetWifiStatus",
+  "RespGetWifiStatus",
+  "",
+  sizeof(RespGetWifiStatus),
+  4,
+  resp_get_wifi_status__field_descriptors,
+  resp_get_wifi_status__field_indices_by_name,
+  2,  resp_get_wifi_status__number_ranges,
+  (ProtobufCMessageInit) resp_get_wifi_status__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define cmd_get_thread_status__field_descriptors NULL
+#define cmd_get_thread_status__field_indices_by_name NULL
+#define cmd_get_thread_status__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_get_thread_status__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "CmdGetThreadStatus",
+  "CmdGetThreadStatus",
+  "CmdGetThreadStatus",
+  "",
+  sizeof(CmdGetThreadStatus),
+  0,
+  cmd_get_thread_status__field_descriptors,
+  cmd_get_thread_status__field_indices_by_name,
+  0,  cmd_get_thread_status__number_ranges,
+  (ProtobufCMessageInit) cmd_get_thread_status__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor resp_get_thread_status__field_descriptors[4] =
+{
   {
-    "thread_fail_reason",
-    22,
+    "status",
+    1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
-    offsetof(RespGetStatus, state_case),
-    offsetof(RespGetStatus, thread_fail_reason),
+    0,   /* quantifier_offset */
+    offsetof(RespGetThreadStatus, status),
+    &status__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "thread_state",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(RespGetThreadStatus, thread_state),
+    &thread_network_state__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "thread_fail_reason",
+    10,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    offsetof(RespGetThreadStatus, state_case),
+    offsetof(RespGetThreadStatus, thread_fail_reason),
     &thread_attach_failed_reason__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
@@ -538,50 +746,45 @@ static const ProtobufCFieldDescriptor resp_get_status__field_descriptors[8] =
   },
   {
     "thread_attached",
-    23,
+    11,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(RespGetStatus, state_case),
-    offsetof(RespGetStatus, thread_attached),
+    offsetof(RespGetThreadStatus, state_case),
+    offsetof(RespGetThreadStatus, thread_attached),
     &thread_attach_state__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned resp_get_status__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-  1,   /* field[1] = status */
-  7,   /* field[7] = thread_attached */
-  6,   /* field[6] = thread_fail_reason */
-  3,   /* field[3] = thread_state */
-  5,   /* field[5] = wifi_connected */
-  4,   /* field[4] = wifi_fail_reason */
-  2,   /* field[2] = wifi_sta_state */
+static const unsigned resp_get_thread_status__field_indices_by_name[] = {
+  0,   /* field[0] = status */
+  3,   /* field[3] = thread_attached */
+  2,   /* field[2] = thread_fail_reason */
+  1,   /* field[1] = thread_state */
 };
-static const ProtobufCIntRange resp_get_status__number_ranges[3 + 1] =
+static const ProtobufCIntRange resp_get_thread_status__number_ranges[2 + 1] =
 {
   { 1, 0 },
   { 10, 2 },
-  { 20, 4 },
-  { 0, 8 }
+  { 0, 4 }
 };
-const ProtobufCMessageDescriptor resp_get_status__descriptor =
+const ProtobufCMessageDescriptor resp_get_thread_status__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "RespGetStatus",
-  "RespGetStatus",
-  "RespGetStatus",
+  "RespGetThreadStatus",
+  "RespGetThreadStatus",
+  "RespGetThreadStatus",
   "",
-  sizeof(RespGetStatus),
-  8,
-  resp_get_status__field_descriptors,
-  resp_get_status__field_indices_by_name,
-  3,  resp_get_status__number_ranges,
-  (ProtobufCMessageInit) resp_get_status__init,
+  sizeof(RespGetThreadStatus),
+  4,
+  resp_get_thread_status__field_descriptors,
+  resp_get_thread_status__field_indices_by_name,
+  2,  resp_get_thread_status__number_ranges,
+  (ProtobufCMessageInit) resp_get_thread_status__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor wifi_set_config__field_descriptors[4] =
+static const ProtobufCFieldDescriptor cmd_set_wifi_config__field_descriptors[4] =
 {
   {
     "ssid",
@@ -589,7 +792,7 @@ static const ProtobufCFieldDescriptor wifi_set_config__field_descriptors[4] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BYTES,
     0,   /* quantifier_offset */
-    offsetof(WifiSetConfig, ssid),
+    offsetof(CmdSetWifiConfig, ssid),
     NULL,
     NULL,
     0,             /* flags */
@@ -601,7 +804,7 @@ static const ProtobufCFieldDescriptor wifi_set_config__field_descriptors[4] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BYTES,
     0,   /* quantifier_offset */
-    offsetof(WifiSetConfig, passphrase),
+    offsetof(CmdSetWifiConfig, passphrase),
     NULL,
     NULL,
     0,             /* flags */
@@ -613,7 +816,7 @@ static const ProtobufCFieldDescriptor wifi_set_config__field_descriptors[4] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BYTES,
     0,   /* quantifier_offset */
-    offsetof(WifiSetConfig, bssid),
+    offsetof(CmdSetWifiConfig, bssid),
     NULL,
     NULL,
     0,             /* flags */
@@ -625,40 +828,40 @@ static const ProtobufCFieldDescriptor wifi_set_config__field_descriptors[4] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_INT32,
     0,   /* quantifier_offset */
-    offsetof(WifiSetConfig, channel),
+    offsetof(CmdSetWifiConfig, channel),
     NULL,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned wifi_set_config__field_indices_by_name[] = {
+static const unsigned cmd_set_wifi_config__field_indices_by_name[] = {
   2,   /* field[2] = bssid */
   3,   /* field[3] = channel */
   1,   /* field[1] = passphrase */
   0,   /* field[0] = ssid */
 };
-static const ProtobufCIntRange wifi_set_config__number_ranges[1 + 1] =
+static const ProtobufCIntRange cmd_set_wifi_config__number_ranges[1 + 1] =
 {
   { 1, 0 },
   { 0, 4 }
 };
-const ProtobufCMessageDescriptor wifi_set_config__descriptor =
+const ProtobufCMessageDescriptor cmd_set_wifi_config__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "WifiSetConfig",
-  "WifiSetConfig",
-  "WifiSetConfig",
+  "CmdSetWifiConfig",
+  "CmdSetWifiConfig",
+  "CmdSetWifiConfig",
   "",
-  sizeof(WifiSetConfig),
+  sizeof(CmdSetWifiConfig),
   4,
-  wifi_set_config__field_descriptors,
-  wifi_set_config__field_indices_by_name,
-  1,  wifi_set_config__number_ranges,
-  (ProtobufCMessageInit) wifi_set_config__init,
+  cmd_set_wifi_config__field_descriptors,
+  cmd_set_wifi_config__field_indices_by_name,
+  1,  cmd_set_wifi_config__number_ranges,
+  (ProtobufCMessageInit) cmd_set_wifi_config__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor thread_set_config__field_descriptors[1] =
+static const ProtobufCFieldDescriptor cmd_set_thread_config__field_descriptors[1] =
 {
   {
     "dataset",
@@ -666,242 +869,225 @@ static const ProtobufCFieldDescriptor thread_set_config__field_descriptors[1] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BYTES,
     0,   /* quantifier_offset */
-    offsetof(ThreadSetConfig, dataset),
+    offsetof(CmdSetThreadConfig, dataset),
     NULL,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned thread_set_config__field_indices_by_name[] = {
+static const unsigned cmd_set_thread_config__field_indices_by_name[] = {
   0,   /* field[0] = dataset */
 };
-static const ProtobufCIntRange thread_set_config__number_ranges[1 + 1] =
+static const ProtobufCIntRange cmd_set_thread_config__number_ranges[1 + 1] =
 {
   { 1, 0 },
   { 0, 1 }
 };
-const ProtobufCMessageDescriptor thread_set_config__descriptor =
+const ProtobufCMessageDescriptor cmd_set_thread_config__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "ThreadSetConfig",
-  "ThreadSetConfig",
-  "ThreadSetConfig",
+  "CmdSetThreadConfig",
+  "CmdSetThreadConfig",
+  "CmdSetThreadConfig",
   "",
-  sizeof(ThreadSetConfig),
+  sizeof(CmdSetThreadConfig),
   1,
-  thread_set_config__field_descriptors,
-  thread_set_config__field_indices_by_name,
-  1,  thread_set_config__number_ranges,
-  (ProtobufCMessageInit) thread_set_config__init,
+  cmd_set_thread_config__field_descriptors,
+  cmd_set_thread_config__field_indices_by_name,
+  1,  cmd_set_thread_config__number_ranges,
+  (ProtobufCMessageInit) cmd_set_thread_config__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor cmd_set_config__field_descriptors[3] =
+static const ProtobufCFieldDescriptor resp_set_wifi_config__field_descriptors[1] =
 {
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(CmdSetConfig, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "wifi_config",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(CmdSetConfig, payload_case),
-    offsetof(CmdSetConfig, wifi_config),
-    &wifi_set_config__descriptor,
-    NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "thread_config",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(CmdSetConfig, payload_case),
-    offsetof(CmdSetConfig, thread_config),
-    &thread_set_config__descriptor,
-    NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned cmd_set_config__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-  2,   /* field[2] = thread_config */
-  1,   /* field[1] = wifi_config */
-};
-static const ProtobufCIntRange cmd_set_config__number_ranges[2 + 1] =
-{
-  { 1, 0 },
-  { 10, 1 },
-  { 0, 3 }
-};
-const ProtobufCMessageDescriptor cmd_set_config__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "CmdSetConfig",
-  "CmdSetConfig",
-  "CmdSetConfig",
-  "",
-  sizeof(CmdSetConfig),
-  3,
-  cmd_set_config__field_descriptors,
-  cmd_set_config__field_indices_by_name,
-  2,  cmd_set_config__number_ranges,
-  (ProtobufCMessageInit) cmd_set_config__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor resp_set_config__field_descriptors[2] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(RespSetConfig, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
   {
     "status",
-    2,
+    1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
     0,   /* quantifier_offset */
-    offsetof(RespSetConfig, status),
+    offsetof(RespSetWifiConfig, status),
     &status__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned resp_set_config__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-  1,   /* field[1] = status */
+static const unsigned resp_set_wifi_config__field_indices_by_name[] = {
+  0,   /* field[0] = status */
 };
-static const ProtobufCIntRange resp_set_config__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 2 }
-};
-const ProtobufCMessageDescriptor resp_set_config__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "RespSetConfig",
-  "RespSetConfig",
-  "RespSetConfig",
-  "",
-  sizeof(RespSetConfig),
-  2,
-  resp_set_config__field_descriptors,
-  resp_set_config__field_indices_by_name,
-  1,  resp_set_config__number_ranges,
-  (ProtobufCMessageInit) resp_set_config__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor cmd_apply_config__field_descriptors[1] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(CmdApplyConfig, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned cmd_apply_config__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-};
-static const ProtobufCIntRange cmd_apply_config__number_ranges[1 + 1] =
+static const ProtobufCIntRange resp_set_wifi_config__number_ranges[1 + 1] =
 {
   { 1, 0 },
   { 0, 1 }
 };
-const ProtobufCMessageDescriptor cmd_apply_config__descriptor =
+const ProtobufCMessageDescriptor resp_set_wifi_config__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "CmdApplyConfig",
-  "CmdApplyConfig",
-  "CmdApplyConfig",
+  "RespSetWifiConfig",
+  "RespSetWifiConfig",
+  "RespSetWifiConfig",
   "",
-  sizeof(CmdApplyConfig),
+  sizeof(RespSetWifiConfig),
   1,
-  cmd_apply_config__field_descriptors,
-  cmd_apply_config__field_indices_by_name,
-  1,  cmd_apply_config__number_ranges,
-  (ProtobufCMessageInit) cmd_apply_config__init,
+  resp_set_wifi_config__field_descriptors,
+  resp_set_wifi_config__field_indices_by_name,
+  1,  resp_set_wifi_config__number_ranges,
+  (ProtobufCMessageInit) resp_set_wifi_config__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor resp_apply_config__field_descriptors[2] =
+static const ProtobufCFieldDescriptor resp_set_thread_config__field_descriptors[1] =
 {
   {
-    "net_type",
+    "status",
     1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
     0,   /* quantifier_offset */
-    offsetof(RespApplyConfig, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "status",
-    2,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(RespApplyConfig, status),
+    offsetof(RespSetThreadConfig, status),
     &status__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned resp_apply_config__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-  1,   /* field[1] = status */
+static const unsigned resp_set_thread_config__field_indices_by_name[] = {
+  0,   /* field[0] = status */
 };
-static const ProtobufCIntRange resp_apply_config__number_ranges[1 + 1] =
+static const ProtobufCIntRange resp_set_thread_config__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 2 }
+  { 0, 1 }
 };
-const ProtobufCMessageDescriptor resp_apply_config__descriptor =
+const ProtobufCMessageDescriptor resp_set_thread_config__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "RespApplyConfig",
-  "RespApplyConfig",
-  "RespApplyConfig",
+  "RespSetThreadConfig",
+  "RespSetThreadConfig",
+  "RespSetThreadConfig",
   "",
-  sizeof(RespApplyConfig),
-  2,
-  resp_apply_config__field_descriptors,
-  resp_apply_config__field_indices_by_name,
-  1,  resp_apply_config__number_ranges,
-  (ProtobufCMessageInit) resp_apply_config__init,
+  sizeof(RespSetThreadConfig),
+  1,
+  resp_set_thread_config__field_descriptors,
+  resp_set_thread_config__field_indices_by_name,
+  1,  resp_set_thread_config__number_ranges,
+  (ProtobufCMessageInit) resp_set_thread_config__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor network_config_payload__field_descriptors[7] =
+#define cmd_apply_wifi_config__field_descriptors NULL
+#define cmd_apply_wifi_config__field_indices_by_name NULL
+#define cmd_apply_wifi_config__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_apply_wifi_config__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "CmdApplyWifiConfig",
+  "CmdApplyWifiConfig",
+  "CmdApplyWifiConfig",
+  "",
+  sizeof(CmdApplyWifiConfig),
+  0,
+  cmd_apply_wifi_config__field_descriptors,
+  cmd_apply_wifi_config__field_indices_by_name,
+  0,  cmd_apply_wifi_config__number_ranges,
+  (ProtobufCMessageInit) cmd_apply_wifi_config__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define cmd_apply_thread_config__field_descriptors NULL
+#define cmd_apply_thread_config__field_indices_by_name NULL
+#define cmd_apply_thread_config__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_apply_thread_config__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "CmdApplyThreadConfig",
+  "CmdApplyThreadConfig",
+  "CmdApplyThreadConfig",
+  "",
+  sizeof(CmdApplyThreadConfig),
+  0,
+  cmd_apply_thread_config__field_descriptors,
+  cmd_apply_thread_config__field_indices_by_name,
+  0,  cmd_apply_thread_config__number_ranges,
+  (ProtobufCMessageInit) cmd_apply_thread_config__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor resp_apply_wifi_config__field_descriptors[1] =
+{
+  {
+    "status",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(RespApplyWifiConfig, status),
+    &status__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned resp_apply_wifi_config__field_indices_by_name[] = {
+  0,   /* field[0] = status */
+};
+static const ProtobufCIntRange resp_apply_wifi_config__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor resp_apply_wifi_config__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "RespApplyWifiConfig",
+  "RespApplyWifiConfig",
+  "RespApplyWifiConfig",
+  "",
+  sizeof(RespApplyWifiConfig),
+  1,
+  resp_apply_wifi_config__field_descriptors,
+  resp_apply_wifi_config__field_indices_by_name,
+  1,  resp_apply_wifi_config__number_ranges,
+  (ProtobufCMessageInit) resp_apply_wifi_config__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor resp_apply_thread_config__field_descriptors[1] =
+{
+  {
+    "status",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_ENUM,
+    0,   /* quantifier_offset */
+    offsetof(RespApplyThreadConfig, status),
+    &status__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned resp_apply_thread_config__field_indices_by_name[] = {
+  0,   /* field[0] = status */
+};
+static const ProtobufCIntRange resp_apply_thread_config__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor resp_apply_thread_config__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "RespApplyThreadConfig",
+  "RespApplyThreadConfig",
+  "RespApplyThreadConfig",
+  "",
+  sizeof(RespApplyThreadConfig),
+  1,
+  resp_apply_thread_config__field_descriptors,
+  resp_apply_thread_config__field_indices_by_name,
+  1,  resp_apply_thread_config__number_ranges,
+  (ProtobufCMessageInit) resp_apply_thread_config__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor network_config_payload__field_descriptors[13] =
 {
   {
     "msg",
@@ -916,92 +1102,170 @@ static const ProtobufCFieldDescriptor network_config_payload__field_descriptors[
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cmd_get_status",
+    "cmd_get_wifi_status",
     10,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkConfigPayload, payload_case),
-    offsetof(NetworkConfigPayload, cmd_get_status),
-    &cmd_get_status__descriptor,
+    offsetof(NetworkConfigPayload, cmd_get_wifi_status),
+    &cmd_get_wifi_status__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "resp_get_status",
+    "resp_get_wifi_status",
     11,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkConfigPayload, payload_case),
-    offsetof(NetworkConfigPayload, resp_get_status),
-    &resp_get_status__descriptor,
+    offsetof(NetworkConfigPayload, resp_get_wifi_status),
+    &resp_get_wifi_status__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cmd_set_config",
+    "cmd_set_wifi_config",
     12,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkConfigPayload, payload_case),
-    offsetof(NetworkConfigPayload, cmd_set_config),
-    &cmd_set_config__descriptor,
+    offsetof(NetworkConfigPayload, cmd_set_wifi_config),
+    &cmd_set_wifi_config__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "resp_set_config",
+    "resp_set_wifi_config",
     13,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkConfigPayload, payload_case),
-    offsetof(NetworkConfigPayload, resp_set_config),
-    &resp_set_config__descriptor,
+    offsetof(NetworkConfigPayload, resp_set_wifi_config),
+    &resp_set_wifi_config__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cmd_apply_config",
+    "cmd_apply_wifi_config",
     14,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkConfigPayload, payload_case),
-    offsetof(NetworkConfigPayload, cmd_apply_config),
-    &cmd_apply_config__descriptor,
+    offsetof(NetworkConfigPayload, cmd_apply_wifi_config),
+    &cmd_apply_wifi_config__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "resp_apply_config",
+    "resp_apply_wifi_config",
     15,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkConfigPayload, payload_case),
-    offsetof(NetworkConfigPayload, resp_apply_config),
-    &resp_apply_config__descriptor,
+    offsetof(NetworkConfigPayload, resp_apply_wifi_config),
+    &resp_apply_wifi_config__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "cmd_get_thread_status",
+    16,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkConfigPayload, payload_case),
+    offsetof(NetworkConfigPayload, cmd_get_thread_status),
+    &cmd_get_thread_status__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "resp_get_thread_status",
+    17,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkConfigPayload, payload_case),
+    offsetof(NetworkConfigPayload, resp_get_thread_status),
+    &resp_get_thread_status__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "cmd_set_thread_config",
+    18,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkConfigPayload, payload_case),
+    offsetof(NetworkConfigPayload, cmd_set_thread_config),
+    &cmd_set_thread_config__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "resp_set_thread_config",
+    19,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkConfigPayload, payload_case),
+    offsetof(NetworkConfigPayload, resp_set_thread_config),
+    &resp_set_thread_config__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "cmd_apply_thread_config",
+    20,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkConfigPayload, payload_case),
+    offsetof(NetworkConfigPayload, cmd_apply_thread_config),
+    &cmd_apply_thread_config__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "resp_apply_thread_config",
+    21,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkConfigPayload, payload_case),
+    offsetof(NetworkConfigPayload, resp_apply_thread_config),
+    &resp_apply_thread_config__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
 static const unsigned network_config_payload__field_indices_by_name[] = {
-  5,   /* field[5] = cmd_apply_config */
-  1,   /* field[1] = cmd_get_status */
-  3,   /* field[3] = cmd_set_config */
+  11,   /* field[11] = cmd_apply_thread_config */
+  5,   /* field[5] = cmd_apply_wifi_config */
+  7,   /* field[7] = cmd_get_thread_status */
+  1,   /* field[1] = cmd_get_wifi_status */
+  9,   /* field[9] = cmd_set_thread_config */
+  3,   /* field[3] = cmd_set_wifi_config */
   0,   /* field[0] = msg */
-  6,   /* field[6] = resp_apply_config */
-  2,   /* field[2] = resp_get_status */
-  4,   /* field[4] = resp_set_config */
+  12,   /* field[12] = resp_apply_thread_config */
+  6,   /* field[6] = resp_apply_wifi_config */
+  8,   /* field[8] = resp_get_thread_status */
+  2,   /* field[2] = resp_get_wifi_status */
+  10,   /* field[10] = resp_set_thread_config */
+  4,   /* field[4] = resp_set_wifi_config */
 };
 static const ProtobufCIntRange network_config_payload__number_ranges[2 + 1] =
 {
   { 1, 0 },
   { 10, 1 },
-  { 0, 7 }
+  { 0, 13 }
 };
 const ProtobufCMessageDescriptor network_config_payload__descriptor =
 {
@@ -1011,33 +1275,45 @@ const ProtobufCMessageDescriptor network_config_payload__descriptor =
   "NetworkConfigPayload",
   "",
   sizeof(NetworkConfigPayload),
-  7,
+  13,
   network_config_payload__field_descriptors,
   network_config_payload__field_indices_by_name,
   2,  network_config_payload__number_ranges,
   (ProtobufCMessageInit) network_config_payload__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCEnumValue network_config_msg_type__enum_values_by_number[6] =
+static const ProtobufCEnumValue network_config_msg_type__enum_values_by_number[12] =
 {
-  { "TypeCmdGetStatus", "NETWORK_CONFIG_MSG_TYPE__TypeCmdGetStatus", 0 },
-  { "TypeRespGetStatus", "NETWORK_CONFIG_MSG_TYPE__TypeRespGetStatus", 1 },
-  { "TypeCmdSetConfig", "NETWORK_CONFIG_MSG_TYPE__TypeCmdSetConfig", 2 },
-  { "TypeRespSetConfig", "NETWORK_CONFIG_MSG_TYPE__TypeRespSetConfig", 3 },
-  { "TypeCmdApplyConfig", "NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyConfig", 4 },
-  { "TypeRespApplyConfig", "NETWORK_CONFIG_MSG_TYPE__TypeRespApplyConfig", 5 },
+  { "TypeCmdGetWifiStatus", "NETWORK_CONFIG_MSG_TYPE__TypeCmdGetWifiStatus", 0 },
+  { "TypeRespGetWifiStatus", "NETWORK_CONFIG_MSG_TYPE__TypeRespGetWifiStatus", 1 },
+  { "TypeCmdSetWifiConfig", "NETWORK_CONFIG_MSG_TYPE__TypeCmdSetWifiConfig", 2 },
+  { "TypeRespSetWifiConfig", "NETWORK_CONFIG_MSG_TYPE__TypeRespSetWifiConfig", 3 },
+  { "TypeCmdApplyWifiConfig", "NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyWifiConfig", 4 },
+  { "TypeRespApplyWifiConfig", "NETWORK_CONFIG_MSG_TYPE__TypeRespApplyWifiConfig", 5 },
+  { "TypeCmdGetThreadStatus", "NETWORK_CONFIG_MSG_TYPE__TypeCmdGetThreadStatus", 6 },
+  { "TypeRespGetThreadStatus", "NETWORK_CONFIG_MSG_TYPE__TypeRespGetThreadStatus", 7 },
+  { "TypeCmdSetThreadConfig", "NETWORK_CONFIG_MSG_TYPE__TypeCmdSetThreadConfig", 8 },
+  { "TypeRespSetThreadConfig", "NETWORK_CONFIG_MSG_TYPE__TypeRespSetThreadConfig", 9 },
+  { "TypeCmdApplyThreadConfig", "NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyThreadConfig", 10 },
+  { "TypeRespApplyThreadConfig", "NETWORK_CONFIG_MSG_TYPE__TypeRespApplyThreadConfig", 11 },
 };
 static const ProtobufCIntRange network_config_msg_type__value_ranges[] = {
-{0, 0},{0, 6}
+{0, 0},{0, 12}
 };
-static const ProtobufCEnumValueIndex network_config_msg_type__enum_values_by_name[6] =
+static const ProtobufCEnumValueIndex network_config_msg_type__enum_values_by_name[12] =
 {
-  { "TypeCmdApplyConfig", 4 },
-  { "TypeCmdGetStatus", 0 },
-  { "TypeCmdSetConfig", 2 },
-  { "TypeRespApplyConfig", 5 },
-  { "TypeRespGetStatus", 1 },
-  { "TypeRespSetConfig", 3 },
+  { "TypeCmdApplyThreadConfig", 10 },
+  { "TypeCmdApplyWifiConfig", 4 },
+  { "TypeCmdGetThreadStatus", 6 },
+  { "TypeCmdGetWifiStatus", 0 },
+  { "TypeCmdSetThreadConfig", 8 },
+  { "TypeCmdSetWifiConfig", 2 },
+  { "TypeRespApplyThreadConfig", 11 },
+  { "TypeRespApplyWifiConfig", 5 },
+  { "TypeRespGetThreadStatus", 7 },
+  { "TypeRespGetWifiStatus", 1 },
+  { "TypeRespSetThreadConfig", 9 },
+  { "TypeRespSetWifiConfig", 3 },
 };
 const ProtobufCEnumDescriptor network_config_msg_type__descriptor =
 {
@@ -1046,9 +1322,9 @@ const ProtobufCEnumDescriptor network_config_msg_type__descriptor =
   "NetworkConfigMsgType",
   "NetworkConfigMsgType",
   "",
-  6,
+  12,
   network_config_msg_type__enum_values_by_number,
-  6,
+  12,
   network_config_msg_type__enum_values_by_name,
   1,
   network_config_msg_type__value_ranges,

--- a/network_provisioning/proto-c/network_config.pb-c.h
+++ b/network_provisioning/proto-c/network_config.pb-c.h
@@ -17,81 +17,106 @@ PROTOBUF_C__BEGIN_DECLS
 #include "constants.pb-c.h"
 #include "network_constants.pb-c.h"
 
-typedef struct CmdGetStatus CmdGetStatus;
-typedef struct RespGetStatus RespGetStatus;
-typedef struct WifiSetConfig WifiSetConfig;
-typedef struct ThreadSetConfig ThreadSetConfig;
-typedef struct CmdSetConfig CmdSetConfig;
-typedef struct RespSetConfig RespSetConfig;
-typedef struct CmdApplyConfig CmdApplyConfig;
-typedef struct RespApplyConfig RespApplyConfig;
+typedef struct CmdGetWifiStatus CmdGetWifiStatus;
+typedef struct RespGetWifiStatus RespGetWifiStatus;
+typedef struct CmdGetThreadStatus CmdGetThreadStatus;
+typedef struct RespGetThreadStatus RespGetThreadStatus;
+typedef struct CmdSetWifiConfig CmdSetWifiConfig;
+typedef struct CmdSetThreadConfig CmdSetThreadConfig;
+typedef struct RespSetWifiConfig RespSetWifiConfig;
+typedef struct RespSetThreadConfig RespSetThreadConfig;
+typedef struct CmdApplyWifiConfig CmdApplyWifiConfig;
+typedef struct CmdApplyThreadConfig CmdApplyThreadConfig;
+typedef struct RespApplyWifiConfig RespApplyWifiConfig;
+typedef struct RespApplyThreadConfig RespApplyThreadConfig;
 typedef struct NetworkConfigPayload NetworkConfigPayload;
 
 
 /* --- enums --- */
 
 typedef enum _NetworkConfigMsgType {
-  NETWORK_CONFIG_MSG_TYPE__TypeCmdGetStatus = 0,
-  NETWORK_CONFIG_MSG_TYPE__TypeRespGetStatus = 1,
-  NETWORK_CONFIG_MSG_TYPE__TypeCmdSetConfig = 2,
-  NETWORK_CONFIG_MSG_TYPE__TypeRespSetConfig = 3,
-  NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyConfig = 4,
-  NETWORK_CONFIG_MSG_TYPE__TypeRespApplyConfig = 5
+  NETWORK_CONFIG_MSG_TYPE__TypeCmdGetWifiStatus = 0,
+  NETWORK_CONFIG_MSG_TYPE__TypeRespGetWifiStatus = 1,
+  NETWORK_CONFIG_MSG_TYPE__TypeCmdSetWifiConfig = 2,
+  NETWORK_CONFIG_MSG_TYPE__TypeRespSetWifiConfig = 3,
+  NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyWifiConfig = 4,
+  NETWORK_CONFIG_MSG_TYPE__TypeRespApplyWifiConfig = 5,
+  NETWORK_CONFIG_MSG_TYPE__TypeCmdGetThreadStatus = 6,
+  NETWORK_CONFIG_MSG_TYPE__TypeRespGetThreadStatus = 7,
+  NETWORK_CONFIG_MSG_TYPE__TypeCmdSetThreadConfig = 8,
+  NETWORK_CONFIG_MSG_TYPE__TypeRespSetThreadConfig = 9,
+  NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyThreadConfig = 10,
+  NETWORK_CONFIG_MSG_TYPE__TypeRespApplyThreadConfig = 11
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NETWORK_CONFIG_MSG_TYPE)
 } NetworkConfigMsgType;
 
 /* --- messages --- */
 
-struct  CmdGetStatus
+struct  CmdGetWifiStatus
 {
   ProtobufCMessage base;
-  NetworkType net_type;
 };
-#define CMD_GET_STATUS__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&cmd_get_status__descriptor) \
-    , NETWORK_TYPE__WifiNetwork }
+#define CMD_GET_WIFI_STATUS__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_get_wifi_status__descriptor) \
+     }
 
 
 typedef enum {
-  RESP_GET_STATUS__PAYLOAD__NOT_SET = 0,
-  RESP_GET_STATUS__PAYLOAD_WIFI_STA_STATE = 10,
-  RESP_GET_STATUS__PAYLOAD_THREAD_STATE = 11
-    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(RESP_GET_STATUS__PAYLOAD__CASE)
-} RespGetStatus__PayloadCase;
+  RESP_GET_WIFI_STATUS__STATE__NOT_SET = 0,
+  RESP_GET_WIFI_STATUS__STATE_WIFI_FAIL_REASON = 10,
+  RESP_GET_WIFI_STATUS__STATE_WIFI_CONNECTED = 11
+    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(RESP_GET_WIFI_STATUS__STATE__CASE)
+} RespGetWifiStatus__StateCase;
 
-typedef enum {
-  RESP_GET_STATUS__STATE__NOT_SET = 0,
-  RESP_GET_STATUS__STATE_WIFI_FAIL_REASON = 20,
-  RESP_GET_STATUS__STATE_WIFI_CONNECTED = 21,
-  RESP_GET_STATUS__STATE_THREAD_FAIL_REASON = 22,
-  RESP_GET_STATUS__STATE_THREAD_ATTACHED = 23
-    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(RESP_GET_STATUS__STATE__CASE)
-} RespGetStatus__StateCase;
-
-struct  RespGetStatus
+struct  RespGetWifiStatus
 {
   ProtobufCMessage base;
-  NetworkType net_type;
   Status status;
-  RespGetStatus__PayloadCase payload_case;
-  union {
-    WifiStationState wifi_sta_state;
-    ThreadNetworkState thread_state;
-  };
-  RespGetStatus__StateCase state_case;
+  WifiStationState wifi_sta_state;
+  RespGetWifiStatus__StateCase state_case;
   union {
     WifiConnectFailedReason wifi_fail_reason;
     WifiConnectedState *wifi_connected;
+  };
+};
+#define RESP_GET_WIFI_STATUS__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_get_wifi_status__descriptor) \
+    , STATUS__Success, WIFI_STATION_STATE__Connected, RESP_GET_WIFI_STATUS__STATE__NOT_SET, {0} }
+
+
+struct  CmdGetThreadStatus
+{
+  ProtobufCMessage base;
+};
+#define CMD_GET_THREAD_STATUS__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_get_thread_status__descriptor) \
+     }
+
+
+typedef enum {
+  RESP_GET_THREAD_STATUS__STATE__NOT_SET = 0,
+  RESP_GET_THREAD_STATUS__STATE_THREAD_FAIL_REASON = 10,
+  RESP_GET_THREAD_STATUS__STATE_THREAD_ATTACHED = 11
+    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(RESP_GET_THREAD_STATUS__STATE__CASE)
+} RespGetThreadStatus__StateCase;
+
+struct  RespGetThreadStatus
+{
+  ProtobufCMessage base;
+  Status status;
+  ThreadNetworkState thread_state;
+  RespGetThreadStatus__StateCase state_case;
+  union {
     ThreadAttachFailedReason thread_fail_reason;
     ThreadAttachState *thread_attached;
   };
 };
-#define RESP_GET_STATUS__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&resp_get_status__descriptor) \
-    , NETWORK_TYPE__WifiNetwork, STATUS__Success, RESP_GET_STATUS__PAYLOAD__NOT_SET, {0}, RESP_GET_STATUS__STATE__NOT_SET, {0} }
+#define RESP_GET_THREAD_STATUS__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_get_thread_status__descriptor) \
+    , STATUS__Success, THREAD_NETWORK_STATE__Attached, RESP_GET_THREAD_STATUS__STATE__NOT_SET, {0} }
 
 
-struct  WifiSetConfig
+struct  CmdSetWifiConfig
 {
   ProtobufCMessage base;
   ProtobufCBinaryData ssid;
@@ -99,83 +124,93 @@ struct  WifiSetConfig
   ProtobufCBinaryData bssid;
   int32_t channel;
 };
-#define WIFI_SET_CONFIG__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&wifi_set_config__descriptor) \
+#define CMD_SET_WIFI_CONFIG__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_set_wifi_config__descriptor) \
     , {0,NULL}, {0,NULL}, {0,NULL}, 0 }
 
 
-struct  ThreadSetConfig
+struct  CmdSetThreadConfig
 {
   ProtobufCMessage base;
   ProtobufCBinaryData dataset;
 };
-#define THREAD_SET_CONFIG__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&thread_set_config__descriptor) \
+#define CMD_SET_THREAD_CONFIG__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_set_thread_config__descriptor) \
     , {0,NULL} }
 
 
-typedef enum {
-  CMD_SET_CONFIG__PAYLOAD__NOT_SET = 0,
-  CMD_SET_CONFIG__PAYLOAD_WIFI_CONFIG = 10,
-  CMD_SET_CONFIG__PAYLOAD_THREAD_CONFIG = 11
-    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CMD_SET_CONFIG__PAYLOAD__CASE)
-} CmdSetConfig__PayloadCase;
-
-struct  CmdSetConfig
+struct  RespSetWifiConfig
 {
   ProtobufCMessage base;
-  NetworkType net_type;
-  CmdSetConfig__PayloadCase payload_case;
-  union {
-    WifiSetConfig *wifi_config;
-    ThreadSetConfig *thread_config;
-  };
-};
-#define CMD_SET_CONFIG__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&cmd_set_config__descriptor) \
-    , NETWORK_TYPE__WifiNetwork, CMD_SET_CONFIG__PAYLOAD__NOT_SET, {0} }
-
-
-struct  RespSetConfig
-{
-  ProtobufCMessage base;
-  NetworkType net_type;
   Status status;
 };
-#define RESP_SET_CONFIG__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&resp_set_config__descriptor) \
-    , NETWORK_TYPE__WifiNetwork, STATUS__Success }
+#define RESP_SET_WIFI_CONFIG__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_set_wifi_config__descriptor) \
+    , STATUS__Success }
 
 
-struct  CmdApplyConfig
+struct  RespSetThreadConfig
 {
   ProtobufCMessage base;
-  NetworkType net_type;
-};
-#define CMD_APPLY_CONFIG__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&cmd_apply_config__descriptor) \
-    , NETWORK_TYPE__WifiNetwork }
-
-
-struct  RespApplyConfig
-{
-  ProtobufCMessage base;
-  NetworkType net_type;
   Status status;
 };
-#define RESP_APPLY_CONFIG__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&resp_apply_config__descriptor) \
-    , NETWORK_TYPE__WifiNetwork, STATUS__Success }
+#define RESP_SET_THREAD_CONFIG__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_set_thread_config__descriptor) \
+    , STATUS__Success }
+
+
+struct  CmdApplyWifiConfig
+{
+  ProtobufCMessage base;
+};
+#define CMD_APPLY_WIFI_CONFIG__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_apply_wifi_config__descriptor) \
+     }
+
+
+struct  CmdApplyThreadConfig
+{
+  ProtobufCMessage base;
+};
+#define CMD_APPLY_THREAD_CONFIG__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_apply_thread_config__descriptor) \
+     }
+
+
+struct  RespApplyWifiConfig
+{
+  ProtobufCMessage base;
+  Status status;
+};
+#define RESP_APPLY_WIFI_CONFIG__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_apply_wifi_config__descriptor) \
+    , STATUS__Success }
+
+
+struct  RespApplyThreadConfig
+{
+  ProtobufCMessage base;
+  Status status;
+};
+#define RESP_APPLY_THREAD_CONFIG__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_apply_thread_config__descriptor) \
+    , STATUS__Success }
 
 
 typedef enum {
   NETWORK_CONFIG_PAYLOAD__PAYLOAD__NOT_SET = 0,
-  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_GET_STATUS = 10,
-  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_GET_STATUS = 11,
-  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_SET_CONFIG = 12,
-  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_SET_CONFIG = 13,
-  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_APPLY_CONFIG = 14,
-  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_APPLY_CONFIG = 15
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_GET_WIFI_STATUS = 10,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_GET_WIFI_STATUS = 11,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_SET_WIFI_CONFIG = 12,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_SET_WIFI_CONFIG = 13,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_APPLY_WIFI_CONFIG = 14,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_APPLY_WIFI_CONFIG = 15,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_GET_THREAD_STATUS = 16,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_GET_THREAD_STATUS = 17,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_SET_THREAD_CONFIG = 18,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_SET_THREAD_CONFIG = 19,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_CMD_APPLY_THREAD_CONFIG = 20,
+  NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_APPLY_THREAD_CONFIG = 21
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NETWORK_CONFIG_PAYLOAD__PAYLOAD__CASE)
 } NetworkConfigPayload__PayloadCase;
 
@@ -185,170 +220,252 @@ struct  NetworkConfigPayload
   NetworkConfigMsgType msg;
   NetworkConfigPayload__PayloadCase payload_case;
   union {
-    CmdGetStatus *cmd_get_status;
-    RespGetStatus *resp_get_status;
-    CmdSetConfig *cmd_set_config;
-    RespSetConfig *resp_set_config;
-    CmdApplyConfig *cmd_apply_config;
-    RespApplyConfig *resp_apply_config;
+    CmdGetWifiStatus *cmd_get_wifi_status;
+    RespGetWifiStatus *resp_get_wifi_status;
+    CmdSetWifiConfig *cmd_set_wifi_config;
+    RespSetWifiConfig *resp_set_wifi_config;
+    CmdApplyWifiConfig *cmd_apply_wifi_config;
+    RespApplyWifiConfig *resp_apply_wifi_config;
+    CmdGetThreadStatus *cmd_get_thread_status;
+    RespGetThreadStatus *resp_get_thread_status;
+    CmdSetThreadConfig *cmd_set_thread_config;
+    RespSetThreadConfig *resp_set_thread_config;
+    CmdApplyThreadConfig *cmd_apply_thread_config;
+    RespApplyThreadConfig *resp_apply_thread_config;
   };
 };
 #define NETWORK_CONFIG_PAYLOAD__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&network_config_payload__descriptor) \
-    , NETWORK_CONFIG_MSG_TYPE__TypeCmdGetStatus, NETWORK_CONFIG_PAYLOAD__PAYLOAD__NOT_SET, {0} }
+    , NETWORK_CONFIG_MSG_TYPE__TypeCmdGetWifiStatus, NETWORK_CONFIG_PAYLOAD__PAYLOAD__NOT_SET, {0} }
 
 
-/* CmdGetStatus methods */
-void   cmd_get_status__init
-                     (CmdGetStatus         *message);
-size_t cmd_get_status__get_packed_size
-                     (const CmdGetStatus   *message);
-size_t cmd_get_status__pack
-                     (const CmdGetStatus   *message,
+/* CmdGetWifiStatus methods */
+void   cmd_get_wifi_status__init
+                     (CmdGetWifiStatus         *message);
+size_t cmd_get_wifi_status__get_packed_size
+                     (const CmdGetWifiStatus   *message);
+size_t cmd_get_wifi_status__pack
+                     (const CmdGetWifiStatus   *message,
                       uint8_t             *out);
-size_t cmd_get_status__pack_to_buffer
-                     (const CmdGetStatus   *message,
+size_t cmd_get_wifi_status__pack_to_buffer
+                     (const CmdGetWifiStatus   *message,
                       ProtobufCBuffer     *buffer);
-CmdGetStatus *
-       cmd_get_status__unpack
+CmdGetWifiStatus *
+       cmd_get_wifi_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   cmd_get_status__free_unpacked
-                     (CmdGetStatus *message,
+void   cmd_get_wifi_status__free_unpacked
+                     (CmdGetWifiStatus *message,
                       ProtobufCAllocator *allocator);
-/* RespGetStatus methods */
-void   resp_get_status__init
-                     (RespGetStatus         *message);
-size_t resp_get_status__get_packed_size
-                     (const RespGetStatus   *message);
-size_t resp_get_status__pack
-                     (const RespGetStatus   *message,
+/* RespGetWifiStatus methods */
+void   resp_get_wifi_status__init
+                     (RespGetWifiStatus         *message);
+size_t resp_get_wifi_status__get_packed_size
+                     (const RespGetWifiStatus   *message);
+size_t resp_get_wifi_status__pack
+                     (const RespGetWifiStatus   *message,
                       uint8_t             *out);
-size_t resp_get_status__pack_to_buffer
-                     (const RespGetStatus   *message,
+size_t resp_get_wifi_status__pack_to_buffer
+                     (const RespGetWifiStatus   *message,
                       ProtobufCBuffer     *buffer);
-RespGetStatus *
-       resp_get_status__unpack
+RespGetWifiStatus *
+       resp_get_wifi_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   resp_get_status__free_unpacked
-                     (RespGetStatus *message,
+void   resp_get_wifi_status__free_unpacked
+                     (RespGetWifiStatus *message,
                       ProtobufCAllocator *allocator);
-/* WifiSetConfig methods */
-void   wifi_set_config__init
-                     (WifiSetConfig         *message);
-size_t wifi_set_config__get_packed_size
-                     (const WifiSetConfig   *message);
-size_t wifi_set_config__pack
-                     (const WifiSetConfig   *message,
+/* CmdGetThreadStatus methods */
+void   cmd_get_thread_status__init
+                     (CmdGetThreadStatus         *message);
+size_t cmd_get_thread_status__get_packed_size
+                     (const CmdGetThreadStatus   *message);
+size_t cmd_get_thread_status__pack
+                     (const CmdGetThreadStatus   *message,
                       uint8_t             *out);
-size_t wifi_set_config__pack_to_buffer
-                     (const WifiSetConfig   *message,
+size_t cmd_get_thread_status__pack_to_buffer
+                     (const CmdGetThreadStatus   *message,
                       ProtobufCBuffer     *buffer);
-WifiSetConfig *
-       wifi_set_config__unpack
+CmdGetThreadStatus *
+       cmd_get_thread_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   wifi_set_config__free_unpacked
-                     (WifiSetConfig *message,
+void   cmd_get_thread_status__free_unpacked
+                     (CmdGetThreadStatus *message,
                       ProtobufCAllocator *allocator);
-/* ThreadSetConfig methods */
-void   thread_set_config__init
-                     (ThreadSetConfig         *message);
-size_t thread_set_config__get_packed_size
-                     (const ThreadSetConfig   *message);
-size_t thread_set_config__pack
-                     (const ThreadSetConfig   *message,
+/* RespGetThreadStatus methods */
+void   resp_get_thread_status__init
+                     (RespGetThreadStatus         *message);
+size_t resp_get_thread_status__get_packed_size
+                     (const RespGetThreadStatus   *message);
+size_t resp_get_thread_status__pack
+                     (const RespGetThreadStatus   *message,
                       uint8_t             *out);
-size_t thread_set_config__pack_to_buffer
-                     (const ThreadSetConfig   *message,
+size_t resp_get_thread_status__pack_to_buffer
+                     (const RespGetThreadStatus   *message,
                       ProtobufCBuffer     *buffer);
-ThreadSetConfig *
-       thread_set_config__unpack
+RespGetThreadStatus *
+       resp_get_thread_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   thread_set_config__free_unpacked
-                     (ThreadSetConfig *message,
+void   resp_get_thread_status__free_unpacked
+                     (RespGetThreadStatus *message,
                       ProtobufCAllocator *allocator);
-/* CmdSetConfig methods */
-void   cmd_set_config__init
-                     (CmdSetConfig         *message);
-size_t cmd_set_config__get_packed_size
-                     (const CmdSetConfig   *message);
-size_t cmd_set_config__pack
-                     (const CmdSetConfig   *message,
+/* CmdSetWifiConfig methods */
+void   cmd_set_wifi_config__init
+                     (CmdSetWifiConfig         *message);
+size_t cmd_set_wifi_config__get_packed_size
+                     (const CmdSetWifiConfig   *message);
+size_t cmd_set_wifi_config__pack
+                     (const CmdSetWifiConfig   *message,
                       uint8_t             *out);
-size_t cmd_set_config__pack_to_buffer
-                     (const CmdSetConfig   *message,
+size_t cmd_set_wifi_config__pack_to_buffer
+                     (const CmdSetWifiConfig   *message,
                       ProtobufCBuffer     *buffer);
-CmdSetConfig *
-       cmd_set_config__unpack
+CmdSetWifiConfig *
+       cmd_set_wifi_config__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   cmd_set_config__free_unpacked
-                     (CmdSetConfig *message,
+void   cmd_set_wifi_config__free_unpacked
+                     (CmdSetWifiConfig *message,
                       ProtobufCAllocator *allocator);
-/* RespSetConfig methods */
-void   resp_set_config__init
-                     (RespSetConfig         *message);
-size_t resp_set_config__get_packed_size
-                     (const RespSetConfig   *message);
-size_t resp_set_config__pack
-                     (const RespSetConfig   *message,
+/* CmdSetThreadConfig methods */
+void   cmd_set_thread_config__init
+                     (CmdSetThreadConfig         *message);
+size_t cmd_set_thread_config__get_packed_size
+                     (const CmdSetThreadConfig   *message);
+size_t cmd_set_thread_config__pack
+                     (const CmdSetThreadConfig   *message,
                       uint8_t             *out);
-size_t resp_set_config__pack_to_buffer
-                     (const RespSetConfig   *message,
+size_t cmd_set_thread_config__pack_to_buffer
+                     (const CmdSetThreadConfig   *message,
                       ProtobufCBuffer     *buffer);
-RespSetConfig *
-       resp_set_config__unpack
+CmdSetThreadConfig *
+       cmd_set_thread_config__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   resp_set_config__free_unpacked
-                     (RespSetConfig *message,
+void   cmd_set_thread_config__free_unpacked
+                     (CmdSetThreadConfig *message,
                       ProtobufCAllocator *allocator);
-/* CmdApplyConfig methods */
-void   cmd_apply_config__init
-                     (CmdApplyConfig         *message);
-size_t cmd_apply_config__get_packed_size
-                     (const CmdApplyConfig   *message);
-size_t cmd_apply_config__pack
-                     (const CmdApplyConfig   *message,
+/* RespSetWifiConfig methods */
+void   resp_set_wifi_config__init
+                     (RespSetWifiConfig         *message);
+size_t resp_set_wifi_config__get_packed_size
+                     (const RespSetWifiConfig   *message);
+size_t resp_set_wifi_config__pack
+                     (const RespSetWifiConfig   *message,
                       uint8_t             *out);
-size_t cmd_apply_config__pack_to_buffer
-                     (const CmdApplyConfig   *message,
+size_t resp_set_wifi_config__pack_to_buffer
+                     (const RespSetWifiConfig   *message,
                       ProtobufCBuffer     *buffer);
-CmdApplyConfig *
-       cmd_apply_config__unpack
+RespSetWifiConfig *
+       resp_set_wifi_config__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   cmd_apply_config__free_unpacked
-                     (CmdApplyConfig *message,
+void   resp_set_wifi_config__free_unpacked
+                     (RespSetWifiConfig *message,
                       ProtobufCAllocator *allocator);
-/* RespApplyConfig methods */
-void   resp_apply_config__init
-                     (RespApplyConfig         *message);
-size_t resp_apply_config__get_packed_size
-                     (const RespApplyConfig   *message);
-size_t resp_apply_config__pack
-                     (const RespApplyConfig   *message,
+/* RespSetThreadConfig methods */
+void   resp_set_thread_config__init
+                     (RespSetThreadConfig         *message);
+size_t resp_set_thread_config__get_packed_size
+                     (const RespSetThreadConfig   *message);
+size_t resp_set_thread_config__pack
+                     (const RespSetThreadConfig   *message,
                       uint8_t             *out);
-size_t resp_apply_config__pack_to_buffer
-                     (const RespApplyConfig   *message,
+size_t resp_set_thread_config__pack_to_buffer
+                     (const RespSetThreadConfig   *message,
                       ProtobufCBuffer     *buffer);
-RespApplyConfig *
-       resp_apply_config__unpack
+RespSetThreadConfig *
+       resp_set_thread_config__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   resp_apply_config__free_unpacked
-                     (RespApplyConfig *message,
+void   resp_set_thread_config__free_unpacked
+                     (RespSetThreadConfig *message,
+                      ProtobufCAllocator *allocator);
+/* CmdApplyWifiConfig methods */
+void   cmd_apply_wifi_config__init
+                     (CmdApplyWifiConfig         *message);
+size_t cmd_apply_wifi_config__get_packed_size
+                     (const CmdApplyWifiConfig   *message);
+size_t cmd_apply_wifi_config__pack
+                     (const CmdApplyWifiConfig   *message,
+                      uint8_t             *out);
+size_t cmd_apply_wifi_config__pack_to_buffer
+                     (const CmdApplyWifiConfig   *message,
+                      ProtobufCBuffer     *buffer);
+CmdApplyWifiConfig *
+       cmd_apply_wifi_config__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   cmd_apply_wifi_config__free_unpacked
+                     (CmdApplyWifiConfig *message,
+                      ProtobufCAllocator *allocator);
+/* CmdApplyThreadConfig methods */
+void   cmd_apply_thread_config__init
+                     (CmdApplyThreadConfig         *message);
+size_t cmd_apply_thread_config__get_packed_size
+                     (const CmdApplyThreadConfig   *message);
+size_t cmd_apply_thread_config__pack
+                     (const CmdApplyThreadConfig   *message,
+                      uint8_t             *out);
+size_t cmd_apply_thread_config__pack_to_buffer
+                     (const CmdApplyThreadConfig   *message,
+                      ProtobufCBuffer     *buffer);
+CmdApplyThreadConfig *
+       cmd_apply_thread_config__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   cmd_apply_thread_config__free_unpacked
+                     (CmdApplyThreadConfig *message,
+                      ProtobufCAllocator *allocator);
+/* RespApplyWifiConfig methods */
+void   resp_apply_wifi_config__init
+                     (RespApplyWifiConfig         *message);
+size_t resp_apply_wifi_config__get_packed_size
+                     (const RespApplyWifiConfig   *message);
+size_t resp_apply_wifi_config__pack
+                     (const RespApplyWifiConfig   *message,
+                      uint8_t             *out);
+size_t resp_apply_wifi_config__pack_to_buffer
+                     (const RespApplyWifiConfig   *message,
+                      ProtobufCBuffer     *buffer);
+RespApplyWifiConfig *
+       resp_apply_wifi_config__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   resp_apply_wifi_config__free_unpacked
+                     (RespApplyWifiConfig *message,
+                      ProtobufCAllocator *allocator);
+/* RespApplyThreadConfig methods */
+void   resp_apply_thread_config__init
+                     (RespApplyThreadConfig         *message);
+size_t resp_apply_thread_config__get_packed_size
+                     (const RespApplyThreadConfig   *message);
+size_t resp_apply_thread_config__pack
+                     (const RespApplyThreadConfig   *message,
+                      uint8_t             *out);
+size_t resp_apply_thread_config__pack_to_buffer
+                     (const RespApplyThreadConfig   *message,
+                      ProtobufCBuffer     *buffer);
+RespApplyThreadConfig *
+       resp_apply_thread_config__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   resp_apply_thread_config__free_unpacked
+                     (RespApplyThreadConfig *message,
                       ProtobufCAllocator *allocator);
 /* NetworkConfigPayload methods */
 void   network_config_payload__init
@@ -371,29 +488,41 @@ void   network_config_payload__free_unpacked
                       ProtobufCAllocator *allocator);
 /* --- per-message closures --- */
 
-typedef void (*CmdGetStatus_Closure)
-                 (const CmdGetStatus *message,
+typedef void (*CmdGetWifiStatus_Closure)
+                 (const CmdGetWifiStatus *message,
                   void *closure_data);
-typedef void (*RespGetStatus_Closure)
-                 (const RespGetStatus *message,
+typedef void (*RespGetWifiStatus_Closure)
+                 (const RespGetWifiStatus *message,
                   void *closure_data);
-typedef void (*WifiSetConfig_Closure)
-                 (const WifiSetConfig *message,
+typedef void (*CmdGetThreadStatus_Closure)
+                 (const CmdGetThreadStatus *message,
                   void *closure_data);
-typedef void (*ThreadSetConfig_Closure)
-                 (const ThreadSetConfig *message,
+typedef void (*RespGetThreadStatus_Closure)
+                 (const RespGetThreadStatus *message,
                   void *closure_data);
-typedef void (*CmdSetConfig_Closure)
-                 (const CmdSetConfig *message,
+typedef void (*CmdSetWifiConfig_Closure)
+                 (const CmdSetWifiConfig *message,
                   void *closure_data);
-typedef void (*RespSetConfig_Closure)
-                 (const RespSetConfig *message,
+typedef void (*CmdSetThreadConfig_Closure)
+                 (const CmdSetThreadConfig *message,
                   void *closure_data);
-typedef void (*CmdApplyConfig_Closure)
-                 (const CmdApplyConfig *message,
+typedef void (*RespSetWifiConfig_Closure)
+                 (const RespSetWifiConfig *message,
                   void *closure_data);
-typedef void (*RespApplyConfig_Closure)
-                 (const RespApplyConfig *message,
+typedef void (*RespSetThreadConfig_Closure)
+                 (const RespSetThreadConfig *message,
+                  void *closure_data);
+typedef void (*CmdApplyWifiConfig_Closure)
+                 (const CmdApplyWifiConfig *message,
+                  void *closure_data);
+typedef void (*CmdApplyThreadConfig_Closure)
+                 (const CmdApplyThreadConfig *message,
+                  void *closure_data);
+typedef void (*RespApplyWifiConfig_Closure)
+                 (const RespApplyWifiConfig *message,
+                  void *closure_data);
+typedef void (*RespApplyThreadConfig_Closure)
+                 (const RespApplyThreadConfig *message,
                   void *closure_data);
 typedef void (*NetworkConfigPayload_Closure)
                  (const NetworkConfigPayload *message,
@@ -405,14 +534,18 @@ typedef void (*NetworkConfigPayload_Closure)
 /* --- descriptors --- */
 
 extern const ProtobufCEnumDescriptor    network_config_msg_type__descriptor;
-extern const ProtobufCMessageDescriptor cmd_get_status__descriptor;
-extern const ProtobufCMessageDescriptor resp_get_status__descriptor;
-extern const ProtobufCMessageDescriptor wifi_set_config__descriptor;
-extern const ProtobufCMessageDescriptor thread_set_config__descriptor;
-extern const ProtobufCMessageDescriptor cmd_set_config__descriptor;
-extern const ProtobufCMessageDescriptor resp_set_config__descriptor;
-extern const ProtobufCMessageDescriptor cmd_apply_config__descriptor;
-extern const ProtobufCMessageDescriptor resp_apply_config__descriptor;
+extern const ProtobufCMessageDescriptor cmd_get_wifi_status__descriptor;
+extern const ProtobufCMessageDescriptor resp_get_wifi_status__descriptor;
+extern const ProtobufCMessageDescriptor cmd_get_thread_status__descriptor;
+extern const ProtobufCMessageDescriptor resp_get_thread_status__descriptor;
+extern const ProtobufCMessageDescriptor cmd_set_wifi_config__descriptor;
+extern const ProtobufCMessageDescriptor cmd_set_thread_config__descriptor;
+extern const ProtobufCMessageDescriptor resp_set_wifi_config__descriptor;
+extern const ProtobufCMessageDescriptor resp_set_thread_config__descriptor;
+extern const ProtobufCMessageDescriptor cmd_apply_wifi_config__descriptor;
+extern const ProtobufCMessageDescriptor cmd_apply_thread_config__descriptor;
+extern const ProtobufCMessageDescriptor resp_apply_wifi_config__descriptor;
+extern const ProtobufCMessageDescriptor resp_apply_thread_config__descriptor;
 extern const ProtobufCMessageDescriptor network_config_payload__descriptor;
 
 PROTOBUF_C__END_DECLS

--- a/network_provisioning/proto-c/network_constants.pb-c.c
+++ b/network_provisioning/proto-c/network_constants.pb-c.c
@@ -264,34 +264,6 @@ const ProtobufCMessageDescriptor thread_attach_state__descriptor =
   (ProtobufCMessageInit) thread_attach_state__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCEnumValue network_type__enum_values_by_number[2] =
-{
-  { "WifiNetwork", "NETWORK_TYPE__WifiNetwork", 0 },
-  { "ThreadNetwork", "NETWORK_TYPE__ThreadNetwork", 1 },
-};
-static const ProtobufCIntRange network_type__value_ranges[] = {
-{0, 0},{0, 2}
-};
-static const ProtobufCEnumValueIndex network_type__enum_values_by_name[2] =
-{
-  { "ThreadNetwork", 1 },
-  { "WifiNetwork", 0 },
-};
-const ProtobufCEnumDescriptor network_type__descriptor =
-{
-  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
-  "NetworkType",
-  "NetworkType",
-  "NetworkType",
-  "",
-  2,
-  network_type__enum_values_by_number,
-  2,
-  network_type__enum_values_by_name,
-  1,
-  network_type__value_ranges,
-  NULL,NULL,NULL,NULL   /* reserved[1234] */
-};
 static const ProtobufCEnumValue wifi_station_state__enum_values_by_number[4] =
 {
   { "Connected", "WIFI_STATION_STATE__Connected", 0 },

--- a/network_provisioning/proto-c/network_constants.pb-c.h
+++ b/network_provisioning/proto-c/network_constants.pb-c.h
@@ -21,11 +21,6 @@ typedef struct ThreadAttachState ThreadAttachState;
 
 /* --- enums --- */
 
-typedef enum _NetworkType {
-  NETWORK_TYPE__WifiNetwork = 0,
-  NETWORK_TYPE__ThreadNetwork = 1
-    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NETWORK_TYPE)
-} NetworkType;
 typedef enum _WifiStationState {
   WIFI_STATION_STATE__Connected = 0,
   WIFI_STATION_STATE__Connecting = 1,
@@ -143,7 +138,6 @@ typedef void (*ThreadAttachState_Closure)
 
 /* --- descriptors --- */
 
-extern const ProtobufCEnumDescriptor    network_type__descriptor;
 extern const ProtobufCEnumDescriptor    wifi_station_state__descriptor;
 extern const ProtobufCEnumDescriptor    wifi_connect_failed_reason__descriptor;
 extern const ProtobufCEnumDescriptor    wifi_auth_mode__descriptor;

--- a/network_provisioning/proto-c/network_ctrl.pb-c.c
+++ b/network_provisioning/proto-c/network_ctrl.pb-c.c
@@ -7,184 +7,364 @@
 #endif
 
 #include "network_ctrl.pb-c.h"
-void   cmd_ctrl_reset__init
-                     (CmdCtrlReset         *message)
+void   cmd_ctrl_wifi_reset__init
+                     (CmdCtrlWifiReset         *message)
 {
-  static const CmdCtrlReset init_value = CMD_CTRL_RESET__INIT;
+  static const CmdCtrlWifiReset init_value = CMD_CTRL_WIFI_RESET__INIT;
   *message = init_value;
 }
-size_t cmd_ctrl_reset__get_packed_size
-                     (const CmdCtrlReset *message)
+size_t cmd_ctrl_wifi_reset__get_packed_size
+                     (const CmdCtrlWifiReset *message)
 {
-  assert(message->base.descriptor == &cmd_ctrl_reset__descriptor);
+  assert(message->base.descriptor == &cmd_ctrl_wifi_reset__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t cmd_ctrl_reset__pack
-                     (const CmdCtrlReset *message,
+size_t cmd_ctrl_wifi_reset__pack
+                     (const CmdCtrlWifiReset *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &cmd_ctrl_reset__descriptor);
+  assert(message->base.descriptor == &cmd_ctrl_wifi_reset__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t cmd_ctrl_reset__pack_to_buffer
-                     (const CmdCtrlReset *message,
+size_t cmd_ctrl_wifi_reset__pack_to_buffer
+                     (const CmdCtrlWifiReset *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &cmd_ctrl_reset__descriptor);
+  assert(message->base.descriptor == &cmd_ctrl_wifi_reset__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-CmdCtrlReset *
-       cmd_ctrl_reset__unpack
+CmdCtrlWifiReset *
+       cmd_ctrl_wifi_reset__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (CmdCtrlReset *)
-     protobuf_c_message_unpack (&cmd_ctrl_reset__descriptor,
+  return (CmdCtrlWifiReset *)
+     protobuf_c_message_unpack (&cmd_ctrl_wifi_reset__descriptor,
                                 allocator, len, data);
 }
-void   cmd_ctrl_reset__free_unpacked
-                     (CmdCtrlReset *message,
+void   cmd_ctrl_wifi_reset__free_unpacked
+                     (CmdCtrlWifiReset *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &cmd_ctrl_reset__descriptor);
+  assert(message->base.descriptor == &cmd_ctrl_wifi_reset__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   resp_ctrl_reset__init
-                     (RespCtrlReset         *message)
+void   resp_ctrl_wifi_reset__init
+                     (RespCtrlWifiReset         *message)
 {
-  static const RespCtrlReset init_value = RESP_CTRL_RESET__INIT;
+  static const RespCtrlWifiReset init_value = RESP_CTRL_WIFI_RESET__INIT;
   *message = init_value;
 }
-size_t resp_ctrl_reset__get_packed_size
-                     (const RespCtrlReset *message)
+size_t resp_ctrl_wifi_reset__get_packed_size
+                     (const RespCtrlWifiReset *message)
 {
-  assert(message->base.descriptor == &resp_ctrl_reset__descriptor);
+  assert(message->base.descriptor == &resp_ctrl_wifi_reset__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t resp_ctrl_reset__pack
-                     (const RespCtrlReset *message,
+size_t resp_ctrl_wifi_reset__pack
+                     (const RespCtrlWifiReset *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &resp_ctrl_reset__descriptor);
+  assert(message->base.descriptor == &resp_ctrl_wifi_reset__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t resp_ctrl_reset__pack_to_buffer
-                     (const RespCtrlReset *message,
+size_t resp_ctrl_wifi_reset__pack_to_buffer
+                     (const RespCtrlWifiReset *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &resp_ctrl_reset__descriptor);
+  assert(message->base.descriptor == &resp_ctrl_wifi_reset__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-RespCtrlReset *
-       resp_ctrl_reset__unpack
+RespCtrlWifiReset *
+       resp_ctrl_wifi_reset__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (RespCtrlReset *)
-     protobuf_c_message_unpack (&resp_ctrl_reset__descriptor,
+  return (RespCtrlWifiReset *)
+     protobuf_c_message_unpack (&resp_ctrl_wifi_reset__descriptor,
                                 allocator, len, data);
 }
-void   resp_ctrl_reset__free_unpacked
-                     (RespCtrlReset *message,
+void   resp_ctrl_wifi_reset__free_unpacked
+                     (RespCtrlWifiReset *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &resp_ctrl_reset__descriptor);
+  assert(message->base.descriptor == &resp_ctrl_wifi_reset__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   cmd_ctrl_reprov__init
-                     (CmdCtrlReprov         *message)
+void   cmd_ctrl_wifi_reprov__init
+                     (CmdCtrlWifiReprov         *message)
 {
-  static const CmdCtrlReprov init_value = CMD_CTRL_REPROV__INIT;
+  static const CmdCtrlWifiReprov init_value = CMD_CTRL_WIFI_REPROV__INIT;
   *message = init_value;
 }
-size_t cmd_ctrl_reprov__get_packed_size
-                     (const CmdCtrlReprov *message)
+size_t cmd_ctrl_wifi_reprov__get_packed_size
+                     (const CmdCtrlWifiReprov *message)
 {
-  assert(message->base.descriptor == &cmd_ctrl_reprov__descriptor);
+  assert(message->base.descriptor == &cmd_ctrl_wifi_reprov__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t cmd_ctrl_reprov__pack
-                     (const CmdCtrlReprov *message,
+size_t cmd_ctrl_wifi_reprov__pack
+                     (const CmdCtrlWifiReprov *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &cmd_ctrl_reprov__descriptor);
+  assert(message->base.descriptor == &cmd_ctrl_wifi_reprov__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t cmd_ctrl_reprov__pack_to_buffer
-                     (const CmdCtrlReprov *message,
+size_t cmd_ctrl_wifi_reprov__pack_to_buffer
+                     (const CmdCtrlWifiReprov *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &cmd_ctrl_reprov__descriptor);
+  assert(message->base.descriptor == &cmd_ctrl_wifi_reprov__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-CmdCtrlReprov *
-       cmd_ctrl_reprov__unpack
+CmdCtrlWifiReprov *
+       cmd_ctrl_wifi_reprov__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (CmdCtrlReprov *)
-     protobuf_c_message_unpack (&cmd_ctrl_reprov__descriptor,
+  return (CmdCtrlWifiReprov *)
+     protobuf_c_message_unpack (&cmd_ctrl_wifi_reprov__descriptor,
                                 allocator, len, data);
 }
-void   cmd_ctrl_reprov__free_unpacked
-                     (CmdCtrlReprov *message,
+void   cmd_ctrl_wifi_reprov__free_unpacked
+                     (CmdCtrlWifiReprov *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &cmd_ctrl_reprov__descriptor);
+  assert(message->base.descriptor == &cmd_ctrl_wifi_reprov__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   resp_ctrl_reprov__init
-                     (RespCtrlReprov         *message)
+void   resp_ctrl_wifi_reprov__init
+                     (RespCtrlWifiReprov         *message)
 {
-  static const RespCtrlReprov init_value = RESP_CTRL_REPROV__INIT;
+  static const RespCtrlWifiReprov init_value = RESP_CTRL_WIFI_REPROV__INIT;
   *message = init_value;
 }
-size_t resp_ctrl_reprov__get_packed_size
-                     (const RespCtrlReprov *message)
+size_t resp_ctrl_wifi_reprov__get_packed_size
+                     (const RespCtrlWifiReprov *message)
 {
-  assert(message->base.descriptor == &resp_ctrl_reprov__descriptor);
+  assert(message->base.descriptor == &resp_ctrl_wifi_reprov__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t resp_ctrl_reprov__pack
-                     (const RespCtrlReprov *message,
+size_t resp_ctrl_wifi_reprov__pack
+                     (const RespCtrlWifiReprov *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &resp_ctrl_reprov__descriptor);
+  assert(message->base.descriptor == &resp_ctrl_wifi_reprov__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t resp_ctrl_reprov__pack_to_buffer
-                     (const RespCtrlReprov *message,
+size_t resp_ctrl_wifi_reprov__pack_to_buffer
+                     (const RespCtrlWifiReprov *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &resp_ctrl_reprov__descriptor);
+  assert(message->base.descriptor == &resp_ctrl_wifi_reprov__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-RespCtrlReprov *
-       resp_ctrl_reprov__unpack
+RespCtrlWifiReprov *
+       resp_ctrl_wifi_reprov__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (RespCtrlReprov *)
-     protobuf_c_message_unpack (&resp_ctrl_reprov__descriptor,
+  return (RespCtrlWifiReprov *)
+     protobuf_c_message_unpack (&resp_ctrl_wifi_reprov__descriptor,
                                 allocator, len, data);
 }
-void   resp_ctrl_reprov__free_unpacked
-                     (RespCtrlReprov *message,
+void   resp_ctrl_wifi_reprov__free_unpacked
+                     (RespCtrlWifiReprov *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &resp_ctrl_reprov__descriptor);
+  assert(message->base.descriptor == &resp_ctrl_wifi_reprov__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   cmd_ctrl_thread_reset__init
+                     (CmdCtrlThreadReset         *message)
+{
+  static const CmdCtrlThreadReset init_value = CMD_CTRL_THREAD_RESET__INIT;
+  *message = init_value;
+}
+size_t cmd_ctrl_thread_reset__get_packed_size
+                     (const CmdCtrlThreadReset *message)
+{
+  assert(message->base.descriptor == &cmd_ctrl_thread_reset__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t cmd_ctrl_thread_reset__pack
+                     (const CmdCtrlThreadReset *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &cmd_ctrl_thread_reset__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t cmd_ctrl_thread_reset__pack_to_buffer
+                     (const CmdCtrlThreadReset *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &cmd_ctrl_thread_reset__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+CmdCtrlThreadReset *
+       cmd_ctrl_thread_reset__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (CmdCtrlThreadReset *)
+     protobuf_c_message_unpack (&cmd_ctrl_thread_reset__descriptor,
+                                allocator, len, data);
+}
+void   cmd_ctrl_thread_reset__free_unpacked
+                     (CmdCtrlThreadReset *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &cmd_ctrl_thread_reset__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   resp_ctrl_thread_reset__init
+                     (RespCtrlThreadReset         *message)
+{
+  static const RespCtrlThreadReset init_value = RESP_CTRL_THREAD_RESET__INIT;
+  *message = init_value;
+}
+size_t resp_ctrl_thread_reset__get_packed_size
+                     (const RespCtrlThreadReset *message)
+{
+  assert(message->base.descriptor == &resp_ctrl_thread_reset__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t resp_ctrl_thread_reset__pack
+                     (const RespCtrlThreadReset *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &resp_ctrl_thread_reset__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t resp_ctrl_thread_reset__pack_to_buffer
+                     (const RespCtrlThreadReset *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &resp_ctrl_thread_reset__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+RespCtrlThreadReset *
+       resp_ctrl_thread_reset__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (RespCtrlThreadReset *)
+     protobuf_c_message_unpack (&resp_ctrl_thread_reset__descriptor,
+                                allocator, len, data);
+}
+void   resp_ctrl_thread_reset__free_unpacked
+                     (RespCtrlThreadReset *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &resp_ctrl_thread_reset__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   cmd_ctrl_thread_reprov__init
+                     (CmdCtrlThreadReprov         *message)
+{
+  static const CmdCtrlThreadReprov init_value = CMD_CTRL_THREAD_REPROV__INIT;
+  *message = init_value;
+}
+size_t cmd_ctrl_thread_reprov__get_packed_size
+                     (const CmdCtrlThreadReprov *message)
+{
+  assert(message->base.descriptor == &cmd_ctrl_thread_reprov__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t cmd_ctrl_thread_reprov__pack
+                     (const CmdCtrlThreadReprov *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &cmd_ctrl_thread_reprov__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t cmd_ctrl_thread_reprov__pack_to_buffer
+                     (const CmdCtrlThreadReprov *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &cmd_ctrl_thread_reprov__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+CmdCtrlThreadReprov *
+       cmd_ctrl_thread_reprov__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (CmdCtrlThreadReprov *)
+     protobuf_c_message_unpack (&cmd_ctrl_thread_reprov__descriptor,
+                                allocator, len, data);
+}
+void   cmd_ctrl_thread_reprov__free_unpacked
+                     (CmdCtrlThreadReprov *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &cmd_ctrl_thread_reprov__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   resp_ctrl_thread_reprov__init
+                     (RespCtrlThreadReprov         *message)
+{
+  static const RespCtrlThreadReprov init_value = RESP_CTRL_THREAD_REPROV__INIT;
+  *message = init_value;
+}
+size_t resp_ctrl_thread_reprov__get_packed_size
+                     (const RespCtrlThreadReprov *message)
+{
+  assert(message->base.descriptor == &resp_ctrl_thread_reprov__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t resp_ctrl_thread_reprov__pack
+                     (const RespCtrlThreadReprov *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &resp_ctrl_thread_reprov__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t resp_ctrl_thread_reprov__pack_to_buffer
+                     (const RespCtrlThreadReprov *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &resp_ctrl_thread_reprov__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+RespCtrlThreadReprov *
+       resp_ctrl_thread_reprov__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (RespCtrlThreadReprov *)
+     protobuf_c_message_unpack (&resp_ctrl_thread_reprov__descriptor,
+                                allocator, len, data);
+}
+void   resp_ctrl_thread_reprov__free_unpacked
+                     (RespCtrlThreadReprov *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &resp_ctrl_thread_reprov__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
 void   network_ctrl_payload__init
@@ -232,159 +412,151 @@ void   network_ctrl_payload__free_unpacked
   assert(message->base.descriptor == &network_ctrl_payload__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-static const ProtobufCFieldDescriptor cmd_ctrl_reset__field_descriptors[1] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(CmdCtrlReset, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned cmd_ctrl_reset__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-};
-static const ProtobufCIntRange cmd_ctrl_reset__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor cmd_ctrl_reset__descriptor =
+#define cmd_ctrl_wifi_reset__field_descriptors NULL
+#define cmd_ctrl_wifi_reset__field_indices_by_name NULL
+#define cmd_ctrl_wifi_reset__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_ctrl_wifi_reset__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "CmdCtrlReset",
-  "CmdCtrlReset",
-  "CmdCtrlReset",
+  "CmdCtrlWifiReset",
+  "CmdCtrlWifiReset",
+  "CmdCtrlWifiReset",
   "",
-  sizeof(CmdCtrlReset),
-  1,
-  cmd_ctrl_reset__field_descriptors,
-  cmd_ctrl_reset__field_indices_by_name,
-  1,  cmd_ctrl_reset__number_ranges,
-  (ProtobufCMessageInit) cmd_ctrl_reset__init,
+  sizeof(CmdCtrlWifiReset),
+  0,
+  cmd_ctrl_wifi_reset__field_descriptors,
+  cmd_ctrl_wifi_reset__field_indices_by_name,
+  0,  cmd_ctrl_wifi_reset__number_ranges,
+  (ProtobufCMessageInit) cmd_ctrl_wifi_reset__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor resp_ctrl_reset__field_descriptors[1] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(RespCtrlReset, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned resp_ctrl_reset__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-};
-static const ProtobufCIntRange resp_ctrl_reset__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor resp_ctrl_reset__descriptor =
+#define resp_ctrl_wifi_reset__field_descriptors NULL
+#define resp_ctrl_wifi_reset__field_indices_by_name NULL
+#define resp_ctrl_wifi_reset__number_ranges NULL
+const ProtobufCMessageDescriptor resp_ctrl_wifi_reset__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "RespCtrlReset",
-  "RespCtrlReset",
-  "RespCtrlReset",
+  "RespCtrlWifiReset",
+  "RespCtrlWifiReset",
+  "RespCtrlWifiReset",
   "",
-  sizeof(RespCtrlReset),
-  1,
-  resp_ctrl_reset__field_descriptors,
-  resp_ctrl_reset__field_indices_by_name,
-  1,  resp_ctrl_reset__number_ranges,
-  (ProtobufCMessageInit) resp_ctrl_reset__init,
+  sizeof(RespCtrlWifiReset),
+  0,
+  resp_ctrl_wifi_reset__field_descriptors,
+  resp_ctrl_wifi_reset__field_indices_by_name,
+  0,  resp_ctrl_wifi_reset__number_ranges,
+  (ProtobufCMessageInit) resp_ctrl_wifi_reset__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor cmd_ctrl_reprov__field_descriptors[1] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(CmdCtrlReprov, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned cmd_ctrl_reprov__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-};
-static const ProtobufCIntRange cmd_ctrl_reprov__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor cmd_ctrl_reprov__descriptor =
+#define cmd_ctrl_wifi_reprov__field_descriptors NULL
+#define cmd_ctrl_wifi_reprov__field_indices_by_name NULL
+#define cmd_ctrl_wifi_reprov__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_ctrl_wifi_reprov__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "CmdCtrlReprov",
-  "CmdCtrlReprov",
-  "CmdCtrlReprov",
+  "CmdCtrlWifiReprov",
+  "CmdCtrlWifiReprov",
+  "CmdCtrlWifiReprov",
   "",
-  sizeof(CmdCtrlReprov),
-  1,
-  cmd_ctrl_reprov__field_descriptors,
-  cmd_ctrl_reprov__field_indices_by_name,
-  1,  cmd_ctrl_reprov__number_ranges,
-  (ProtobufCMessageInit) cmd_ctrl_reprov__init,
+  sizeof(CmdCtrlWifiReprov),
+  0,
+  cmd_ctrl_wifi_reprov__field_descriptors,
+  cmd_ctrl_wifi_reprov__field_indices_by_name,
+  0,  cmd_ctrl_wifi_reprov__number_ranges,
+  (ProtobufCMessageInit) cmd_ctrl_wifi_reprov__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor resp_ctrl_reprov__field_descriptors[1] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(RespCtrlReprov, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned resp_ctrl_reprov__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-};
-static const ProtobufCIntRange resp_ctrl_reprov__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor resp_ctrl_reprov__descriptor =
+#define resp_ctrl_wifi_reprov__field_descriptors NULL
+#define resp_ctrl_wifi_reprov__field_indices_by_name NULL
+#define resp_ctrl_wifi_reprov__number_ranges NULL
+const ProtobufCMessageDescriptor resp_ctrl_wifi_reprov__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "RespCtrlReprov",
-  "RespCtrlReprov",
-  "RespCtrlReprov",
+  "RespCtrlWifiReprov",
+  "RespCtrlWifiReprov",
+  "RespCtrlWifiReprov",
   "",
-  sizeof(RespCtrlReprov),
-  1,
-  resp_ctrl_reprov__field_descriptors,
-  resp_ctrl_reprov__field_indices_by_name,
-  1,  resp_ctrl_reprov__number_ranges,
-  (ProtobufCMessageInit) resp_ctrl_reprov__init,
+  sizeof(RespCtrlWifiReprov),
+  0,
+  resp_ctrl_wifi_reprov__field_descriptors,
+  resp_ctrl_wifi_reprov__field_indices_by_name,
+  0,  resp_ctrl_wifi_reprov__number_ranges,
+  (ProtobufCMessageInit) resp_ctrl_wifi_reprov__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor network_ctrl_payload__field_descriptors[6] =
+#define cmd_ctrl_thread_reset__field_descriptors NULL
+#define cmd_ctrl_thread_reset__field_indices_by_name NULL
+#define cmd_ctrl_thread_reset__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_ctrl_thread_reset__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "CmdCtrlThreadReset",
+  "CmdCtrlThreadReset",
+  "CmdCtrlThreadReset",
+  "",
+  sizeof(CmdCtrlThreadReset),
+  0,
+  cmd_ctrl_thread_reset__field_descriptors,
+  cmd_ctrl_thread_reset__field_indices_by_name,
+  0,  cmd_ctrl_thread_reset__number_ranges,
+  (ProtobufCMessageInit) cmd_ctrl_thread_reset__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define resp_ctrl_thread_reset__field_descriptors NULL
+#define resp_ctrl_thread_reset__field_indices_by_name NULL
+#define resp_ctrl_thread_reset__number_ranges NULL
+const ProtobufCMessageDescriptor resp_ctrl_thread_reset__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "RespCtrlThreadReset",
+  "RespCtrlThreadReset",
+  "RespCtrlThreadReset",
+  "",
+  sizeof(RespCtrlThreadReset),
+  0,
+  resp_ctrl_thread_reset__field_descriptors,
+  resp_ctrl_thread_reset__field_indices_by_name,
+  0,  resp_ctrl_thread_reset__number_ranges,
+  (ProtobufCMessageInit) resp_ctrl_thread_reset__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define cmd_ctrl_thread_reprov__field_descriptors NULL
+#define cmd_ctrl_thread_reprov__field_indices_by_name NULL
+#define cmd_ctrl_thread_reprov__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_ctrl_thread_reprov__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "CmdCtrlThreadReprov",
+  "CmdCtrlThreadReprov",
+  "CmdCtrlThreadReprov",
+  "",
+  sizeof(CmdCtrlThreadReprov),
+  0,
+  cmd_ctrl_thread_reprov__field_descriptors,
+  cmd_ctrl_thread_reprov__field_indices_by_name,
+  0,  cmd_ctrl_thread_reprov__number_ranges,
+  (ProtobufCMessageInit) cmd_ctrl_thread_reprov__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+#define resp_ctrl_thread_reprov__field_descriptors NULL
+#define resp_ctrl_thread_reprov__field_indices_by_name NULL
+#define resp_ctrl_thread_reprov__number_ranges NULL
+const ProtobufCMessageDescriptor resp_ctrl_thread_reprov__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "RespCtrlThreadReprov",
+  "RespCtrlThreadReprov",
+  "RespCtrlThreadReprov",
+  "",
+  sizeof(RespCtrlThreadReprov),
+  0,
+  resp_ctrl_thread_reprov__field_descriptors,
+  resp_ctrl_thread_reprov__field_indices_by_name,
+  0,  resp_ctrl_thread_reprov__number_ranges,
+  (ProtobufCMessageInit) resp_ctrl_thread_reprov__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor network_ctrl_payload__field_descriptors[10] =
 {
   {
     "msg",
@@ -411,67 +583,119 @@ static const ProtobufCFieldDescriptor network_ctrl_payload__field_descriptors[6]
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cmd_ctrl_reset",
+    "cmd_ctrl_wifi_reset",
     11,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkCtrlPayload, payload_case),
-    offsetof(NetworkCtrlPayload, cmd_ctrl_reset),
-    &cmd_ctrl_reset__descriptor,
+    offsetof(NetworkCtrlPayload, cmd_ctrl_wifi_reset),
+    &cmd_ctrl_wifi_reset__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "resp_ctrl_reset",
+    "resp_ctrl_wifi_reset",
     12,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkCtrlPayload, payload_case),
-    offsetof(NetworkCtrlPayload, resp_ctrl_reset),
-    &resp_ctrl_reset__descriptor,
+    offsetof(NetworkCtrlPayload, resp_ctrl_wifi_reset),
+    &resp_ctrl_wifi_reset__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cmd_ctrl_reprov",
+    "cmd_ctrl_wifi_reprov",
     13,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkCtrlPayload, payload_case),
-    offsetof(NetworkCtrlPayload, cmd_ctrl_reprov),
-    &cmd_ctrl_reprov__descriptor,
+    offsetof(NetworkCtrlPayload, cmd_ctrl_wifi_reprov),
+    &cmd_ctrl_wifi_reprov__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "resp_ctrl_reprov",
+    "resp_ctrl_wifi_reprov",
     14,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkCtrlPayload, payload_case),
-    offsetof(NetworkCtrlPayload, resp_ctrl_reprov),
-    &resp_ctrl_reprov__descriptor,
+    offsetof(NetworkCtrlPayload, resp_ctrl_wifi_reprov),
+    &resp_ctrl_wifi_reprov__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "cmd_ctrl_thread_reset",
+    15,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkCtrlPayload, payload_case),
+    offsetof(NetworkCtrlPayload, cmd_ctrl_thread_reset),
+    &cmd_ctrl_thread_reset__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "resp_ctrl_thread_reset",
+    16,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkCtrlPayload, payload_case),
+    offsetof(NetworkCtrlPayload, resp_ctrl_thread_reset),
+    &resp_ctrl_thread_reset__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "cmd_ctrl_thread_reprov",
+    17,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkCtrlPayload, payload_case),
+    offsetof(NetworkCtrlPayload, cmd_ctrl_thread_reprov),
+    &cmd_ctrl_thread_reprov__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "resp_ctrl_thread_reprov",
+    18,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkCtrlPayload, payload_case),
+    offsetof(NetworkCtrlPayload, resp_ctrl_thread_reprov),
+    &resp_ctrl_thread_reprov__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
 static const unsigned network_ctrl_payload__field_indices_by_name[] = {
-  4,   /* field[4] = cmd_ctrl_reprov */
-  2,   /* field[2] = cmd_ctrl_reset */
+  8,   /* field[8] = cmd_ctrl_thread_reprov */
+  6,   /* field[6] = cmd_ctrl_thread_reset */
+  4,   /* field[4] = cmd_ctrl_wifi_reprov */
+  2,   /* field[2] = cmd_ctrl_wifi_reset */
   0,   /* field[0] = msg */
-  5,   /* field[5] = resp_ctrl_reprov */
-  3,   /* field[3] = resp_ctrl_reset */
+  9,   /* field[9] = resp_ctrl_thread_reprov */
+  7,   /* field[7] = resp_ctrl_thread_reset */
+  5,   /* field[5] = resp_ctrl_wifi_reprov */
+  3,   /* field[3] = resp_ctrl_wifi_reset */
   1,   /* field[1] = status */
 };
 static const ProtobufCIntRange network_ctrl_payload__number_ranges[2 + 1] =
 {
   { 1, 0 },
   { 11, 2 },
-  { 0, 6 }
+  { 0, 10 }
 };
 const ProtobufCMessageDescriptor network_ctrl_payload__descriptor =
 {
@@ -481,31 +705,39 @@ const ProtobufCMessageDescriptor network_ctrl_payload__descriptor =
   "NetworkCtrlPayload",
   "",
   sizeof(NetworkCtrlPayload),
-  6,
+  10,
   network_ctrl_payload__field_descriptors,
   network_ctrl_payload__field_indices_by_name,
   2,  network_ctrl_payload__number_ranges,
   (ProtobufCMessageInit) network_ctrl_payload__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCEnumValue network_ctrl_msg_type__enum_values_by_number[5] =
+static const ProtobufCEnumValue network_ctrl_msg_type__enum_values_by_number[9] =
 {
   { "TypeCtrlReserved", "NETWORK_CTRL_MSG_TYPE__TypeCtrlReserved", 0 },
-  { "TypeCmdCtrlReset", "NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlReset", 1 },
-  { "TypeRespCtrlReset", "NETWORK_CTRL_MSG_TYPE__TypeRespCtrlReset", 2 },
-  { "TypeCmdCtrlReprov", "NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlReprov", 3 },
-  { "TypeRespCtrlReprov", "NETWORK_CTRL_MSG_TYPE__TypeRespCtrlReprov", 4 },
+  { "TypeCmdCtrlWifiReset", "NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlWifiReset", 1 },
+  { "TypeRespCtrlWifiReset", "NETWORK_CTRL_MSG_TYPE__TypeRespCtrlWifiReset", 2 },
+  { "TypeCmdCtrlWifiReprov", "NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlWifiReprov", 3 },
+  { "TypeRespCtrlWifiReprov", "NETWORK_CTRL_MSG_TYPE__TypeRespCtrlWifiReprov", 4 },
+  { "TypeCmdCtrlThreadReset", "NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlThreadReset", 5 },
+  { "TypeRespCtrlThreadReset", "NETWORK_CTRL_MSG_TYPE__TypeRespCtrlThreadReset", 6 },
+  { "TypeCmdCtrlThreadReprov", "NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlThreadReprov", 7 },
+  { "TypeRespCtrlThreadReprov", "NETWORK_CTRL_MSG_TYPE__TypeRespCtrlThreadReprov", 8 },
 };
 static const ProtobufCIntRange network_ctrl_msg_type__value_ranges[] = {
-{0, 0},{0, 5}
+{0, 0},{0, 9}
 };
-static const ProtobufCEnumValueIndex network_ctrl_msg_type__enum_values_by_name[5] =
+static const ProtobufCEnumValueIndex network_ctrl_msg_type__enum_values_by_name[9] =
 {
-  { "TypeCmdCtrlReprov", 3 },
-  { "TypeCmdCtrlReset", 1 },
+  { "TypeCmdCtrlThreadReprov", 7 },
+  { "TypeCmdCtrlThreadReset", 5 },
+  { "TypeCmdCtrlWifiReprov", 3 },
+  { "TypeCmdCtrlWifiReset", 1 },
   { "TypeCtrlReserved", 0 },
-  { "TypeRespCtrlReprov", 4 },
-  { "TypeRespCtrlReset", 2 },
+  { "TypeRespCtrlThreadReprov", 8 },
+  { "TypeRespCtrlThreadReset", 6 },
+  { "TypeRespCtrlWifiReprov", 4 },
+  { "TypeRespCtrlWifiReset", 2 },
 };
 const ProtobufCEnumDescriptor network_ctrl_msg_type__descriptor =
 {
@@ -514,9 +746,9 @@ const ProtobufCEnumDescriptor network_ctrl_msg_type__descriptor =
   "NetworkCtrlMsgType",
   "NetworkCtrlMsgType",
   "",
-  5,
+  9,
   network_ctrl_msg_type__enum_values_by_number,
-  5,
+  9,
   network_ctrl_msg_type__enum_values_by_name,
   1,
   network_ctrl_msg_type__value_ranges,

--- a/network_provisioning/proto-c/network_ctrl.pb-c.h
+++ b/network_provisioning/proto-c/network_ctrl.pb-c.h
@@ -15,12 +15,15 @@ PROTOBUF_C__BEGIN_DECLS
 #endif
 
 #include "constants.pb-c.h"
-#include "network_constants.pb-c.h"
 
-typedef struct CmdCtrlReset CmdCtrlReset;
-typedef struct RespCtrlReset RespCtrlReset;
-typedef struct CmdCtrlReprov CmdCtrlReprov;
-typedef struct RespCtrlReprov RespCtrlReprov;
+typedef struct CmdCtrlWifiReset CmdCtrlWifiReset;
+typedef struct RespCtrlWifiReset RespCtrlWifiReset;
+typedef struct CmdCtrlWifiReprov CmdCtrlWifiReprov;
+typedef struct RespCtrlWifiReprov RespCtrlWifiReprov;
+typedef struct CmdCtrlThreadReset CmdCtrlThreadReset;
+typedef struct RespCtrlThreadReset RespCtrlThreadReset;
+typedef struct CmdCtrlThreadReprov CmdCtrlThreadReprov;
+typedef struct RespCtrlThreadReprov RespCtrlThreadReprov;
 typedef struct NetworkCtrlPayload NetworkCtrlPayload;
 
 
@@ -28,61 +31,101 @@ typedef struct NetworkCtrlPayload NetworkCtrlPayload;
 
 typedef enum _NetworkCtrlMsgType {
   NETWORK_CTRL_MSG_TYPE__TypeCtrlReserved = 0,
-  NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlReset = 1,
-  NETWORK_CTRL_MSG_TYPE__TypeRespCtrlReset = 2,
-  NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlReprov = 3,
-  NETWORK_CTRL_MSG_TYPE__TypeRespCtrlReprov = 4
+  NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlWifiReset = 1,
+  NETWORK_CTRL_MSG_TYPE__TypeRespCtrlWifiReset = 2,
+  NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlWifiReprov = 3,
+  NETWORK_CTRL_MSG_TYPE__TypeRespCtrlWifiReprov = 4,
+  NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlThreadReset = 5,
+  NETWORK_CTRL_MSG_TYPE__TypeRespCtrlThreadReset = 6,
+  NETWORK_CTRL_MSG_TYPE__TypeCmdCtrlThreadReprov = 7,
+  NETWORK_CTRL_MSG_TYPE__TypeRespCtrlThreadReprov = 8
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NETWORK_CTRL_MSG_TYPE)
 } NetworkCtrlMsgType;
 
 /* --- messages --- */
 
-struct  CmdCtrlReset
+struct  CmdCtrlWifiReset
 {
   ProtobufCMessage base;
-  NetworkType net_type;
 };
-#define CMD_CTRL_RESET__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&cmd_ctrl_reset__descriptor) \
-    , NETWORK_TYPE__WifiNetwork }
+#define CMD_CTRL_WIFI_RESET__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_ctrl_wifi_reset__descriptor) \
+     }
 
 
-struct  RespCtrlReset
+struct  RespCtrlWifiReset
 {
   ProtobufCMessage base;
-  NetworkType net_type;
 };
-#define RESP_CTRL_RESET__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&resp_ctrl_reset__descriptor) \
-    , NETWORK_TYPE__WifiNetwork }
+#define RESP_CTRL_WIFI_RESET__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_ctrl_wifi_reset__descriptor) \
+     }
 
 
-struct  CmdCtrlReprov
+struct  CmdCtrlWifiReprov
 {
   ProtobufCMessage base;
-  NetworkType net_type;
 };
-#define CMD_CTRL_REPROV__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&cmd_ctrl_reprov__descriptor) \
-    , NETWORK_TYPE__WifiNetwork }
+#define CMD_CTRL_WIFI_REPROV__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_ctrl_wifi_reprov__descriptor) \
+     }
 
 
-struct  RespCtrlReprov
+struct  RespCtrlWifiReprov
 {
   ProtobufCMessage base;
-  NetworkType net_type;
 };
-#define RESP_CTRL_REPROV__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&resp_ctrl_reprov__descriptor) \
-    , NETWORK_TYPE__WifiNetwork }
+#define RESP_CTRL_WIFI_REPROV__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_ctrl_wifi_reprov__descriptor) \
+     }
+
+
+struct  CmdCtrlThreadReset
+{
+  ProtobufCMessage base;
+};
+#define CMD_CTRL_THREAD_RESET__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_ctrl_thread_reset__descriptor) \
+     }
+
+
+struct  RespCtrlThreadReset
+{
+  ProtobufCMessage base;
+};
+#define RESP_CTRL_THREAD_RESET__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_ctrl_thread_reset__descriptor) \
+     }
+
+
+struct  CmdCtrlThreadReprov
+{
+  ProtobufCMessage base;
+};
+#define CMD_CTRL_THREAD_REPROV__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_ctrl_thread_reprov__descriptor) \
+     }
+
+
+struct  RespCtrlThreadReprov
+{
+  ProtobufCMessage base;
+};
+#define RESP_CTRL_THREAD_REPROV__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_ctrl_thread_reprov__descriptor) \
+     }
 
 
 typedef enum {
   NETWORK_CTRL_PAYLOAD__PAYLOAD__NOT_SET = 0,
-  NETWORK_CTRL_PAYLOAD__PAYLOAD_CMD_CTRL_RESET = 11,
-  NETWORK_CTRL_PAYLOAD__PAYLOAD_RESP_CTRL_RESET = 12,
-  NETWORK_CTRL_PAYLOAD__PAYLOAD_CMD_CTRL_REPROV = 13,
-  NETWORK_CTRL_PAYLOAD__PAYLOAD_RESP_CTRL_REPROV = 14
+  NETWORK_CTRL_PAYLOAD__PAYLOAD_CMD_CTRL_WIFI_RESET = 11,
+  NETWORK_CTRL_PAYLOAD__PAYLOAD_RESP_CTRL_WIFI_RESET = 12,
+  NETWORK_CTRL_PAYLOAD__PAYLOAD_CMD_CTRL_WIFI_REPROV = 13,
+  NETWORK_CTRL_PAYLOAD__PAYLOAD_RESP_CTRL_WIFI_REPROV = 14,
+  NETWORK_CTRL_PAYLOAD__PAYLOAD_CMD_CTRL_THREAD_RESET = 15,
+  NETWORK_CTRL_PAYLOAD__PAYLOAD_RESP_CTRL_THREAD_RESET = 16,
+  NETWORK_CTRL_PAYLOAD__PAYLOAD_CMD_CTRL_THREAD_REPROV = 17,
+  NETWORK_CTRL_PAYLOAD__PAYLOAD_RESP_CTRL_THREAD_REPROV = 18
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NETWORK_CTRL_PAYLOAD__PAYLOAD__CASE)
 } NetworkCtrlPayload__PayloadCase;
 
@@ -93,10 +136,14 @@ struct  NetworkCtrlPayload
   Status status;
   NetworkCtrlPayload__PayloadCase payload_case;
   union {
-    CmdCtrlReset *cmd_ctrl_reset;
-    RespCtrlReset *resp_ctrl_reset;
-    CmdCtrlReprov *cmd_ctrl_reprov;
-    RespCtrlReprov *resp_ctrl_reprov;
+    CmdCtrlWifiReset *cmd_ctrl_wifi_reset;
+    RespCtrlWifiReset *resp_ctrl_wifi_reset;
+    CmdCtrlWifiReprov *cmd_ctrl_wifi_reprov;
+    RespCtrlWifiReprov *resp_ctrl_wifi_reprov;
+    CmdCtrlThreadReset *cmd_ctrl_thread_reset;
+    RespCtrlThreadReset *resp_ctrl_thread_reset;
+    CmdCtrlThreadReprov *cmd_ctrl_thread_reprov;
+    RespCtrlThreadReprov *resp_ctrl_thread_reprov;
   };
 };
 #define NETWORK_CTRL_PAYLOAD__INIT \
@@ -104,81 +151,157 @@ struct  NetworkCtrlPayload
     , NETWORK_CTRL_MSG_TYPE__TypeCtrlReserved, STATUS__Success, NETWORK_CTRL_PAYLOAD__PAYLOAD__NOT_SET, {0} }
 
 
-/* CmdCtrlReset methods */
-void   cmd_ctrl_reset__init
-                     (CmdCtrlReset         *message);
-size_t cmd_ctrl_reset__get_packed_size
-                     (const CmdCtrlReset   *message);
-size_t cmd_ctrl_reset__pack
-                     (const CmdCtrlReset   *message,
+/* CmdCtrlWifiReset methods */
+void   cmd_ctrl_wifi_reset__init
+                     (CmdCtrlWifiReset         *message);
+size_t cmd_ctrl_wifi_reset__get_packed_size
+                     (const CmdCtrlWifiReset   *message);
+size_t cmd_ctrl_wifi_reset__pack
+                     (const CmdCtrlWifiReset   *message,
                       uint8_t             *out);
-size_t cmd_ctrl_reset__pack_to_buffer
-                     (const CmdCtrlReset   *message,
+size_t cmd_ctrl_wifi_reset__pack_to_buffer
+                     (const CmdCtrlWifiReset   *message,
                       ProtobufCBuffer     *buffer);
-CmdCtrlReset *
-       cmd_ctrl_reset__unpack
+CmdCtrlWifiReset *
+       cmd_ctrl_wifi_reset__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   cmd_ctrl_reset__free_unpacked
-                     (CmdCtrlReset *message,
+void   cmd_ctrl_wifi_reset__free_unpacked
+                     (CmdCtrlWifiReset *message,
                       ProtobufCAllocator *allocator);
-/* RespCtrlReset methods */
-void   resp_ctrl_reset__init
-                     (RespCtrlReset         *message);
-size_t resp_ctrl_reset__get_packed_size
-                     (const RespCtrlReset   *message);
-size_t resp_ctrl_reset__pack
-                     (const RespCtrlReset   *message,
+/* RespCtrlWifiReset methods */
+void   resp_ctrl_wifi_reset__init
+                     (RespCtrlWifiReset         *message);
+size_t resp_ctrl_wifi_reset__get_packed_size
+                     (const RespCtrlWifiReset   *message);
+size_t resp_ctrl_wifi_reset__pack
+                     (const RespCtrlWifiReset   *message,
                       uint8_t             *out);
-size_t resp_ctrl_reset__pack_to_buffer
-                     (const RespCtrlReset   *message,
+size_t resp_ctrl_wifi_reset__pack_to_buffer
+                     (const RespCtrlWifiReset   *message,
                       ProtobufCBuffer     *buffer);
-RespCtrlReset *
-       resp_ctrl_reset__unpack
+RespCtrlWifiReset *
+       resp_ctrl_wifi_reset__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   resp_ctrl_reset__free_unpacked
-                     (RespCtrlReset *message,
+void   resp_ctrl_wifi_reset__free_unpacked
+                     (RespCtrlWifiReset *message,
                       ProtobufCAllocator *allocator);
-/* CmdCtrlReprov methods */
-void   cmd_ctrl_reprov__init
-                     (CmdCtrlReprov         *message);
-size_t cmd_ctrl_reprov__get_packed_size
-                     (const CmdCtrlReprov   *message);
-size_t cmd_ctrl_reprov__pack
-                     (const CmdCtrlReprov   *message,
+/* CmdCtrlWifiReprov methods */
+void   cmd_ctrl_wifi_reprov__init
+                     (CmdCtrlWifiReprov         *message);
+size_t cmd_ctrl_wifi_reprov__get_packed_size
+                     (const CmdCtrlWifiReprov   *message);
+size_t cmd_ctrl_wifi_reprov__pack
+                     (const CmdCtrlWifiReprov   *message,
                       uint8_t             *out);
-size_t cmd_ctrl_reprov__pack_to_buffer
-                     (const CmdCtrlReprov   *message,
+size_t cmd_ctrl_wifi_reprov__pack_to_buffer
+                     (const CmdCtrlWifiReprov   *message,
                       ProtobufCBuffer     *buffer);
-CmdCtrlReprov *
-       cmd_ctrl_reprov__unpack
+CmdCtrlWifiReprov *
+       cmd_ctrl_wifi_reprov__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   cmd_ctrl_reprov__free_unpacked
-                     (CmdCtrlReprov *message,
+void   cmd_ctrl_wifi_reprov__free_unpacked
+                     (CmdCtrlWifiReprov *message,
                       ProtobufCAllocator *allocator);
-/* RespCtrlReprov methods */
-void   resp_ctrl_reprov__init
-                     (RespCtrlReprov         *message);
-size_t resp_ctrl_reprov__get_packed_size
-                     (const RespCtrlReprov   *message);
-size_t resp_ctrl_reprov__pack
-                     (const RespCtrlReprov   *message,
+/* RespCtrlWifiReprov methods */
+void   resp_ctrl_wifi_reprov__init
+                     (RespCtrlWifiReprov         *message);
+size_t resp_ctrl_wifi_reprov__get_packed_size
+                     (const RespCtrlWifiReprov   *message);
+size_t resp_ctrl_wifi_reprov__pack
+                     (const RespCtrlWifiReprov   *message,
                       uint8_t             *out);
-size_t resp_ctrl_reprov__pack_to_buffer
-                     (const RespCtrlReprov   *message,
+size_t resp_ctrl_wifi_reprov__pack_to_buffer
+                     (const RespCtrlWifiReprov   *message,
                       ProtobufCBuffer     *buffer);
-RespCtrlReprov *
-       resp_ctrl_reprov__unpack
+RespCtrlWifiReprov *
+       resp_ctrl_wifi_reprov__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   resp_ctrl_reprov__free_unpacked
-                     (RespCtrlReprov *message,
+void   resp_ctrl_wifi_reprov__free_unpacked
+                     (RespCtrlWifiReprov *message,
+                      ProtobufCAllocator *allocator);
+/* CmdCtrlThreadReset methods */
+void   cmd_ctrl_thread_reset__init
+                     (CmdCtrlThreadReset         *message);
+size_t cmd_ctrl_thread_reset__get_packed_size
+                     (const CmdCtrlThreadReset   *message);
+size_t cmd_ctrl_thread_reset__pack
+                     (const CmdCtrlThreadReset   *message,
+                      uint8_t             *out);
+size_t cmd_ctrl_thread_reset__pack_to_buffer
+                     (const CmdCtrlThreadReset   *message,
+                      ProtobufCBuffer     *buffer);
+CmdCtrlThreadReset *
+       cmd_ctrl_thread_reset__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   cmd_ctrl_thread_reset__free_unpacked
+                     (CmdCtrlThreadReset *message,
+                      ProtobufCAllocator *allocator);
+/* RespCtrlThreadReset methods */
+void   resp_ctrl_thread_reset__init
+                     (RespCtrlThreadReset         *message);
+size_t resp_ctrl_thread_reset__get_packed_size
+                     (const RespCtrlThreadReset   *message);
+size_t resp_ctrl_thread_reset__pack
+                     (const RespCtrlThreadReset   *message,
+                      uint8_t             *out);
+size_t resp_ctrl_thread_reset__pack_to_buffer
+                     (const RespCtrlThreadReset   *message,
+                      ProtobufCBuffer     *buffer);
+RespCtrlThreadReset *
+       resp_ctrl_thread_reset__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   resp_ctrl_thread_reset__free_unpacked
+                     (RespCtrlThreadReset *message,
+                      ProtobufCAllocator *allocator);
+/* CmdCtrlThreadReprov methods */
+void   cmd_ctrl_thread_reprov__init
+                     (CmdCtrlThreadReprov         *message);
+size_t cmd_ctrl_thread_reprov__get_packed_size
+                     (const CmdCtrlThreadReprov   *message);
+size_t cmd_ctrl_thread_reprov__pack
+                     (const CmdCtrlThreadReprov   *message,
+                      uint8_t             *out);
+size_t cmd_ctrl_thread_reprov__pack_to_buffer
+                     (const CmdCtrlThreadReprov   *message,
+                      ProtobufCBuffer     *buffer);
+CmdCtrlThreadReprov *
+       cmd_ctrl_thread_reprov__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   cmd_ctrl_thread_reprov__free_unpacked
+                     (CmdCtrlThreadReprov *message,
+                      ProtobufCAllocator *allocator);
+/* RespCtrlThreadReprov methods */
+void   resp_ctrl_thread_reprov__init
+                     (RespCtrlThreadReprov         *message);
+size_t resp_ctrl_thread_reprov__get_packed_size
+                     (const RespCtrlThreadReprov   *message);
+size_t resp_ctrl_thread_reprov__pack
+                     (const RespCtrlThreadReprov   *message,
+                      uint8_t             *out);
+size_t resp_ctrl_thread_reprov__pack_to_buffer
+                     (const RespCtrlThreadReprov   *message,
+                      ProtobufCBuffer     *buffer);
+RespCtrlThreadReprov *
+       resp_ctrl_thread_reprov__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   resp_ctrl_thread_reprov__free_unpacked
+                     (RespCtrlThreadReprov *message,
                       ProtobufCAllocator *allocator);
 /* NetworkCtrlPayload methods */
 void   network_ctrl_payload__init
@@ -201,17 +324,29 @@ void   network_ctrl_payload__free_unpacked
                       ProtobufCAllocator *allocator);
 /* --- per-message closures --- */
 
-typedef void (*CmdCtrlReset_Closure)
-                 (const CmdCtrlReset *message,
+typedef void (*CmdCtrlWifiReset_Closure)
+                 (const CmdCtrlWifiReset *message,
                   void *closure_data);
-typedef void (*RespCtrlReset_Closure)
-                 (const RespCtrlReset *message,
+typedef void (*RespCtrlWifiReset_Closure)
+                 (const RespCtrlWifiReset *message,
                   void *closure_data);
-typedef void (*CmdCtrlReprov_Closure)
-                 (const CmdCtrlReprov *message,
+typedef void (*CmdCtrlWifiReprov_Closure)
+                 (const CmdCtrlWifiReprov *message,
                   void *closure_data);
-typedef void (*RespCtrlReprov_Closure)
-                 (const RespCtrlReprov *message,
+typedef void (*RespCtrlWifiReprov_Closure)
+                 (const RespCtrlWifiReprov *message,
+                  void *closure_data);
+typedef void (*CmdCtrlThreadReset_Closure)
+                 (const CmdCtrlThreadReset *message,
+                  void *closure_data);
+typedef void (*RespCtrlThreadReset_Closure)
+                 (const RespCtrlThreadReset *message,
+                  void *closure_data);
+typedef void (*CmdCtrlThreadReprov_Closure)
+                 (const CmdCtrlThreadReprov *message,
+                  void *closure_data);
+typedef void (*RespCtrlThreadReprov_Closure)
+                 (const RespCtrlThreadReprov *message,
                   void *closure_data);
 typedef void (*NetworkCtrlPayload_Closure)
                  (const NetworkCtrlPayload *message,
@@ -223,10 +358,14 @@ typedef void (*NetworkCtrlPayload_Closure)
 /* --- descriptors --- */
 
 extern const ProtobufCEnumDescriptor    network_ctrl_msg_type__descriptor;
-extern const ProtobufCMessageDescriptor cmd_ctrl_reset__descriptor;
-extern const ProtobufCMessageDescriptor resp_ctrl_reset__descriptor;
-extern const ProtobufCMessageDescriptor cmd_ctrl_reprov__descriptor;
-extern const ProtobufCMessageDescriptor resp_ctrl_reprov__descriptor;
+extern const ProtobufCMessageDescriptor cmd_ctrl_wifi_reset__descriptor;
+extern const ProtobufCMessageDescriptor resp_ctrl_wifi_reset__descriptor;
+extern const ProtobufCMessageDescriptor cmd_ctrl_wifi_reprov__descriptor;
+extern const ProtobufCMessageDescriptor resp_ctrl_wifi_reprov__descriptor;
+extern const ProtobufCMessageDescriptor cmd_ctrl_thread_reset__descriptor;
+extern const ProtobufCMessageDescriptor resp_ctrl_thread_reset__descriptor;
+extern const ProtobufCMessageDescriptor cmd_ctrl_thread_reprov__descriptor;
+extern const ProtobufCMessageDescriptor resp_ctrl_thread_reprov__descriptor;
 extern const ProtobufCMessageDescriptor network_ctrl_payload__descriptor;
 
 PROTOBUF_C__END_DECLS

--- a/network_provisioning/proto-c/network_scan.pb-c.c
+++ b/network_provisioning/proto-c/network_scan.pb-c.c
@@ -7,364 +7,499 @@
 #endif
 
 #include "network_scan.pb-c.h"
-void   wifi_scan_start__init
-                     (WifiScanStart         *message)
+void   cmd_scan_wifi_start__init
+                     (CmdScanWifiStart         *message)
 {
-  static const WifiScanStart init_value = WIFI_SCAN_START__INIT;
+  static const CmdScanWifiStart init_value = CMD_SCAN_WIFI_START__INIT;
   *message = init_value;
 }
-size_t wifi_scan_start__get_packed_size
-                     (const WifiScanStart *message)
+size_t cmd_scan_wifi_start__get_packed_size
+                     (const CmdScanWifiStart *message)
 {
-  assert(message->base.descriptor == &wifi_scan_start__descriptor);
+  assert(message->base.descriptor == &cmd_scan_wifi_start__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t wifi_scan_start__pack
-                     (const WifiScanStart *message,
+size_t cmd_scan_wifi_start__pack
+                     (const CmdScanWifiStart *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &wifi_scan_start__descriptor);
+  assert(message->base.descriptor == &cmd_scan_wifi_start__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t wifi_scan_start__pack_to_buffer
-                     (const WifiScanStart *message,
+size_t cmd_scan_wifi_start__pack_to_buffer
+                     (const CmdScanWifiStart *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &wifi_scan_start__descriptor);
+  assert(message->base.descriptor == &cmd_scan_wifi_start__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-WifiScanStart *
-       wifi_scan_start__unpack
+CmdScanWifiStart *
+       cmd_scan_wifi_start__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (WifiScanStart *)
-     protobuf_c_message_unpack (&wifi_scan_start__descriptor,
+  return (CmdScanWifiStart *)
+     protobuf_c_message_unpack (&cmd_scan_wifi_start__descriptor,
                                 allocator, len, data);
 }
-void   wifi_scan_start__free_unpacked
-                     (WifiScanStart *message,
+void   cmd_scan_wifi_start__free_unpacked
+                     (CmdScanWifiStart *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &wifi_scan_start__descriptor);
+  assert(message->base.descriptor == &cmd_scan_wifi_start__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   thread_scan_start__init
-                     (ThreadScanStart         *message)
+void   cmd_scan_thread_start__init
+                     (CmdScanThreadStart         *message)
 {
-  static const ThreadScanStart init_value = THREAD_SCAN_START__INIT;
+  static const CmdScanThreadStart init_value = CMD_SCAN_THREAD_START__INIT;
   *message = init_value;
 }
-size_t thread_scan_start__get_packed_size
-                     (const ThreadScanStart *message)
+size_t cmd_scan_thread_start__get_packed_size
+                     (const CmdScanThreadStart *message)
 {
-  assert(message->base.descriptor == &thread_scan_start__descriptor);
+  assert(message->base.descriptor == &cmd_scan_thread_start__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t thread_scan_start__pack
-                     (const ThreadScanStart *message,
+size_t cmd_scan_thread_start__pack
+                     (const CmdScanThreadStart *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &thread_scan_start__descriptor);
+  assert(message->base.descriptor == &cmd_scan_thread_start__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t thread_scan_start__pack_to_buffer
-                     (const ThreadScanStart *message,
+size_t cmd_scan_thread_start__pack_to_buffer
+                     (const CmdScanThreadStart *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &thread_scan_start__descriptor);
+  assert(message->base.descriptor == &cmd_scan_thread_start__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-ThreadScanStart *
-       thread_scan_start__unpack
+CmdScanThreadStart *
+       cmd_scan_thread_start__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (ThreadScanStart *)
-     protobuf_c_message_unpack (&thread_scan_start__descriptor,
+  return (CmdScanThreadStart *)
+     protobuf_c_message_unpack (&cmd_scan_thread_start__descriptor,
                                 allocator, len, data);
 }
-void   thread_scan_start__free_unpacked
-                     (ThreadScanStart *message,
+void   cmd_scan_thread_start__free_unpacked
+                     (CmdScanThreadStart *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &thread_scan_start__descriptor);
+  assert(message->base.descriptor == &cmd_scan_thread_start__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   cmd_scan_start__init
-                     (CmdScanStart         *message)
+void   resp_scan_wifi_start__init
+                     (RespScanWifiStart         *message)
 {
-  static const CmdScanStart init_value = CMD_SCAN_START__INIT;
+  static const RespScanWifiStart init_value = RESP_SCAN_WIFI_START__INIT;
   *message = init_value;
 }
-size_t cmd_scan_start__get_packed_size
-                     (const CmdScanStart *message)
+size_t resp_scan_wifi_start__get_packed_size
+                     (const RespScanWifiStart *message)
 {
-  assert(message->base.descriptor == &cmd_scan_start__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_start__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t cmd_scan_start__pack
-                     (const CmdScanStart *message,
+size_t resp_scan_wifi_start__pack
+                     (const RespScanWifiStart *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &cmd_scan_start__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_start__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t cmd_scan_start__pack_to_buffer
-                     (const CmdScanStart *message,
+size_t resp_scan_wifi_start__pack_to_buffer
+                     (const RespScanWifiStart *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &cmd_scan_start__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_start__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-CmdScanStart *
-       cmd_scan_start__unpack
+RespScanWifiStart *
+       resp_scan_wifi_start__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (CmdScanStart *)
-     protobuf_c_message_unpack (&cmd_scan_start__descriptor,
+  return (RespScanWifiStart *)
+     protobuf_c_message_unpack (&resp_scan_wifi_start__descriptor,
                                 allocator, len, data);
 }
-void   cmd_scan_start__free_unpacked
-                     (CmdScanStart *message,
+void   resp_scan_wifi_start__free_unpacked
+                     (RespScanWifiStart *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &cmd_scan_start__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_start__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   resp_scan_start__init
-                     (RespScanStart         *message)
+void   resp_scan_thread_start__init
+                     (RespScanThreadStart         *message)
 {
-  static const RespScanStart init_value = RESP_SCAN_START__INIT;
+  static const RespScanThreadStart init_value = RESP_SCAN_THREAD_START__INIT;
   *message = init_value;
 }
-size_t resp_scan_start__get_packed_size
-                     (const RespScanStart *message)
+size_t resp_scan_thread_start__get_packed_size
+                     (const RespScanThreadStart *message)
 {
-  assert(message->base.descriptor == &resp_scan_start__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_start__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t resp_scan_start__pack
-                     (const RespScanStart *message,
+size_t resp_scan_thread_start__pack
+                     (const RespScanThreadStart *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &resp_scan_start__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_start__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t resp_scan_start__pack_to_buffer
-                     (const RespScanStart *message,
+size_t resp_scan_thread_start__pack_to_buffer
+                     (const RespScanThreadStart *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &resp_scan_start__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_start__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-RespScanStart *
-       resp_scan_start__unpack
+RespScanThreadStart *
+       resp_scan_thread_start__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (RespScanStart *)
-     protobuf_c_message_unpack (&resp_scan_start__descriptor,
+  return (RespScanThreadStart *)
+     protobuf_c_message_unpack (&resp_scan_thread_start__descriptor,
                                 allocator, len, data);
 }
-void   resp_scan_start__free_unpacked
-                     (RespScanStart *message,
+void   resp_scan_thread_start__free_unpacked
+                     (RespScanThreadStart *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &resp_scan_start__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_start__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   cmd_scan_status__init
-                     (CmdScanStatus         *message)
+void   cmd_scan_wifi_status__init
+                     (CmdScanWifiStatus         *message)
 {
-  static const CmdScanStatus init_value = CMD_SCAN_STATUS__INIT;
+  static const CmdScanWifiStatus init_value = CMD_SCAN_WIFI_STATUS__INIT;
   *message = init_value;
 }
-size_t cmd_scan_status__get_packed_size
-                     (const CmdScanStatus *message)
+size_t cmd_scan_wifi_status__get_packed_size
+                     (const CmdScanWifiStatus *message)
 {
-  assert(message->base.descriptor == &cmd_scan_status__descriptor);
+  assert(message->base.descriptor == &cmd_scan_wifi_status__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t cmd_scan_status__pack
-                     (const CmdScanStatus *message,
+size_t cmd_scan_wifi_status__pack
+                     (const CmdScanWifiStatus *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &cmd_scan_status__descriptor);
+  assert(message->base.descriptor == &cmd_scan_wifi_status__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t cmd_scan_status__pack_to_buffer
-                     (const CmdScanStatus *message,
+size_t cmd_scan_wifi_status__pack_to_buffer
+                     (const CmdScanWifiStatus *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &cmd_scan_status__descriptor);
+  assert(message->base.descriptor == &cmd_scan_wifi_status__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-CmdScanStatus *
-       cmd_scan_status__unpack
+CmdScanWifiStatus *
+       cmd_scan_wifi_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (CmdScanStatus *)
-     protobuf_c_message_unpack (&cmd_scan_status__descriptor,
+  return (CmdScanWifiStatus *)
+     protobuf_c_message_unpack (&cmd_scan_wifi_status__descriptor,
                                 allocator, len, data);
 }
-void   cmd_scan_status__free_unpacked
-                     (CmdScanStatus *message,
+void   cmd_scan_wifi_status__free_unpacked
+                     (CmdScanWifiStatus *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &cmd_scan_status__descriptor);
+  assert(message->base.descriptor == &cmd_scan_wifi_status__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   resp_scan_status__init
-                     (RespScanStatus         *message)
+void   cmd_scan_thread_status__init
+                     (CmdScanThreadStatus         *message)
 {
-  static const RespScanStatus init_value = RESP_SCAN_STATUS__INIT;
+  static const CmdScanThreadStatus init_value = CMD_SCAN_THREAD_STATUS__INIT;
   *message = init_value;
 }
-size_t resp_scan_status__get_packed_size
-                     (const RespScanStatus *message)
+size_t cmd_scan_thread_status__get_packed_size
+                     (const CmdScanThreadStatus *message)
 {
-  assert(message->base.descriptor == &resp_scan_status__descriptor);
+  assert(message->base.descriptor == &cmd_scan_thread_status__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t resp_scan_status__pack
-                     (const RespScanStatus *message,
+size_t cmd_scan_thread_status__pack
+                     (const CmdScanThreadStatus *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &resp_scan_status__descriptor);
+  assert(message->base.descriptor == &cmd_scan_thread_status__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t resp_scan_status__pack_to_buffer
-                     (const RespScanStatus *message,
+size_t cmd_scan_thread_status__pack_to_buffer
+                     (const CmdScanThreadStatus *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &resp_scan_status__descriptor);
+  assert(message->base.descriptor == &cmd_scan_thread_status__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-RespScanStatus *
-       resp_scan_status__unpack
+CmdScanThreadStatus *
+       cmd_scan_thread_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (RespScanStatus *)
-     protobuf_c_message_unpack (&resp_scan_status__descriptor,
+  return (CmdScanThreadStatus *)
+     protobuf_c_message_unpack (&cmd_scan_thread_status__descriptor,
                                 allocator, len, data);
 }
-void   resp_scan_status__free_unpacked
-                     (RespScanStatus *message,
+void   cmd_scan_thread_status__free_unpacked
+                     (CmdScanThreadStatus *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &resp_scan_status__descriptor);
+  assert(message->base.descriptor == &cmd_scan_thread_status__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   cmd_scan_result__init
-                     (CmdScanResult         *message)
+void   resp_scan_wifi_status__init
+                     (RespScanWifiStatus         *message)
 {
-  static const CmdScanResult init_value = CMD_SCAN_RESULT__INIT;
+  static const RespScanWifiStatus init_value = RESP_SCAN_WIFI_STATUS__INIT;
   *message = init_value;
 }
-size_t cmd_scan_result__get_packed_size
-                     (const CmdScanResult *message)
+size_t resp_scan_wifi_status__get_packed_size
+                     (const RespScanWifiStatus *message)
 {
-  assert(message->base.descriptor == &cmd_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_status__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t cmd_scan_result__pack
-                     (const CmdScanResult *message,
+size_t resp_scan_wifi_status__pack
+                     (const RespScanWifiStatus *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &cmd_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_status__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t cmd_scan_result__pack_to_buffer
-                     (const CmdScanResult *message,
+size_t resp_scan_wifi_status__pack_to_buffer
+                     (const RespScanWifiStatus *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &cmd_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_status__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-CmdScanResult *
-       cmd_scan_result__unpack
+RespScanWifiStatus *
+       resp_scan_wifi_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (CmdScanResult *)
-     protobuf_c_message_unpack (&cmd_scan_result__descriptor,
+  return (RespScanWifiStatus *)
+     protobuf_c_message_unpack (&resp_scan_wifi_status__descriptor,
                                 allocator, len, data);
 }
-void   cmd_scan_result__free_unpacked
-                     (CmdScanResult *message,
+void   resp_scan_wifi_status__free_unpacked
+                     (RespScanWifiStatus *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &cmd_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_status__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   wifi_scan_result__init
-                     (WifiScanResult         *message)
+void   resp_scan_thread_status__init
+                     (RespScanThreadStatus         *message)
 {
-  static const WifiScanResult init_value = WIFI_SCAN_RESULT__INIT;
+  static const RespScanThreadStatus init_value = RESP_SCAN_THREAD_STATUS__INIT;
   *message = init_value;
 }
-size_t wifi_scan_result__get_packed_size
-                     (const WifiScanResult *message)
+size_t resp_scan_thread_status__get_packed_size
+                     (const RespScanThreadStatus *message)
 {
-  assert(message->base.descriptor == &wifi_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_status__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t wifi_scan_result__pack
-                     (const WifiScanResult *message,
+size_t resp_scan_thread_status__pack
+                     (const RespScanThreadStatus *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &wifi_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_status__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t wifi_scan_result__pack_to_buffer
-                     (const WifiScanResult *message,
+size_t resp_scan_thread_status__pack_to_buffer
+                     (const RespScanThreadStatus *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &wifi_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_status__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-WifiScanResult *
-       wifi_scan_result__unpack
+RespScanThreadStatus *
+       resp_scan_thread_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (WifiScanResult *)
-     protobuf_c_message_unpack (&wifi_scan_result__descriptor,
+  return (RespScanThreadStatus *)
+     protobuf_c_message_unpack (&resp_scan_thread_status__descriptor,
                                 allocator, len, data);
 }
-void   wifi_scan_result__free_unpacked
-                     (WifiScanResult *message,
+void   resp_scan_thread_status__free_unpacked
+                     (RespScanThreadStatus *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &wifi_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_status__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   cmd_scan_wifi_result__init
+                     (CmdScanWifiResult         *message)
+{
+  static const CmdScanWifiResult init_value = CMD_SCAN_WIFI_RESULT__INIT;
+  *message = init_value;
+}
+size_t cmd_scan_wifi_result__get_packed_size
+                     (const CmdScanWifiResult *message)
+{
+  assert(message->base.descriptor == &cmd_scan_wifi_result__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t cmd_scan_wifi_result__pack
+                     (const CmdScanWifiResult *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &cmd_scan_wifi_result__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t cmd_scan_wifi_result__pack_to_buffer
+                     (const CmdScanWifiResult *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &cmd_scan_wifi_result__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+CmdScanWifiResult *
+       cmd_scan_wifi_result__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (CmdScanWifiResult *)
+     protobuf_c_message_unpack (&cmd_scan_wifi_result__descriptor,
+                                allocator, len, data);
+}
+void   cmd_scan_wifi_result__free_unpacked
+                     (CmdScanWifiResult *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &cmd_scan_wifi_result__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   cmd_scan_thread_result__init
+                     (CmdScanThreadResult         *message)
+{
+  static const CmdScanThreadResult init_value = CMD_SCAN_THREAD_RESULT__INIT;
+  *message = init_value;
+}
+size_t cmd_scan_thread_result__get_packed_size
+                     (const CmdScanThreadResult *message)
+{
+  assert(message->base.descriptor == &cmd_scan_thread_result__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t cmd_scan_thread_result__pack
+                     (const CmdScanThreadResult *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &cmd_scan_thread_result__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t cmd_scan_thread_result__pack_to_buffer
+                     (const CmdScanThreadResult *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &cmd_scan_thread_result__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+CmdScanThreadResult *
+       cmd_scan_thread_result__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (CmdScanThreadResult *)
+     protobuf_c_message_unpack (&cmd_scan_thread_result__descriptor,
+                                allocator, len, data);
+}
+void   cmd_scan_thread_result__free_unpacked
+                     (CmdScanThreadResult *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &cmd_scan_thread_result__descriptor);
+  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
+}
+void   wi_fi_scan_result__init
+                     (WiFiScanResult         *message)
+{
+  static const WiFiScanResult init_value = WI_FI_SCAN_RESULT__INIT;
+  *message = init_value;
+}
+size_t wi_fi_scan_result__get_packed_size
+                     (const WiFiScanResult *message)
+{
+  assert(message->base.descriptor == &wi_fi_scan_result__descriptor);
+  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
+}
+size_t wi_fi_scan_result__pack
+                     (const WiFiScanResult *message,
+                      uint8_t       *out)
+{
+  assert(message->base.descriptor == &wi_fi_scan_result__descriptor);
+  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
+}
+size_t wi_fi_scan_result__pack_to_buffer
+                     (const WiFiScanResult *message,
+                      ProtobufCBuffer *buffer)
+{
+  assert(message->base.descriptor == &wi_fi_scan_result__descriptor);
+  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
+}
+WiFiScanResult *
+       wi_fi_scan_result__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data)
+{
+  return (WiFiScanResult *)
+     protobuf_c_message_unpack (&wi_fi_scan_result__descriptor,
+                                allocator, len, data);
+}
+void   wi_fi_scan_result__free_unpacked
+                     (WiFiScanResult *message,
+                      ProtobufCAllocator *allocator)
+{
+  if(!message)
+    return;
+  assert(message->base.descriptor == &wi_fi_scan_result__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
 void   thread_scan_result__init
@@ -412,94 +547,94 @@ void   thread_scan_result__free_unpacked
   assert(message->base.descriptor == &thread_scan_result__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   scan_result__init
-                     (ScanResult         *message)
+void   resp_scan_wifi_result__init
+                     (RespScanWifiResult         *message)
 {
-  static const ScanResult init_value = SCAN_RESULT__INIT;
+  static const RespScanWifiResult init_value = RESP_SCAN_WIFI_RESULT__INIT;
   *message = init_value;
 }
-size_t scan_result__get_packed_size
-                     (const ScanResult *message)
+size_t resp_scan_wifi_result__get_packed_size
+                     (const RespScanWifiResult *message)
 {
-  assert(message->base.descriptor == &scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_result__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t scan_result__pack
-                     (const ScanResult *message,
+size_t resp_scan_wifi_result__pack
+                     (const RespScanWifiResult *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_result__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t scan_result__pack_to_buffer
-                     (const ScanResult *message,
+size_t resp_scan_wifi_result__pack_to_buffer
+                     (const RespScanWifiResult *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_result__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-ScanResult *
-       scan_result__unpack
+RespScanWifiResult *
+       resp_scan_wifi_result__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (ScanResult *)
-     protobuf_c_message_unpack (&scan_result__descriptor,
+  return (RespScanWifiResult *)
+     protobuf_c_message_unpack (&resp_scan_wifi_result__descriptor,
                                 allocator, len, data);
 }
-void   scan_result__free_unpacked
-                     (ScanResult *message,
+void   resp_scan_wifi_result__free_unpacked
+                     (RespScanWifiResult *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_wifi_result__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   resp_scan_result__init
-                     (RespScanResult         *message)
+void   resp_scan_thread_result__init
+                     (RespScanThreadResult         *message)
 {
-  static const RespScanResult init_value = RESP_SCAN_RESULT__INIT;
+  static const RespScanThreadResult init_value = RESP_SCAN_THREAD_RESULT__INIT;
   *message = init_value;
 }
-size_t resp_scan_result__get_packed_size
-                     (const RespScanResult *message)
+size_t resp_scan_thread_result__get_packed_size
+                     (const RespScanThreadResult *message)
 {
-  assert(message->base.descriptor == &resp_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_result__descriptor);
   return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
 }
-size_t resp_scan_result__pack
-                     (const RespScanResult *message,
+size_t resp_scan_thread_result__pack
+                     (const RespScanThreadResult *message,
                       uint8_t       *out)
 {
-  assert(message->base.descriptor == &resp_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_result__descriptor);
   return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
 }
-size_t resp_scan_result__pack_to_buffer
-                     (const RespScanResult *message,
+size_t resp_scan_thread_result__pack_to_buffer
+                     (const RespScanThreadResult *message,
                       ProtobufCBuffer *buffer)
 {
-  assert(message->base.descriptor == &resp_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_result__descriptor);
   return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
 }
-RespScanResult *
-       resp_scan_result__unpack
+RespScanThreadResult *
+       resp_scan_thread_result__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data)
 {
-  return (RespScanResult *)
-     protobuf_c_message_unpack (&resp_scan_result__descriptor,
+  return (RespScanThreadResult *)
+     protobuf_c_message_unpack (&resp_scan_thread_result__descriptor,
                                 allocator, len, data);
 }
-void   resp_scan_result__free_unpacked
-                     (RespScanResult *message,
+void   resp_scan_thread_result__free_unpacked
+                     (RespScanThreadResult *message,
                       ProtobufCAllocator *allocator)
 {
   if(!message)
     return;
-  assert(message->base.descriptor == &resp_scan_result__descriptor);
+  assert(message->base.descriptor == &resp_scan_thread_result__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
 void   network_scan_payload__init
@@ -547,7 +682,7 @@ void   network_scan_payload__free_unpacked
   assert(message->base.descriptor == &network_scan_payload__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-static const ProtobufCFieldDescriptor wifi_scan_start__field_descriptors[4] =
+static const ProtobufCFieldDescriptor cmd_scan_wifi_start__field_descriptors[4] =
 {
   {
     "blocking",
@@ -555,7 +690,7 @@ static const ProtobufCFieldDescriptor wifi_scan_start__field_descriptors[4] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BOOL,
     0,   /* quantifier_offset */
-    offsetof(WifiScanStart, blocking),
+    offsetof(CmdScanWifiStart, blocking),
     NULL,
     NULL,
     0,             /* flags */
@@ -567,7 +702,7 @@ static const ProtobufCFieldDescriptor wifi_scan_start__field_descriptors[4] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BOOL,
     0,   /* quantifier_offset */
-    offsetof(WifiScanStart, passive),
+    offsetof(CmdScanWifiStart, passive),
     NULL,
     NULL,
     0,             /* flags */
@@ -579,7 +714,7 @@ static const ProtobufCFieldDescriptor wifi_scan_start__field_descriptors[4] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_UINT32,
     0,   /* quantifier_offset */
-    offsetof(WifiScanStart, group_channels),
+    offsetof(CmdScanWifiStart, group_channels),
     NULL,
     NULL,
     0,             /* flags */
@@ -591,40 +726,40 @@ static const ProtobufCFieldDescriptor wifi_scan_start__field_descriptors[4] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_UINT32,
     0,   /* quantifier_offset */
-    offsetof(WifiScanStart, period_ms),
+    offsetof(CmdScanWifiStart, period_ms),
     NULL,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned wifi_scan_start__field_indices_by_name[] = {
+static const unsigned cmd_scan_wifi_start__field_indices_by_name[] = {
   0,   /* field[0] = blocking */
   2,   /* field[2] = group_channels */
   1,   /* field[1] = passive */
   3,   /* field[3] = period_ms */
 };
-static const ProtobufCIntRange wifi_scan_start__number_ranges[1 + 1] =
+static const ProtobufCIntRange cmd_scan_wifi_start__number_ranges[1 + 1] =
 {
   { 1, 0 },
   { 0, 4 }
 };
-const ProtobufCMessageDescriptor wifi_scan_start__descriptor =
+const ProtobufCMessageDescriptor cmd_scan_wifi_start__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "WifiScanStart",
-  "WifiScanStart",
-  "WifiScanStart",
+  "CmdScanWifiStart",
+  "CmdScanWifiStart",
+  "CmdScanWifiStart",
   "",
-  sizeof(WifiScanStart),
+  sizeof(CmdScanWifiStart),
   4,
-  wifi_scan_start__field_descriptors,
-  wifi_scan_start__field_indices_by_name,
-  1,  wifi_scan_start__number_ranges,
-  (ProtobufCMessageInit) wifi_scan_start__init,
+  cmd_scan_wifi_start__field_descriptors,
+  cmd_scan_wifi_start__field_indices_by_name,
+  1,  cmd_scan_wifi_start__number_ranges,
+  (ProtobufCMessageInit) cmd_scan_wifi_start__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor thread_scan_start__field_descriptors[2] =
+static const ProtobufCFieldDescriptor cmd_scan_thread_start__field_descriptors[2] =
 {
   {
     "blocking",
@@ -632,7 +767,7 @@ static const ProtobufCFieldDescriptor thread_scan_start__field_descriptors[2] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BOOL,
     0,   /* quantifier_offset */
-    offsetof(ThreadScanStart, blocking),
+    offsetof(CmdScanThreadStart, blocking),
     NULL,
     NULL,
     0,             /* flags */
@@ -644,199 +779,118 @@ static const ProtobufCFieldDescriptor thread_scan_start__field_descriptors[2] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_UINT32,
     0,   /* quantifier_offset */
-    offsetof(ThreadScanStart, channel_mask),
+    offsetof(CmdScanThreadStart, channel_mask),
     NULL,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned thread_scan_start__field_indices_by_name[] = {
+static const unsigned cmd_scan_thread_start__field_indices_by_name[] = {
   0,   /* field[0] = blocking */
   1,   /* field[1] = channel_mask */
 };
-static const ProtobufCIntRange thread_scan_start__number_ranges[1 + 1] =
+static const ProtobufCIntRange cmd_scan_thread_start__number_ranges[1 + 1] =
 {
   { 1, 0 },
   { 0, 2 }
 };
-const ProtobufCMessageDescriptor thread_scan_start__descriptor =
+const ProtobufCMessageDescriptor cmd_scan_thread_start__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "ThreadScanStart",
-  "ThreadScanStart",
-  "ThreadScanStart",
+  "CmdScanThreadStart",
+  "CmdScanThreadStart",
+  "CmdScanThreadStart",
   "",
-  sizeof(ThreadScanStart),
+  sizeof(CmdScanThreadStart),
   2,
-  thread_scan_start__field_descriptors,
-  thread_scan_start__field_indices_by_name,
-  1,  thread_scan_start__number_ranges,
-  (ProtobufCMessageInit) thread_scan_start__init,
+  cmd_scan_thread_start__field_descriptors,
+  cmd_scan_thread_start__field_indices_by_name,
+  1,  cmd_scan_thread_start__number_ranges,
+  (ProtobufCMessageInit) cmd_scan_thread_start__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor cmd_scan_start__field_descriptors[3] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(CmdScanStart, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "wifi_scan_start",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(CmdScanStart, payload_case),
-    offsetof(CmdScanStart, wifi_scan_start),
-    &wifi_scan_start__descriptor,
-    NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "thread_scan_start",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(CmdScanStart, payload_case),
-    offsetof(CmdScanStart, thread_scan_start),
-    &thread_scan_start__descriptor,
-    NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned cmd_scan_start__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-  2,   /* field[2] = thread_scan_start */
-  1,   /* field[1] = wifi_scan_start */
-};
-static const ProtobufCIntRange cmd_scan_start__number_ranges[2 + 1] =
-{
-  { 1, 0 },
-  { 10, 1 },
-  { 0, 3 }
-};
-const ProtobufCMessageDescriptor cmd_scan_start__descriptor =
+#define resp_scan_wifi_start__field_descriptors NULL
+#define resp_scan_wifi_start__field_indices_by_name NULL
+#define resp_scan_wifi_start__number_ranges NULL
+const ProtobufCMessageDescriptor resp_scan_wifi_start__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "CmdScanStart",
-  "CmdScanStart",
-  "CmdScanStart",
+  "RespScanWifiStart",
+  "RespScanWifiStart",
+  "RespScanWifiStart",
   "",
-  sizeof(CmdScanStart),
-  3,
-  cmd_scan_start__field_descriptors,
-  cmd_scan_start__field_indices_by_name,
-  2,  cmd_scan_start__number_ranges,
-  (ProtobufCMessageInit) cmd_scan_start__init,
+  sizeof(RespScanWifiStart),
+  0,
+  resp_scan_wifi_start__field_descriptors,
+  resp_scan_wifi_start__field_indices_by_name,
+  0,  resp_scan_wifi_start__number_ranges,
+  (ProtobufCMessageInit) resp_scan_wifi_start__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor resp_scan_start__field_descriptors[1] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(RespScanStart, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned resp_scan_start__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-};
-static const ProtobufCIntRange resp_scan_start__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor resp_scan_start__descriptor =
+#define resp_scan_thread_start__field_descriptors NULL
+#define resp_scan_thread_start__field_indices_by_name NULL
+#define resp_scan_thread_start__number_ranges NULL
+const ProtobufCMessageDescriptor resp_scan_thread_start__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "RespScanStart",
-  "RespScanStart",
-  "RespScanStart",
+  "RespScanThreadStart",
+  "RespScanThreadStart",
+  "RespScanThreadStart",
   "",
-  sizeof(RespScanStart),
-  1,
-  resp_scan_start__field_descriptors,
-  resp_scan_start__field_indices_by_name,
-  1,  resp_scan_start__number_ranges,
-  (ProtobufCMessageInit) resp_scan_start__init,
+  sizeof(RespScanThreadStart),
+  0,
+  resp_scan_thread_start__field_descriptors,
+  resp_scan_thread_start__field_indices_by_name,
+  0,  resp_scan_thread_start__number_ranges,
+  (ProtobufCMessageInit) resp_scan_thread_start__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor cmd_scan_status__field_descriptors[1] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(CmdScanStatus, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned cmd_scan_status__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-};
-static const ProtobufCIntRange cmd_scan_status__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 1 }
-};
-const ProtobufCMessageDescriptor cmd_scan_status__descriptor =
+#define cmd_scan_wifi_status__field_descriptors NULL
+#define cmd_scan_wifi_status__field_indices_by_name NULL
+#define cmd_scan_wifi_status__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_scan_wifi_status__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "CmdScanStatus",
-  "CmdScanStatus",
-  "CmdScanStatus",
+  "CmdScanWifiStatus",
+  "CmdScanWifiStatus",
+  "CmdScanWifiStatus",
   "",
-  sizeof(CmdScanStatus),
-  1,
-  cmd_scan_status__field_descriptors,
-  cmd_scan_status__field_indices_by_name,
-  1,  cmd_scan_status__number_ranges,
-  (ProtobufCMessageInit) cmd_scan_status__init,
+  sizeof(CmdScanWifiStatus),
+  0,
+  cmd_scan_wifi_status__field_descriptors,
+  cmd_scan_wifi_status__field_indices_by_name,
+  0,  cmd_scan_wifi_status__number_ranges,
+  (ProtobufCMessageInit) cmd_scan_wifi_status__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor resp_scan_status__field_descriptors[3] =
+#define cmd_scan_thread_status__field_descriptors NULL
+#define cmd_scan_thread_status__field_indices_by_name NULL
+#define cmd_scan_thread_status__number_ranges NULL
+const ProtobufCMessageDescriptor cmd_scan_thread_status__descriptor =
 {
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(RespScanStatus, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "CmdScanThreadStatus",
+  "CmdScanThreadStatus",
+  "CmdScanThreadStatus",
+  "",
+  sizeof(CmdScanThreadStatus),
+  0,
+  cmd_scan_thread_status__field_descriptors,
+  cmd_scan_thread_status__field_indices_by_name,
+  0,  cmd_scan_thread_status__number_ranges,
+  (ProtobufCMessageInit) cmd_scan_thread_status__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor resp_scan_wifi_status__field_descriptors[2] =
+{
   {
     "scan_finished",
-    2,
+    1,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BOOL,
     0,   /* quantifier_offset */
-    offsetof(RespScanStatus, scan_finished),
+    offsetof(RespScanWifiStatus, scan_finished),
     NULL,
     NULL,
     0,             /* flags */
@@ -844,63 +898,101 @@ static const ProtobufCFieldDescriptor resp_scan_status__field_descriptors[3] =
   },
   {
     "result_count",
-    3,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_UINT32,
-    0,   /* quantifier_offset */
-    offsetof(RespScanStatus, result_count),
-    NULL,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned resp_scan_status__field_indices_by_name[] = {
-  0,   /* field[0] = net_type */
-  2,   /* field[2] = result_count */
-  1,   /* field[1] = scan_finished */
-};
-static const ProtobufCIntRange resp_scan_status__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 3 }
-};
-const ProtobufCMessageDescriptor resp_scan_status__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "RespScanStatus",
-  "RespScanStatus",
-  "RespScanStatus",
-  "",
-  sizeof(RespScanStatus),
-  3,
-  resp_scan_status__field_descriptors,
-  resp_scan_status__field_indices_by_name,
-  1,  resp_scan_status__number_ranges,
-  (ProtobufCMessageInit) resp_scan_status__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor cmd_scan_result__field_descriptors[3] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(CmdScanResult, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "start_index",
     2,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_UINT32,
     0,   /* quantifier_offset */
-    offsetof(CmdScanResult, start_index),
+    offsetof(RespScanWifiStatus, result_count),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned resp_scan_wifi_status__field_indices_by_name[] = {
+  1,   /* field[1] = result_count */
+  0,   /* field[0] = scan_finished */
+};
+static const ProtobufCIntRange resp_scan_wifi_status__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor resp_scan_wifi_status__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "RespScanWifiStatus",
+  "RespScanWifiStatus",
+  "RespScanWifiStatus",
+  "",
+  sizeof(RespScanWifiStatus),
+  2,
+  resp_scan_wifi_status__field_descriptors,
+  resp_scan_wifi_status__field_indices_by_name,
+  1,  resp_scan_wifi_status__number_ranges,
+  (ProtobufCMessageInit) resp_scan_wifi_status__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor resp_scan_thread_status__field_descriptors[2] =
+{
+  {
+    "scan_finished",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_BOOL,
+    0,   /* quantifier_offset */
+    offsetof(RespScanThreadStatus, scan_finished),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "result_count",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_UINT32,
+    0,   /* quantifier_offset */
+    offsetof(RespScanThreadStatus, result_count),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned resp_scan_thread_status__field_indices_by_name[] = {
+  1,   /* field[1] = result_count */
+  0,   /* field[0] = scan_finished */
+};
+static const ProtobufCIntRange resp_scan_thread_status__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor resp_scan_thread_status__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "RespScanThreadStatus",
+  "RespScanThreadStatus",
+  "RespScanThreadStatus",
+  "",
+  sizeof(RespScanThreadStatus),
+  2,
+  resp_scan_thread_status__field_descriptors,
+  resp_scan_thread_status__field_indices_by_name,
+  1,  resp_scan_thread_status__number_ranges,
+  (ProtobufCMessageInit) resp_scan_thread_status__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor cmd_scan_wifi_result__field_descriptors[2] =
+{
+  {
+    "start_index",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_UINT32,
+    0,   /* quantifier_offset */
+    offsetof(CmdScanWifiResult, start_index),
     NULL,
     NULL,
     0,             /* flags */
@@ -908,43 +1000,93 @@ static const ProtobufCFieldDescriptor cmd_scan_result__field_descriptors[3] =
   },
   {
     "count",
-    3,
+    2,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_UINT32,
     0,   /* quantifier_offset */
-    offsetof(CmdScanResult, count),
+    offsetof(CmdScanWifiResult, count),
     NULL,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned cmd_scan_result__field_indices_by_name[] = {
-  2,   /* field[2] = count */
-  0,   /* field[0] = net_type */
-  1,   /* field[1] = start_index */
+static const unsigned cmd_scan_wifi_result__field_indices_by_name[] = {
+  1,   /* field[1] = count */
+  0,   /* field[0] = start_index */
 };
-static const ProtobufCIntRange cmd_scan_result__number_ranges[1 + 1] =
+static const ProtobufCIntRange cmd_scan_wifi_result__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 3 }
+  { 0, 2 }
 };
-const ProtobufCMessageDescriptor cmd_scan_result__descriptor =
+const ProtobufCMessageDescriptor cmd_scan_wifi_result__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "CmdScanResult",
-  "CmdScanResult",
-  "CmdScanResult",
+  "CmdScanWifiResult",
+  "CmdScanWifiResult",
+  "CmdScanWifiResult",
   "",
-  sizeof(CmdScanResult),
-  3,
-  cmd_scan_result__field_descriptors,
-  cmd_scan_result__field_indices_by_name,
-  1,  cmd_scan_result__number_ranges,
-  (ProtobufCMessageInit) cmd_scan_result__init,
+  sizeof(CmdScanWifiResult),
+  2,
+  cmd_scan_wifi_result__field_descriptors,
+  cmd_scan_wifi_result__field_indices_by_name,
+  1,  cmd_scan_wifi_result__number_ranges,
+  (ProtobufCMessageInit) cmd_scan_wifi_result__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor wifi_scan_result__field_descriptors[5] =
+static const ProtobufCFieldDescriptor cmd_scan_thread_result__field_descriptors[2] =
+{
+  {
+    "start_index",
+    1,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_UINT32,
+    0,   /* quantifier_offset */
+    offsetof(CmdScanThreadResult, start_index),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "count",
+    2,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_UINT32,
+    0,   /* quantifier_offset */
+    offsetof(CmdScanThreadResult, count),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned cmd_scan_thread_result__field_indices_by_name[] = {
+  1,   /* field[1] = count */
+  0,   /* field[0] = start_index */
+};
+static const ProtobufCIntRange cmd_scan_thread_result__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 2 }
+};
+const ProtobufCMessageDescriptor cmd_scan_thread_result__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "CmdScanThreadResult",
+  "CmdScanThreadResult",
+  "CmdScanThreadResult",
+  "",
+  sizeof(CmdScanThreadResult),
+  2,
+  cmd_scan_thread_result__field_descriptors,
+  cmd_scan_thread_result__field_indices_by_name,
+  1,  cmd_scan_thread_result__number_ranges,
+  (ProtobufCMessageInit) cmd_scan_thread_result__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor wi_fi_scan_result__field_descriptors[5] =
 {
   {
     "ssid",
@@ -952,7 +1094,7 @@ static const ProtobufCFieldDescriptor wifi_scan_result__field_descriptors[5] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BYTES,
     0,   /* quantifier_offset */
-    offsetof(WifiScanResult, ssid),
+    offsetof(WiFiScanResult, ssid),
     NULL,
     NULL,
     0,             /* flags */
@@ -964,7 +1106,7 @@ static const ProtobufCFieldDescriptor wifi_scan_result__field_descriptors[5] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_UINT32,
     0,   /* quantifier_offset */
-    offsetof(WifiScanResult, channel),
+    offsetof(WiFiScanResult, channel),
     NULL,
     NULL,
     0,             /* flags */
@@ -976,7 +1118,7 @@ static const ProtobufCFieldDescriptor wifi_scan_result__field_descriptors[5] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_INT32,
     0,   /* quantifier_offset */
-    offsetof(WifiScanResult, rssi),
+    offsetof(WiFiScanResult, rssi),
     NULL,
     NULL,
     0,             /* flags */
@@ -988,7 +1130,7 @@ static const ProtobufCFieldDescriptor wifi_scan_result__field_descriptors[5] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_BYTES,
     0,   /* quantifier_offset */
-    offsetof(WifiScanResult, bssid),
+    offsetof(WiFiScanResult, bssid),
     NULL,
     NULL,
     0,             /* flags */
@@ -1000,38 +1142,38 @@ static const ProtobufCFieldDescriptor wifi_scan_result__field_descriptors[5] =
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
     0,   /* quantifier_offset */
-    offsetof(WifiScanResult, auth),
+    offsetof(WiFiScanResult, auth),
     &wifi_auth_mode__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned wifi_scan_result__field_indices_by_name[] = {
+static const unsigned wi_fi_scan_result__field_indices_by_name[] = {
   4,   /* field[4] = auth */
   3,   /* field[3] = bssid */
   1,   /* field[1] = channel */
   2,   /* field[2] = rssi */
   0,   /* field[0] = ssid */
 };
-static const ProtobufCIntRange wifi_scan_result__number_ranges[1 + 1] =
+static const ProtobufCIntRange wi_fi_scan_result__number_ranges[1 + 1] =
 {
   { 1, 0 },
   { 0, 5 }
 };
-const ProtobufCMessageDescriptor wifi_scan_result__descriptor =
+const ProtobufCMessageDescriptor wi_fi_scan_result__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "WifiScanResult",
-  "WifiScanResult",
-  "WifiScanResult",
+  "WiFiScanResult",
+  "WiFiScanResult",
+  "WiFiScanResult",
   "",
-  sizeof(WifiScanResult),
+  sizeof(WiFiScanResult),
   5,
-  wifi_scan_result__field_descriptors,
-  wifi_scan_result__field_indices_by_name,
-  1,  wifi_scan_result__number_ranges,
-  (ProtobufCMessageInit) wifi_scan_result__init,
+  wi_fi_scan_result__field_descriptors,
+  wi_fi_scan_result__field_indices_by_name,
+  1,  wi_fi_scan_result__number_ranges,
+  (ProtobufCMessageInit) wi_fi_scan_result__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
 static const ProtobufCFieldDescriptor thread_scan_result__field_descriptors[7] =
@@ -1150,109 +1292,83 @@ const ProtobufCMessageDescriptor thread_scan_result__descriptor =
   (ProtobufCMessageInit) thread_scan_result__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor scan_result__field_descriptors[2] =
+static const ProtobufCFieldDescriptor resp_scan_wifi_result__field_descriptors[1] =
 {
-  {
-    "wifi_result",
-    10,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(ScanResult, result_case),
-    offsetof(ScanResult, wifi_result),
-    &wifi_scan_result__descriptor,
-    NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-  {
-    "thread_result",
-    11,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(ScanResult, result_case),
-    offsetof(ScanResult, thread_result),
-    &thread_scan_result__descriptor,
-    NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned scan_result__field_indices_by_name[] = {
-  1,   /* field[1] = thread_result */
-  0,   /* field[0] = wifi_result */
-};
-static const ProtobufCIntRange scan_result__number_ranges[1 + 1] =
-{
-  { 10, 0 },
-  { 0, 2 }
-};
-const ProtobufCMessageDescriptor scan_result__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "ScanResult",
-  "ScanResult",
-  "ScanResult",
-  "",
-  sizeof(ScanResult),
-  2,
-  scan_result__field_descriptors,
-  scan_result__field_indices_by_name,
-  1,  scan_result__number_ranges,
-  (ProtobufCMessageInit) scan_result__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor resp_scan_result__field_descriptors[2] =
-{
-  {
-    "net_type",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_ENUM,
-    0,   /* quantifier_offset */
-    offsetof(RespScanResult, net_type),
-    &network_type__descriptor,
-    NULL,
-    0,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
   {
     "entries",
-    2,
+    1,
     PROTOBUF_C_LABEL_REPEATED,
     PROTOBUF_C_TYPE_MESSAGE,
-    offsetof(RespScanResult, n_entries),
-    offsetof(RespScanResult, entries),
-    &scan_result__descriptor,
+    offsetof(RespScanWifiResult, n_entries),
+    offsetof(RespScanWifiResult, entries),
+    &wi_fi_scan_result__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
-static const unsigned resp_scan_result__field_indices_by_name[] = {
-  1,   /* field[1] = entries */
-  0,   /* field[0] = net_type */
+static const unsigned resp_scan_wifi_result__field_indices_by_name[] = {
+  0,   /* field[0] = entries */
 };
-static const ProtobufCIntRange resp_scan_result__number_ranges[1 + 1] =
+static const ProtobufCIntRange resp_scan_wifi_result__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 2 }
+  { 0, 1 }
 };
-const ProtobufCMessageDescriptor resp_scan_result__descriptor =
+const ProtobufCMessageDescriptor resp_scan_wifi_result__descriptor =
 {
   PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "RespScanResult",
-  "RespScanResult",
-  "RespScanResult",
+  "RespScanWifiResult",
+  "RespScanWifiResult",
+  "RespScanWifiResult",
   "",
-  sizeof(RespScanResult),
-  2,
-  resp_scan_result__field_descriptors,
-  resp_scan_result__field_indices_by_name,
-  1,  resp_scan_result__number_ranges,
-  (ProtobufCMessageInit) resp_scan_result__init,
+  sizeof(RespScanWifiResult),
+  1,
+  resp_scan_wifi_result__field_descriptors,
+  resp_scan_wifi_result__field_indices_by_name,
+  1,  resp_scan_wifi_result__number_ranges,
+  (ProtobufCMessageInit) resp_scan_wifi_result__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor network_scan_payload__field_descriptors[8] =
+static const ProtobufCFieldDescriptor resp_scan_thread_result__field_descriptors[1] =
+{
+  {
+    "entries",
+    1,
+    PROTOBUF_C_LABEL_REPEATED,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(RespScanThreadResult, n_entries),
+    offsetof(RespScanThreadResult, entries),
+    &thread_scan_result__descriptor,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+};
+static const unsigned resp_scan_thread_result__field_indices_by_name[] = {
+  0,   /* field[0] = entries */
+};
+static const ProtobufCIntRange resp_scan_thread_result__number_ranges[1 + 1] =
+{
+  { 1, 0 },
+  { 0, 1 }
+};
+const ProtobufCMessageDescriptor resp_scan_thread_result__descriptor =
+{
+  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
+  "RespScanThreadResult",
+  "RespScanThreadResult",
+  "RespScanThreadResult",
+  "",
+  sizeof(RespScanThreadResult),
+  1,
+  resp_scan_thread_result__field_descriptors,
+  resp_scan_thread_result__field_indices_by_name,
+  1,  resp_scan_thread_result__number_ranges,
+  (ProtobufCMessageInit) resp_scan_thread_result__init,
+  NULL,NULL,NULL    /* reserved[123] */
+};
+static const ProtobufCFieldDescriptor network_scan_payload__field_descriptors[14] =
 {
   {
     "msg",
@@ -1279,93 +1395,171 @@ static const ProtobufCFieldDescriptor network_scan_payload__field_descriptors[8]
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cmd_scan_start",
+    "cmd_scan_wifi_start",
     10,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkScanPayload, payload_case),
-    offsetof(NetworkScanPayload, cmd_scan_start),
-    &cmd_scan_start__descriptor,
+    offsetof(NetworkScanPayload, cmd_scan_wifi_start),
+    &cmd_scan_wifi_start__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "resp_scan_start",
+    "resp_scan_wifi_start",
     11,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkScanPayload, payload_case),
-    offsetof(NetworkScanPayload, resp_scan_start),
-    &resp_scan_start__descriptor,
+    offsetof(NetworkScanPayload, resp_scan_wifi_start),
+    &resp_scan_wifi_start__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cmd_scan_status",
+    "cmd_scan_wifi_status",
     12,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkScanPayload, payload_case),
-    offsetof(NetworkScanPayload, cmd_scan_status),
-    &cmd_scan_status__descriptor,
+    offsetof(NetworkScanPayload, cmd_scan_wifi_status),
+    &cmd_scan_wifi_status__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "resp_scan_status",
+    "resp_scan_wifi_status",
     13,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkScanPayload, payload_case),
-    offsetof(NetworkScanPayload, resp_scan_status),
-    &resp_scan_status__descriptor,
+    offsetof(NetworkScanPayload, resp_scan_wifi_status),
+    &resp_scan_wifi_status__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "cmd_scan_result",
+    "cmd_scan_wifi_result",
     14,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkScanPayload, payload_case),
-    offsetof(NetworkScanPayload, cmd_scan_result),
-    &cmd_scan_result__descriptor,
+    offsetof(NetworkScanPayload, cmd_scan_wifi_result),
+    &cmd_scan_wifi_result__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "resp_scan_result",
+    "resp_scan_wifi_result",
     15,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_MESSAGE,
     offsetof(NetworkScanPayload, payload_case),
-    offsetof(NetworkScanPayload, resp_scan_result),
-    &resp_scan_result__descriptor,
+    offsetof(NetworkScanPayload, resp_scan_wifi_result),
+    &resp_scan_wifi_result__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "cmd_scan_thread_start",
+    16,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkScanPayload, payload_case),
+    offsetof(NetworkScanPayload, cmd_scan_thread_start),
+    &cmd_scan_thread_start__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "resp_scan_thread_start",
+    17,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkScanPayload, payload_case),
+    offsetof(NetworkScanPayload, resp_scan_thread_start),
+    &resp_scan_thread_start__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "cmd_scan_thread_status",
+    18,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkScanPayload, payload_case),
+    offsetof(NetworkScanPayload, cmd_scan_thread_status),
+    &cmd_scan_thread_status__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "resp_scan_thread_status",
+    19,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkScanPayload, payload_case),
+    offsetof(NetworkScanPayload, resp_scan_thread_status),
+    &resp_scan_thread_status__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "cmd_scan_thread_result",
+    20,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkScanPayload, payload_case),
+    offsetof(NetworkScanPayload, cmd_scan_thread_result),
+    &cmd_scan_thread_result__descriptor,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
+  {
+    "resp_scan_thread_result",
+    21,
+    PROTOBUF_C_LABEL_NONE,
+    PROTOBUF_C_TYPE_MESSAGE,
+    offsetof(NetworkScanPayload, payload_case),
+    offsetof(NetworkScanPayload, resp_scan_thread_result),
+    &resp_scan_thread_result__descriptor,
     NULL,
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
 static const unsigned network_scan_payload__field_indices_by_name[] = {
-  6,   /* field[6] = cmd_scan_result */
-  2,   /* field[2] = cmd_scan_start */
-  4,   /* field[4] = cmd_scan_status */
+  12,   /* field[12] = cmd_scan_thread_result */
+  8,   /* field[8] = cmd_scan_thread_start */
+  10,   /* field[10] = cmd_scan_thread_status */
+  6,   /* field[6] = cmd_scan_wifi_result */
+  2,   /* field[2] = cmd_scan_wifi_start */
+  4,   /* field[4] = cmd_scan_wifi_status */
   0,   /* field[0] = msg */
-  7,   /* field[7] = resp_scan_result */
-  3,   /* field[3] = resp_scan_start */
-  5,   /* field[5] = resp_scan_status */
+  13,   /* field[13] = resp_scan_thread_result */
+  9,   /* field[9] = resp_scan_thread_start */
+  11,   /* field[11] = resp_scan_thread_status */
+  7,   /* field[7] = resp_scan_wifi_result */
+  3,   /* field[3] = resp_scan_wifi_start */
+  5,   /* field[5] = resp_scan_wifi_status */
   1,   /* field[1] = status */
 };
 static const ProtobufCIntRange network_scan_payload__number_ranges[2 + 1] =
 {
   { 1, 0 },
   { 10, 2 },
-  { 0, 8 }
+  { 0, 14 }
 };
 const ProtobufCMessageDescriptor network_scan_payload__descriptor =
 {
@@ -1375,33 +1569,45 @@ const ProtobufCMessageDescriptor network_scan_payload__descriptor =
   "NetworkScanPayload",
   "",
   sizeof(NetworkScanPayload),
-  8,
+  14,
   network_scan_payload__field_descriptors,
   network_scan_payload__field_indices_by_name,
   2,  network_scan_payload__number_ranges,
   (ProtobufCMessageInit) network_scan_payload__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCEnumValue network_scan_msg_type__enum_values_by_number[6] =
+static const ProtobufCEnumValue network_scan_msg_type__enum_values_by_number[12] =
 {
-  { "TypeCmdScanStart", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanStart", 0 },
-  { "TypeRespScanStart", "NETWORK_SCAN_MSG_TYPE__TypeRespScanStart", 1 },
-  { "TypeCmdScanStatus", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanStatus", 2 },
-  { "TypeRespScanStatus", "NETWORK_SCAN_MSG_TYPE__TypeRespScanStatus", 3 },
-  { "TypeCmdScanResult", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanResult", 4 },
-  { "TypeRespScanResult", "NETWORK_SCAN_MSG_TYPE__TypeRespScanResult", 5 },
+  { "TypeCmdScanWifiStart", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanWifiStart", 0 },
+  { "TypeRespScanWifiStart", "NETWORK_SCAN_MSG_TYPE__TypeRespScanWifiStart", 1 },
+  { "TypeCmdScanWifiStatus", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanWifiStatus", 2 },
+  { "TypeRespScanWifiStatus", "NETWORK_SCAN_MSG_TYPE__TypeRespScanWifiStatus", 3 },
+  { "TypeCmdScanWifiResult", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanWifiResult", 4 },
+  { "TypeRespScanWifiResult", "NETWORK_SCAN_MSG_TYPE__TypeRespScanWifiResult", 5 },
+  { "TypeCmdScanThreadStart", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanThreadStart", 6 },
+  { "TypeRespScanThreadStart", "NETWORK_SCAN_MSG_TYPE__TypeRespScanThreadStart", 7 },
+  { "TypeCmdScanThreadStatus", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanThreadStatus", 8 },
+  { "TypeRespScanThreadStatus", "NETWORK_SCAN_MSG_TYPE__TypeRespScanThreadStatus", 9 },
+  { "TypeCmdScanThreadResult", "NETWORK_SCAN_MSG_TYPE__TypeCmdScanThreadResult", 10 },
+  { "TypeRespScanThreadResult", "NETWORK_SCAN_MSG_TYPE__TypeRespScanThreadResult", 11 },
 };
 static const ProtobufCIntRange network_scan_msg_type__value_ranges[] = {
-{0, 0},{0, 6}
+{0, 0},{0, 12}
 };
-static const ProtobufCEnumValueIndex network_scan_msg_type__enum_values_by_name[6] =
+static const ProtobufCEnumValueIndex network_scan_msg_type__enum_values_by_name[12] =
 {
-  { "TypeCmdScanResult", 4 },
-  { "TypeCmdScanStart", 0 },
-  { "TypeCmdScanStatus", 2 },
-  { "TypeRespScanResult", 5 },
-  { "TypeRespScanStart", 1 },
-  { "TypeRespScanStatus", 3 },
+  { "TypeCmdScanThreadResult", 10 },
+  { "TypeCmdScanThreadStart", 6 },
+  { "TypeCmdScanThreadStatus", 8 },
+  { "TypeCmdScanWifiResult", 4 },
+  { "TypeCmdScanWifiStart", 0 },
+  { "TypeCmdScanWifiStatus", 2 },
+  { "TypeRespScanThreadResult", 11 },
+  { "TypeRespScanThreadStart", 7 },
+  { "TypeRespScanThreadStatus", 9 },
+  { "TypeRespScanWifiResult", 5 },
+  { "TypeRespScanWifiStart", 1 },
+  { "TypeRespScanWifiStatus", 3 },
 };
 const ProtobufCEnumDescriptor network_scan_msg_type__descriptor =
 {
@@ -1410,9 +1616,9 @@ const ProtobufCEnumDescriptor network_scan_msg_type__descriptor =
   "NetworkScanMsgType",
   "NetworkScanMsgType",
   "",
-  6,
+  12,
   network_scan_msg_type__enum_values_by_number,
-  6,
+  12,
   network_scan_msg_type__enum_values_by_name,
   1,
   network_scan_msg_type__value_ranges,

--- a/network_provisioning/proto-c/network_scan.pb-c.h
+++ b/network_provisioning/proto-c/network_scan.pb-c.h
@@ -17,35 +17,44 @@ PROTOBUF_C__BEGIN_DECLS
 #include "constants.pb-c.h"
 #include "network_constants.pb-c.h"
 
-typedef struct WifiScanStart WifiScanStart;
-typedef struct ThreadScanStart ThreadScanStart;
-typedef struct CmdScanStart CmdScanStart;
-typedef struct RespScanStart RespScanStart;
-typedef struct CmdScanStatus CmdScanStatus;
-typedef struct RespScanStatus RespScanStatus;
-typedef struct CmdScanResult CmdScanResult;
-typedef struct WifiScanResult WifiScanResult;
+typedef struct CmdScanWifiStart CmdScanWifiStart;
+typedef struct CmdScanThreadStart CmdScanThreadStart;
+typedef struct RespScanWifiStart RespScanWifiStart;
+typedef struct RespScanThreadStart RespScanThreadStart;
+typedef struct CmdScanWifiStatus CmdScanWifiStatus;
+typedef struct CmdScanThreadStatus CmdScanThreadStatus;
+typedef struct RespScanWifiStatus RespScanWifiStatus;
+typedef struct RespScanThreadStatus RespScanThreadStatus;
+typedef struct CmdScanWifiResult CmdScanWifiResult;
+typedef struct CmdScanThreadResult CmdScanThreadResult;
+typedef struct WiFiScanResult WiFiScanResult;
 typedef struct ThreadScanResult ThreadScanResult;
-typedef struct ScanResult ScanResult;
-typedef struct RespScanResult RespScanResult;
+typedef struct RespScanWifiResult RespScanWifiResult;
+typedef struct RespScanThreadResult RespScanThreadResult;
 typedef struct NetworkScanPayload NetworkScanPayload;
 
 
 /* --- enums --- */
 
 typedef enum _NetworkScanMsgType {
-  NETWORK_SCAN_MSG_TYPE__TypeCmdScanStart = 0,
-  NETWORK_SCAN_MSG_TYPE__TypeRespScanStart = 1,
-  NETWORK_SCAN_MSG_TYPE__TypeCmdScanStatus = 2,
-  NETWORK_SCAN_MSG_TYPE__TypeRespScanStatus = 3,
-  NETWORK_SCAN_MSG_TYPE__TypeCmdScanResult = 4,
-  NETWORK_SCAN_MSG_TYPE__TypeRespScanResult = 5
+  NETWORK_SCAN_MSG_TYPE__TypeCmdScanWifiStart = 0,
+  NETWORK_SCAN_MSG_TYPE__TypeRespScanWifiStart = 1,
+  NETWORK_SCAN_MSG_TYPE__TypeCmdScanWifiStatus = 2,
+  NETWORK_SCAN_MSG_TYPE__TypeRespScanWifiStatus = 3,
+  NETWORK_SCAN_MSG_TYPE__TypeCmdScanWifiResult = 4,
+  NETWORK_SCAN_MSG_TYPE__TypeRespScanWifiResult = 5,
+  NETWORK_SCAN_MSG_TYPE__TypeCmdScanThreadStart = 6,
+  NETWORK_SCAN_MSG_TYPE__TypeRespScanThreadStart = 7,
+  NETWORK_SCAN_MSG_TYPE__TypeCmdScanThreadStatus = 8,
+  NETWORK_SCAN_MSG_TYPE__TypeRespScanThreadStatus = 9,
+  NETWORK_SCAN_MSG_TYPE__TypeCmdScanThreadResult = 10,
+  NETWORK_SCAN_MSG_TYPE__TypeRespScanThreadResult = 11
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NETWORK_SCAN_MSG_TYPE)
 } NetworkScanMsgType;
 
 /* --- messages --- */
 
-struct  WifiScanStart
+struct  CmdScanWifiStart
 {
   ProtobufCMessage base;
   protobuf_c_boolean blocking;
@@ -53,89 +62,103 @@ struct  WifiScanStart
   uint32_t group_channels;
   uint32_t period_ms;
 };
-#define WIFI_SCAN_START__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&wifi_scan_start__descriptor) \
+#define CMD_SCAN_WIFI_START__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_wifi_start__descriptor) \
     , 0, 0, 0, 0 }
 
 
-struct  ThreadScanStart
+struct  CmdScanThreadStart
 {
   ProtobufCMessage base;
   protobuf_c_boolean blocking;
   uint32_t channel_mask;
 };
-#define THREAD_SCAN_START__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&thread_scan_start__descriptor) \
+#define CMD_SCAN_THREAD_START__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_thread_start__descriptor) \
     , 0, 0 }
 
 
-typedef enum {
-  CMD_SCAN_START__PAYLOAD__NOT_SET = 0,
-  CMD_SCAN_START__PAYLOAD_WIFI_SCAN_START = 10,
-  CMD_SCAN_START__PAYLOAD_THREAD_SCAN_START = 11
-    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CMD_SCAN_START__PAYLOAD__CASE)
-} CmdScanStart__PayloadCase;
-
-struct  CmdScanStart
+struct  RespScanWifiStart
 {
   ProtobufCMessage base;
-  NetworkType net_type;
-  CmdScanStart__PayloadCase payload_case;
-  union {
-    WifiScanStart *wifi_scan_start;
-    ThreadScanStart *thread_scan_start;
-  };
 };
-#define CMD_SCAN_START__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_start__descriptor) \
-    , NETWORK_TYPE__WifiNetwork, CMD_SCAN_START__PAYLOAD__NOT_SET, {0} }
+#define RESP_SCAN_WIFI_START__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_scan_wifi_start__descriptor) \
+     }
 
 
-struct  RespScanStart
+struct  RespScanThreadStart
 {
   ProtobufCMessage base;
-  NetworkType net_type;
 };
-#define RESP_SCAN_START__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&resp_scan_start__descriptor) \
-    , NETWORK_TYPE__WifiNetwork }
+#define RESP_SCAN_THREAD_START__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_scan_thread_start__descriptor) \
+     }
 
 
-struct  CmdScanStatus
+struct  CmdScanWifiStatus
 {
   ProtobufCMessage base;
-  NetworkType net_type;
 };
-#define CMD_SCAN_STATUS__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_status__descriptor) \
-    , NETWORK_TYPE__WifiNetwork }
+#define CMD_SCAN_WIFI_STATUS__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_wifi_status__descriptor) \
+     }
 
 
-struct  RespScanStatus
+struct  CmdScanThreadStatus
 {
   ProtobufCMessage base;
-  NetworkType net_type;
+};
+#define CMD_SCAN_THREAD_STATUS__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_thread_status__descriptor) \
+     }
+
+
+struct  RespScanWifiStatus
+{
+  ProtobufCMessage base;
   protobuf_c_boolean scan_finished;
   uint32_t result_count;
 };
-#define RESP_SCAN_STATUS__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&resp_scan_status__descriptor) \
-    , NETWORK_TYPE__WifiNetwork, 0, 0 }
+#define RESP_SCAN_WIFI_STATUS__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_scan_wifi_status__descriptor) \
+    , 0, 0 }
 
 
-struct  CmdScanResult
+struct  RespScanThreadStatus
 {
   ProtobufCMessage base;
-  NetworkType net_type;
+  protobuf_c_boolean scan_finished;
+  uint32_t result_count;
+};
+#define RESP_SCAN_THREAD_STATUS__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_scan_thread_status__descriptor) \
+    , 0, 0 }
+
+
+struct  CmdScanWifiResult
+{
+  ProtobufCMessage base;
   uint32_t start_index;
   uint32_t count;
 };
-#define CMD_SCAN_RESULT__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_result__descriptor) \
-    , NETWORK_TYPE__WifiNetwork, 0, 0 }
+#define CMD_SCAN_WIFI_RESULT__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_wifi_result__descriptor) \
+    , 0, 0 }
 
 
-struct  WifiScanResult
+struct  CmdScanThreadResult
+{
+  ProtobufCMessage base;
+  uint32_t start_index;
+  uint32_t count;
+};
+#define CMD_SCAN_THREAD_RESULT__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&cmd_scan_thread_result__descriptor) \
+    , 0, 0 }
+
+
+struct  WiFiScanResult
 {
   ProtobufCMessage base;
   ProtobufCBinaryData ssid;
@@ -144,8 +167,8 @@ struct  WifiScanResult
   ProtobufCBinaryData bssid;
   WifiAuthMode auth;
 };
-#define WIFI_SCAN_RESULT__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&wifi_scan_result__descriptor) \
+#define WI_FI_SCAN_RESULT__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&wi_fi_scan_result__descriptor) \
     , {0,NULL}, 0, 0, {0,NULL}, WIFI_AUTH_MODE__Open }
 
 
@@ -165,47 +188,42 @@ struct  ThreadScanResult
     , 0, 0, 0, 0, {0,NULL}, (char *)protobuf_c_empty_string, {0,NULL} }
 
 
-typedef enum {
-  SCAN_RESULT__RESULT__NOT_SET = 0,
-  SCAN_RESULT__RESULT_WIFI_RESULT = 10,
-  SCAN_RESULT__RESULT_THREAD_RESULT = 11
-    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(SCAN_RESULT__RESULT__CASE)
-} ScanResult__ResultCase;
-
-struct  ScanResult
+struct  RespScanWifiResult
 {
   ProtobufCMessage base;
-  ScanResult__ResultCase result_case;
-  union {
-    WifiScanResult *wifi_result;
-    ThreadScanResult *thread_result;
-  };
-};
-#define SCAN_RESULT__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&scan_result__descriptor) \
-    , SCAN_RESULT__RESULT__NOT_SET, {0} }
-
-
-struct  RespScanResult
-{
-  ProtobufCMessage base;
-  NetworkType net_type;
   size_t n_entries;
-  ScanResult **entries;
+  WiFiScanResult **entries;
 };
-#define RESP_SCAN_RESULT__INIT \
- { PROTOBUF_C_MESSAGE_INIT (&resp_scan_result__descriptor) \
-    , NETWORK_TYPE__WifiNetwork, 0,NULL }
+#define RESP_SCAN_WIFI_RESULT__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_scan_wifi_result__descriptor) \
+    , 0,NULL }
+
+
+struct  RespScanThreadResult
+{
+  ProtobufCMessage base;
+  size_t n_entries;
+  ThreadScanResult **entries;
+};
+#define RESP_SCAN_THREAD_RESULT__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&resp_scan_thread_result__descriptor) \
+    , 0,NULL }
 
 
 typedef enum {
   NETWORK_SCAN_PAYLOAD__PAYLOAD__NOT_SET = 0,
-  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_START = 10,
-  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_START = 11,
-  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_STATUS = 12,
-  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_STATUS = 13,
-  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_RESULT = 14,
-  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_RESULT = 15
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_WIFI_START = 10,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_WIFI_START = 11,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_WIFI_STATUS = 12,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_WIFI_STATUS = 13,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_WIFI_RESULT = 14,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_WIFI_RESULT = 15,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_THREAD_START = 16,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_THREAD_START = 17,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_THREAD_STATUS = 18,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_THREAD_STATUS = 19,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_CMD_SCAN_THREAD_RESULT = 20,
+  NETWORK_SCAN_PAYLOAD__PAYLOAD_RESP_SCAN_THREAD_RESULT = 21
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(NETWORK_SCAN_PAYLOAD__PAYLOAD__CASE)
 } NetworkScanPayload__PayloadCase;
 
@@ -216,170 +234,233 @@ struct  NetworkScanPayload
   Status status;
   NetworkScanPayload__PayloadCase payload_case;
   union {
-    CmdScanStart *cmd_scan_start;
-    RespScanStart *resp_scan_start;
-    CmdScanStatus *cmd_scan_status;
-    RespScanStatus *resp_scan_status;
-    CmdScanResult *cmd_scan_result;
-    RespScanResult *resp_scan_result;
+    CmdScanWifiStart *cmd_scan_wifi_start;
+    RespScanWifiStart *resp_scan_wifi_start;
+    CmdScanWifiStatus *cmd_scan_wifi_status;
+    RespScanWifiStatus *resp_scan_wifi_status;
+    CmdScanWifiResult *cmd_scan_wifi_result;
+    RespScanWifiResult *resp_scan_wifi_result;
+    CmdScanThreadStart *cmd_scan_thread_start;
+    RespScanThreadStart *resp_scan_thread_start;
+    CmdScanThreadStatus *cmd_scan_thread_status;
+    RespScanThreadStatus *resp_scan_thread_status;
+    CmdScanThreadResult *cmd_scan_thread_result;
+    RespScanThreadResult *resp_scan_thread_result;
   };
 };
 #define NETWORK_SCAN_PAYLOAD__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&network_scan_payload__descriptor) \
-    , NETWORK_SCAN_MSG_TYPE__TypeCmdScanStart, STATUS__Success, NETWORK_SCAN_PAYLOAD__PAYLOAD__NOT_SET, {0} }
+    , NETWORK_SCAN_MSG_TYPE__TypeCmdScanWifiStart, STATUS__Success, NETWORK_SCAN_PAYLOAD__PAYLOAD__NOT_SET, {0} }
 
 
-/* WifiScanStart methods */
-void   wifi_scan_start__init
-                     (WifiScanStart         *message);
-size_t wifi_scan_start__get_packed_size
-                     (const WifiScanStart   *message);
-size_t wifi_scan_start__pack
-                     (const WifiScanStart   *message,
+/* CmdScanWifiStart methods */
+void   cmd_scan_wifi_start__init
+                     (CmdScanWifiStart         *message);
+size_t cmd_scan_wifi_start__get_packed_size
+                     (const CmdScanWifiStart   *message);
+size_t cmd_scan_wifi_start__pack
+                     (const CmdScanWifiStart   *message,
                       uint8_t             *out);
-size_t wifi_scan_start__pack_to_buffer
-                     (const WifiScanStart   *message,
+size_t cmd_scan_wifi_start__pack_to_buffer
+                     (const CmdScanWifiStart   *message,
                       ProtobufCBuffer     *buffer);
-WifiScanStart *
-       wifi_scan_start__unpack
+CmdScanWifiStart *
+       cmd_scan_wifi_start__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   wifi_scan_start__free_unpacked
-                     (WifiScanStart *message,
+void   cmd_scan_wifi_start__free_unpacked
+                     (CmdScanWifiStart *message,
                       ProtobufCAllocator *allocator);
-/* ThreadScanStart methods */
-void   thread_scan_start__init
-                     (ThreadScanStart         *message);
-size_t thread_scan_start__get_packed_size
-                     (const ThreadScanStart   *message);
-size_t thread_scan_start__pack
-                     (const ThreadScanStart   *message,
+/* CmdScanThreadStart methods */
+void   cmd_scan_thread_start__init
+                     (CmdScanThreadStart         *message);
+size_t cmd_scan_thread_start__get_packed_size
+                     (const CmdScanThreadStart   *message);
+size_t cmd_scan_thread_start__pack
+                     (const CmdScanThreadStart   *message,
                       uint8_t             *out);
-size_t thread_scan_start__pack_to_buffer
-                     (const ThreadScanStart   *message,
+size_t cmd_scan_thread_start__pack_to_buffer
+                     (const CmdScanThreadStart   *message,
                       ProtobufCBuffer     *buffer);
-ThreadScanStart *
-       thread_scan_start__unpack
+CmdScanThreadStart *
+       cmd_scan_thread_start__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   thread_scan_start__free_unpacked
-                     (ThreadScanStart *message,
+void   cmd_scan_thread_start__free_unpacked
+                     (CmdScanThreadStart *message,
                       ProtobufCAllocator *allocator);
-/* CmdScanStart methods */
-void   cmd_scan_start__init
-                     (CmdScanStart         *message);
-size_t cmd_scan_start__get_packed_size
-                     (const CmdScanStart   *message);
-size_t cmd_scan_start__pack
-                     (const CmdScanStart   *message,
+/* RespScanWifiStart methods */
+void   resp_scan_wifi_start__init
+                     (RespScanWifiStart         *message);
+size_t resp_scan_wifi_start__get_packed_size
+                     (const RespScanWifiStart   *message);
+size_t resp_scan_wifi_start__pack
+                     (const RespScanWifiStart   *message,
                       uint8_t             *out);
-size_t cmd_scan_start__pack_to_buffer
-                     (const CmdScanStart   *message,
+size_t resp_scan_wifi_start__pack_to_buffer
+                     (const RespScanWifiStart   *message,
                       ProtobufCBuffer     *buffer);
-CmdScanStart *
-       cmd_scan_start__unpack
+RespScanWifiStart *
+       resp_scan_wifi_start__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   cmd_scan_start__free_unpacked
-                     (CmdScanStart *message,
+void   resp_scan_wifi_start__free_unpacked
+                     (RespScanWifiStart *message,
                       ProtobufCAllocator *allocator);
-/* RespScanStart methods */
-void   resp_scan_start__init
-                     (RespScanStart         *message);
-size_t resp_scan_start__get_packed_size
-                     (const RespScanStart   *message);
-size_t resp_scan_start__pack
-                     (const RespScanStart   *message,
+/* RespScanThreadStart methods */
+void   resp_scan_thread_start__init
+                     (RespScanThreadStart         *message);
+size_t resp_scan_thread_start__get_packed_size
+                     (const RespScanThreadStart   *message);
+size_t resp_scan_thread_start__pack
+                     (const RespScanThreadStart   *message,
                       uint8_t             *out);
-size_t resp_scan_start__pack_to_buffer
-                     (const RespScanStart   *message,
+size_t resp_scan_thread_start__pack_to_buffer
+                     (const RespScanThreadStart   *message,
                       ProtobufCBuffer     *buffer);
-RespScanStart *
-       resp_scan_start__unpack
+RespScanThreadStart *
+       resp_scan_thread_start__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   resp_scan_start__free_unpacked
-                     (RespScanStart *message,
+void   resp_scan_thread_start__free_unpacked
+                     (RespScanThreadStart *message,
                       ProtobufCAllocator *allocator);
-/* CmdScanStatus methods */
-void   cmd_scan_status__init
-                     (CmdScanStatus         *message);
-size_t cmd_scan_status__get_packed_size
-                     (const CmdScanStatus   *message);
-size_t cmd_scan_status__pack
-                     (const CmdScanStatus   *message,
+/* CmdScanWifiStatus methods */
+void   cmd_scan_wifi_status__init
+                     (CmdScanWifiStatus         *message);
+size_t cmd_scan_wifi_status__get_packed_size
+                     (const CmdScanWifiStatus   *message);
+size_t cmd_scan_wifi_status__pack
+                     (const CmdScanWifiStatus   *message,
                       uint8_t             *out);
-size_t cmd_scan_status__pack_to_buffer
-                     (const CmdScanStatus   *message,
+size_t cmd_scan_wifi_status__pack_to_buffer
+                     (const CmdScanWifiStatus   *message,
                       ProtobufCBuffer     *buffer);
-CmdScanStatus *
-       cmd_scan_status__unpack
+CmdScanWifiStatus *
+       cmd_scan_wifi_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   cmd_scan_status__free_unpacked
-                     (CmdScanStatus *message,
+void   cmd_scan_wifi_status__free_unpacked
+                     (CmdScanWifiStatus *message,
                       ProtobufCAllocator *allocator);
-/* RespScanStatus methods */
-void   resp_scan_status__init
-                     (RespScanStatus         *message);
-size_t resp_scan_status__get_packed_size
-                     (const RespScanStatus   *message);
-size_t resp_scan_status__pack
-                     (const RespScanStatus   *message,
+/* CmdScanThreadStatus methods */
+void   cmd_scan_thread_status__init
+                     (CmdScanThreadStatus         *message);
+size_t cmd_scan_thread_status__get_packed_size
+                     (const CmdScanThreadStatus   *message);
+size_t cmd_scan_thread_status__pack
+                     (const CmdScanThreadStatus   *message,
                       uint8_t             *out);
-size_t resp_scan_status__pack_to_buffer
-                     (const RespScanStatus   *message,
+size_t cmd_scan_thread_status__pack_to_buffer
+                     (const CmdScanThreadStatus   *message,
                       ProtobufCBuffer     *buffer);
-RespScanStatus *
-       resp_scan_status__unpack
+CmdScanThreadStatus *
+       cmd_scan_thread_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   resp_scan_status__free_unpacked
-                     (RespScanStatus *message,
+void   cmd_scan_thread_status__free_unpacked
+                     (CmdScanThreadStatus *message,
                       ProtobufCAllocator *allocator);
-/* CmdScanResult methods */
-void   cmd_scan_result__init
-                     (CmdScanResult         *message);
-size_t cmd_scan_result__get_packed_size
-                     (const CmdScanResult   *message);
-size_t cmd_scan_result__pack
-                     (const CmdScanResult   *message,
+/* RespScanWifiStatus methods */
+void   resp_scan_wifi_status__init
+                     (RespScanWifiStatus         *message);
+size_t resp_scan_wifi_status__get_packed_size
+                     (const RespScanWifiStatus   *message);
+size_t resp_scan_wifi_status__pack
+                     (const RespScanWifiStatus   *message,
                       uint8_t             *out);
-size_t cmd_scan_result__pack_to_buffer
-                     (const CmdScanResult   *message,
+size_t resp_scan_wifi_status__pack_to_buffer
+                     (const RespScanWifiStatus   *message,
                       ProtobufCBuffer     *buffer);
-CmdScanResult *
-       cmd_scan_result__unpack
+RespScanWifiStatus *
+       resp_scan_wifi_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   cmd_scan_result__free_unpacked
-                     (CmdScanResult *message,
+void   resp_scan_wifi_status__free_unpacked
+                     (RespScanWifiStatus *message,
                       ProtobufCAllocator *allocator);
-/* WifiScanResult methods */
-void   wifi_scan_result__init
-                     (WifiScanResult         *message);
-size_t wifi_scan_result__get_packed_size
-                     (const WifiScanResult   *message);
-size_t wifi_scan_result__pack
-                     (const WifiScanResult   *message,
+/* RespScanThreadStatus methods */
+void   resp_scan_thread_status__init
+                     (RespScanThreadStatus         *message);
+size_t resp_scan_thread_status__get_packed_size
+                     (const RespScanThreadStatus   *message);
+size_t resp_scan_thread_status__pack
+                     (const RespScanThreadStatus   *message,
                       uint8_t             *out);
-size_t wifi_scan_result__pack_to_buffer
-                     (const WifiScanResult   *message,
+size_t resp_scan_thread_status__pack_to_buffer
+                     (const RespScanThreadStatus   *message,
                       ProtobufCBuffer     *buffer);
-WifiScanResult *
-       wifi_scan_result__unpack
+RespScanThreadStatus *
+       resp_scan_thread_status__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   wifi_scan_result__free_unpacked
-                     (WifiScanResult *message,
+void   resp_scan_thread_status__free_unpacked
+                     (RespScanThreadStatus *message,
+                      ProtobufCAllocator *allocator);
+/* CmdScanWifiResult methods */
+void   cmd_scan_wifi_result__init
+                     (CmdScanWifiResult         *message);
+size_t cmd_scan_wifi_result__get_packed_size
+                     (const CmdScanWifiResult   *message);
+size_t cmd_scan_wifi_result__pack
+                     (const CmdScanWifiResult   *message,
+                      uint8_t             *out);
+size_t cmd_scan_wifi_result__pack_to_buffer
+                     (const CmdScanWifiResult   *message,
+                      ProtobufCBuffer     *buffer);
+CmdScanWifiResult *
+       cmd_scan_wifi_result__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   cmd_scan_wifi_result__free_unpacked
+                     (CmdScanWifiResult *message,
+                      ProtobufCAllocator *allocator);
+/* CmdScanThreadResult methods */
+void   cmd_scan_thread_result__init
+                     (CmdScanThreadResult         *message);
+size_t cmd_scan_thread_result__get_packed_size
+                     (const CmdScanThreadResult   *message);
+size_t cmd_scan_thread_result__pack
+                     (const CmdScanThreadResult   *message,
+                      uint8_t             *out);
+size_t cmd_scan_thread_result__pack_to_buffer
+                     (const CmdScanThreadResult   *message,
+                      ProtobufCBuffer     *buffer);
+CmdScanThreadResult *
+       cmd_scan_thread_result__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   cmd_scan_thread_result__free_unpacked
+                     (CmdScanThreadResult *message,
+                      ProtobufCAllocator *allocator);
+/* WiFiScanResult methods */
+void   wi_fi_scan_result__init
+                     (WiFiScanResult         *message);
+size_t wi_fi_scan_result__get_packed_size
+                     (const WiFiScanResult   *message);
+size_t wi_fi_scan_result__pack
+                     (const WiFiScanResult   *message,
+                      uint8_t             *out);
+size_t wi_fi_scan_result__pack_to_buffer
+                     (const WiFiScanResult   *message,
+                      ProtobufCBuffer     *buffer);
+WiFiScanResult *
+       wi_fi_scan_result__unpack
+                     (ProtobufCAllocator  *allocator,
+                      size_t               len,
+                      const uint8_t       *data);
+void   wi_fi_scan_result__free_unpacked
+                     (WiFiScanResult *message,
                       ProtobufCAllocator *allocator);
 /* ThreadScanResult methods */
 void   thread_scan_result__init
@@ -400,43 +481,43 @@ ThreadScanResult *
 void   thread_scan_result__free_unpacked
                      (ThreadScanResult *message,
                       ProtobufCAllocator *allocator);
-/* ScanResult methods */
-void   scan_result__init
-                     (ScanResult         *message);
-size_t scan_result__get_packed_size
-                     (const ScanResult   *message);
-size_t scan_result__pack
-                     (const ScanResult   *message,
+/* RespScanWifiResult methods */
+void   resp_scan_wifi_result__init
+                     (RespScanWifiResult         *message);
+size_t resp_scan_wifi_result__get_packed_size
+                     (const RespScanWifiResult   *message);
+size_t resp_scan_wifi_result__pack
+                     (const RespScanWifiResult   *message,
                       uint8_t             *out);
-size_t scan_result__pack_to_buffer
-                     (const ScanResult   *message,
+size_t resp_scan_wifi_result__pack_to_buffer
+                     (const RespScanWifiResult   *message,
                       ProtobufCBuffer     *buffer);
-ScanResult *
-       scan_result__unpack
+RespScanWifiResult *
+       resp_scan_wifi_result__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   scan_result__free_unpacked
-                     (ScanResult *message,
+void   resp_scan_wifi_result__free_unpacked
+                     (RespScanWifiResult *message,
                       ProtobufCAllocator *allocator);
-/* RespScanResult methods */
-void   resp_scan_result__init
-                     (RespScanResult         *message);
-size_t resp_scan_result__get_packed_size
-                     (const RespScanResult   *message);
-size_t resp_scan_result__pack
-                     (const RespScanResult   *message,
+/* RespScanThreadResult methods */
+void   resp_scan_thread_result__init
+                     (RespScanThreadResult         *message);
+size_t resp_scan_thread_result__get_packed_size
+                     (const RespScanThreadResult   *message);
+size_t resp_scan_thread_result__pack
+                     (const RespScanThreadResult   *message,
                       uint8_t             *out);
-size_t resp_scan_result__pack_to_buffer
-                     (const RespScanResult   *message,
+size_t resp_scan_thread_result__pack_to_buffer
+                     (const RespScanThreadResult   *message,
                       ProtobufCBuffer     *buffer);
-RespScanResult *
-       resp_scan_result__unpack
+RespScanThreadResult *
+       resp_scan_thread_result__unpack
                      (ProtobufCAllocator  *allocator,
                       size_t               len,
                       const uint8_t       *data);
-void   resp_scan_result__free_unpacked
-                     (RespScanResult *message,
+void   resp_scan_thread_result__free_unpacked
+                     (RespScanThreadResult *message,
                       ProtobufCAllocator *allocator);
 /* NetworkScanPayload methods */
 void   network_scan_payload__init
@@ -459,38 +540,47 @@ void   network_scan_payload__free_unpacked
                       ProtobufCAllocator *allocator);
 /* --- per-message closures --- */
 
-typedef void (*WifiScanStart_Closure)
-                 (const WifiScanStart *message,
+typedef void (*CmdScanWifiStart_Closure)
+                 (const CmdScanWifiStart *message,
                   void *closure_data);
-typedef void (*ThreadScanStart_Closure)
-                 (const ThreadScanStart *message,
+typedef void (*CmdScanThreadStart_Closure)
+                 (const CmdScanThreadStart *message,
                   void *closure_data);
-typedef void (*CmdScanStart_Closure)
-                 (const CmdScanStart *message,
+typedef void (*RespScanWifiStart_Closure)
+                 (const RespScanWifiStart *message,
                   void *closure_data);
-typedef void (*RespScanStart_Closure)
-                 (const RespScanStart *message,
+typedef void (*RespScanThreadStart_Closure)
+                 (const RespScanThreadStart *message,
                   void *closure_data);
-typedef void (*CmdScanStatus_Closure)
-                 (const CmdScanStatus *message,
+typedef void (*CmdScanWifiStatus_Closure)
+                 (const CmdScanWifiStatus *message,
                   void *closure_data);
-typedef void (*RespScanStatus_Closure)
-                 (const RespScanStatus *message,
+typedef void (*CmdScanThreadStatus_Closure)
+                 (const CmdScanThreadStatus *message,
                   void *closure_data);
-typedef void (*CmdScanResult_Closure)
-                 (const CmdScanResult *message,
+typedef void (*RespScanWifiStatus_Closure)
+                 (const RespScanWifiStatus *message,
                   void *closure_data);
-typedef void (*WifiScanResult_Closure)
-                 (const WifiScanResult *message,
+typedef void (*RespScanThreadStatus_Closure)
+                 (const RespScanThreadStatus *message,
+                  void *closure_data);
+typedef void (*CmdScanWifiResult_Closure)
+                 (const CmdScanWifiResult *message,
+                  void *closure_data);
+typedef void (*CmdScanThreadResult_Closure)
+                 (const CmdScanThreadResult *message,
+                  void *closure_data);
+typedef void (*WiFiScanResult_Closure)
+                 (const WiFiScanResult *message,
                   void *closure_data);
 typedef void (*ThreadScanResult_Closure)
                  (const ThreadScanResult *message,
                   void *closure_data);
-typedef void (*ScanResult_Closure)
-                 (const ScanResult *message,
+typedef void (*RespScanWifiResult_Closure)
+                 (const RespScanWifiResult *message,
                   void *closure_data);
-typedef void (*RespScanResult_Closure)
-                 (const RespScanResult *message,
+typedef void (*RespScanThreadResult_Closure)
+                 (const RespScanThreadResult *message,
                   void *closure_data);
 typedef void (*NetworkScanPayload_Closure)
                  (const NetworkScanPayload *message,
@@ -502,17 +592,20 @@ typedef void (*NetworkScanPayload_Closure)
 /* --- descriptors --- */
 
 extern const ProtobufCEnumDescriptor    network_scan_msg_type__descriptor;
-extern const ProtobufCMessageDescriptor wifi_scan_start__descriptor;
-extern const ProtobufCMessageDescriptor thread_scan_start__descriptor;
-extern const ProtobufCMessageDescriptor cmd_scan_start__descriptor;
-extern const ProtobufCMessageDescriptor resp_scan_start__descriptor;
-extern const ProtobufCMessageDescriptor cmd_scan_status__descriptor;
-extern const ProtobufCMessageDescriptor resp_scan_status__descriptor;
-extern const ProtobufCMessageDescriptor cmd_scan_result__descriptor;
-extern const ProtobufCMessageDescriptor wifi_scan_result__descriptor;
+extern const ProtobufCMessageDescriptor cmd_scan_wifi_start__descriptor;
+extern const ProtobufCMessageDescriptor cmd_scan_thread_start__descriptor;
+extern const ProtobufCMessageDescriptor resp_scan_wifi_start__descriptor;
+extern const ProtobufCMessageDescriptor resp_scan_thread_start__descriptor;
+extern const ProtobufCMessageDescriptor cmd_scan_wifi_status__descriptor;
+extern const ProtobufCMessageDescriptor cmd_scan_thread_status__descriptor;
+extern const ProtobufCMessageDescriptor resp_scan_wifi_status__descriptor;
+extern const ProtobufCMessageDescriptor resp_scan_thread_status__descriptor;
+extern const ProtobufCMessageDescriptor cmd_scan_wifi_result__descriptor;
+extern const ProtobufCMessageDescriptor cmd_scan_thread_result__descriptor;
+extern const ProtobufCMessageDescriptor wi_fi_scan_result__descriptor;
 extern const ProtobufCMessageDescriptor thread_scan_result__descriptor;
-extern const ProtobufCMessageDescriptor scan_result__descriptor;
-extern const ProtobufCMessageDescriptor resp_scan_result__descriptor;
+extern const ProtobufCMessageDescriptor resp_scan_wifi_result__descriptor;
+extern const ProtobufCMessageDescriptor resp_scan_thread_result__descriptor;
 extern const ProtobufCMessageDescriptor network_scan_payload__descriptor;
 
 PROTOBUF_C__END_DECLS

--- a/network_provisioning/proto/network_config.proto
+++ b/network_provisioning/proto/network_config.proto
@@ -3,75 +3,93 @@ syntax = "proto3";
 import "constants.proto";
 import "network_constants.proto";
 
-message CmdGetStatus {
-    NetworkType net_type = 1;
+message CmdGetWifiStatus {
 }
 
-message RespGetStatus {
-    NetworkType net_type = 1;
-    Status status = 2;
-    oneof payload {
-        WifiStationState wifi_sta_state = 10;
-        ThreadNetworkState thread_state = 11;
-    }
+message RespGetWifiStatus {
+    Status status = 1;
+    WifiStationState wifi_sta_state = 2;
     oneof state {
-        WifiConnectFailedReason wifi_fail_reason = 20;
-        WifiConnectedState wifi_connected = 21;
-        ThreadAttachFailedReason thread_fail_reason = 22;
-        ThreadAttachState thread_attached = 23;
+        WifiConnectFailedReason wifi_fail_reason = 10;
+        WifiConnectedState wifi_connected = 11;
     }
 }
 
-message WifiSetConfig {
+message CmdGetThreadStatus {
+}
+
+message RespGetThreadStatus {
+    Status status = 1;
+    ThreadNetworkState thread_state = 2;
+    oneof state {
+        ThreadAttachFailedReason thread_fail_reason = 10;
+        ThreadAttachState thread_attached = 11;
+    }
+}
+
+message CmdSetWifiConfig {
     bytes ssid = 1;
     bytes passphrase = 2;
     bytes bssid = 3;
     int32 channel = 4;
 }
 
-message ThreadSetConfig {
+message CmdSetThreadConfig {
     bytes dataset = 1;
 }
 
-message CmdSetConfig {
-    NetworkType net_type = 1;
-    oneof payload {
-        WifiSetConfig wifi_config = 10;
-        ThreadSetConfig thread_config = 11;
-    }
+message RespSetWifiConfig {
+    Status status = 1;
 }
 
-message RespSetConfig {
-    NetworkType net_type = 1;
-    Status status = 2;
+message RespSetThreadConfig {
+    Status status = 1;
 }
 
-message CmdApplyConfig {
-    NetworkType net_type = 1;
+message CmdApplyWifiConfig {
 }
 
-message RespApplyConfig {
-    NetworkType net_type = 1;
-    Status status = 2;
+message CmdApplyThreadConfig {
+}
+
+message RespApplyWifiConfig {
+    Status status = 1;
+}
+
+message RespApplyThreadConfig {
+    Status status = 1;
 }
 
 enum NetworkConfigMsgType {
-    TypeCmdGetStatus = 0;
-    TypeRespGetStatus = 1;
-    TypeCmdSetConfig = 2;
-    TypeRespSetConfig = 3;
-    TypeCmdApplyConfig = 4;
-    TypeRespApplyConfig = 5;
+    TypeCmdGetWifiStatus = 0;
+    TypeRespGetWifiStatus = 1;
+    TypeCmdSetWifiConfig = 2;
+    TypeRespSetWifiConfig = 3;
+    TypeCmdApplyWifiConfig = 4;
+    TypeRespApplyWifiConfig = 5;
+    TypeCmdGetThreadStatus = 6;
+    TypeRespGetThreadStatus = 7;
+    TypeCmdSetThreadConfig = 8;
+    TypeRespSetThreadConfig = 9;
+    TypeCmdApplyThreadConfig = 10;
+    TypeRespApplyThreadConfig = 11;
+
 }
 
 message NetworkConfigPayload {
     NetworkConfigMsgType msg = 1;
     oneof payload {
-        CmdGetStatus cmd_get_status = 10;
-        RespGetStatus resp_get_status = 11;
-        CmdSetConfig cmd_set_config = 12;
-        RespSetConfig resp_set_config = 13;
-        CmdApplyConfig cmd_apply_config = 14;
-        RespApplyConfig resp_apply_config = 15;
+        CmdGetWifiStatus cmd_get_wifi_status = 10;
+        RespGetWifiStatus resp_get_wifi_status = 11;
+        CmdSetWifiConfig cmd_set_wifi_config = 12;
+        RespSetWifiConfig resp_set_wifi_config = 13;
+        CmdApplyWifiConfig cmd_apply_wifi_config = 14;
+        RespApplyWifiConfig resp_apply_wifi_config = 15;
+        CmdGetThreadStatus cmd_get_thread_status = 16;
+        RespGetThreadStatus resp_get_thread_status = 17;
+        CmdSetThreadConfig cmd_set_thread_config = 18;
+        RespSetThreadConfig resp_set_thread_config = 19;
+        CmdApplyThreadConfig cmd_apply_thread_config = 20;
+        RespApplyThreadConfig resp_apply_thread_config = 21;
     }
 }

--- a/network_provisioning/proto/network_constants.proto
+++ b/network_provisioning/proto/network_constants.proto
@@ -1,10 +1,5 @@
 syntax = "proto3";
 
-enum NetworkType {
-    WifiNetwork = 0;
-    ThreadNetwork = 1;
-}
-
 enum WifiStationState {
     Connected = 0;
     Connecting = 1;

--- a/network_provisioning/proto/network_ctrl.proto
+++ b/network_provisioning/proto/network_ctrl.proto
@@ -1,39 +1,55 @@
 syntax = "proto3";
 
 import "constants.proto";
-import "network_constants.proto";
 
-message CmdCtrlReset {
-    NetworkType net_type = 1;
+message CmdCtrlWifiReset {
 }
 
-message RespCtrlReset {
-    NetworkType net_type = 1;
+message RespCtrlWifiReset {
 }
 
-message CmdCtrlReprov {
-    NetworkType net_type = 1;
+message CmdCtrlWifiReprov {
 }
 
-message RespCtrlReprov{
-    NetworkType net_type = 1;
+message RespCtrlWifiReprov{
+}
+
+message CmdCtrlThreadReset {
+}
+
+message RespCtrlThreadReset {
+}
+
+message CmdCtrlThreadReprov {
+}
+
+message RespCtrlThreadReprov{
 }
 
 enum NetworkCtrlMsgType {
     TypeCtrlReserved = 0;
-    TypeCmdCtrlReset = 1;
-    TypeRespCtrlReset = 2;
-    TypeCmdCtrlReprov = 3;
-    TypeRespCtrlReprov = 4;
+    TypeCmdCtrlWifiReset = 1;
+    TypeRespCtrlWifiReset = 2;
+    TypeCmdCtrlWifiReprov = 3;
+    TypeRespCtrlWifiReprov = 4;
+    TypeCmdCtrlThreadReset = 5;
+    TypeRespCtrlThreadReset = 6;
+    TypeCmdCtrlThreadReprov = 7;
+    TypeRespCtrlThreadReprov = 8;
+
 }
 
 message NetworkCtrlPayload {
     NetworkCtrlMsgType msg = 1;
     Status status = 2;
     oneof payload {
-        CmdCtrlReset cmd_ctrl_reset = 11;
-        RespCtrlReset resp_ctrl_reset = 12;
-        CmdCtrlReprov cmd_ctrl_reprov = 13;
-        RespCtrlReprov resp_ctrl_reprov = 14;
+        CmdCtrlWifiReset cmd_ctrl_wifi_reset = 11;
+        RespCtrlWifiReset resp_ctrl_wifi_reset = 12;
+        CmdCtrlWifiReprov cmd_ctrl_wifi_reprov = 13;
+        RespCtrlWifiReprov resp_ctrl_wifi_reprov = 14;
+        CmdCtrlThreadReset cmd_ctrl_thread_reset = 15;
+        RespCtrlThreadReset resp_ctrl_thread_reset = 16;
+        CmdCtrlThreadReprov cmd_ctrl_thread_reprov = 17;
+        RespCtrlThreadReprov resp_ctrl_thread_reprov = 18;
     }
 }

--- a/network_provisioning/proto/network_scan.proto
+++ b/network_provisioning/proto/network_scan.proto
@@ -3,47 +3,51 @@ syntax = "proto3";
 import "constants.proto";
 import "network_constants.proto";
 
-message WifiScanStart {
+message CmdScanWifiStart {
     bool blocking = 1;
     bool passive = 2;
     uint32 group_channels = 3;
     uint32 period_ms = 4;
 }
 
-message ThreadScanStart {
+message CmdScanThreadStart {
     bool blocking = 1;
     uint32 channel_mask = 2;
 }
 
-message CmdScanStart {
-    NetworkType net_type = 1;
-    oneof payload {
-        WifiScanStart wifi_scan_start = 10;
-        ThreadScanStart thread_scan_start = 11;
-    }
+message RespScanWifiStart {
 }
 
-message RespScanStart {
-    NetworkType net_type = 1;
+message RespScanThreadStart {
 }
 
-message CmdScanStatus {
-    NetworkType net_type = 1;
+message CmdScanWifiStatus {
 }
 
-message RespScanStatus {
-    NetworkType net_type = 1;
-    bool scan_finished = 2;
-    uint32 result_count = 3;
+message CmdScanThreadStatus {
 }
 
-message CmdScanResult {
-    NetworkType net_type = 1;
-    uint32 start_index = 2;
-    uint32 count = 3;
+message RespScanWifiStatus {
+    bool scan_finished = 1;
+    uint32 result_count = 2;
 }
 
-message WifiScanResult {
+message RespScanThreadStatus {
+    bool scan_finished = 1;
+    uint32 result_count = 2;
+}
+
+message CmdScanWifiResult {
+    uint32 start_index = 1;
+    uint32 count = 2;
+}
+
+message CmdScanThreadResult {
+    uint32 start_index = 1;
+    uint32 count = 2;
+}
+
+message WiFiScanResult {
     bytes ssid = 1;
     uint32 channel = 2;
     int32 rssi = 3;
@@ -61,36 +65,45 @@ message ThreadScanResult {
     bytes ext_pan_id = 7;
 }
 
-message ScanResult {
-    oneof result {
-        WifiScanResult  wifi_result= 10;
-        ThreadScanResult thread_result = 11;
-    }
+message RespScanWifiResult {
+    repeated WiFiScanResult entries = 1;
 }
 
-message RespScanResult {
-    NetworkType net_type = 1;
-    repeated ScanResult entries = 2;
+message RespScanThreadResult {
+    repeated ThreadScanResult entries = 1;
 }
+
 
 enum NetworkScanMsgType {
-    TypeCmdScanStart = 0;
-    TypeRespScanStart = 1;
-    TypeCmdScanStatus = 2;
-    TypeRespScanStatus = 3;
-    TypeCmdScanResult = 4;
-    TypeRespScanResult = 5;
+    TypeCmdScanWifiStart = 0;
+    TypeRespScanWifiStart = 1;
+    TypeCmdScanWifiStatus = 2;
+    TypeRespScanWifiStatus = 3;
+    TypeCmdScanWifiResult = 4;
+    TypeRespScanWifiResult = 5;
+    TypeCmdScanThreadStart = 6;
+    TypeRespScanThreadStart = 7;
+    TypeCmdScanThreadStatus = 8;
+    TypeRespScanThreadStatus = 9;
+    TypeCmdScanThreadResult = 10;
+    TypeRespScanThreadResult = 11;
 }
 
 message NetworkScanPayload {
     NetworkScanMsgType msg = 1;
     Status status = 2;
     oneof payload {
-        CmdScanStart cmd_scan_start = 10;
-        RespScanStart resp_scan_start = 11;
-        CmdScanStatus cmd_scan_status = 12;
-        RespScanStatus resp_scan_status = 13;
-        CmdScanResult cmd_scan_result = 14;
-        RespScanResult resp_scan_result = 15;
+        CmdScanWifiStart cmd_scan_wifi_start = 10;
+        RespScanWifiStart resp_scan_wifi_start = 11;
+        CmdScanWifiStatus cmd_scan_wifi_status = 12;
+        RespScanWifiStatus resp_scan_wifi_status = 13;
+        CmdScanWifiResult cmd_scan_wifi_result = 14;
+        RespScanWifiResult resp_scan_wifi_result = 15;
+        CmdScanThreadStart cmd_scan_thread_start = 16;
+        RespScanThreadStart resp_scan_thread_start = 17;
+        CmdScanThreadStatus cmd_scan_thread_status = 18;
+        RespScanThreadStatus resp_scan_thread_status = 19;
+        CmdScanThreadResult cmd_scan_thread_result = 20;
+        RespScanThreadResult resp_scan_thread_result = 21;
     }
 }

--- a/network_provisioning/python/network_config_pb2.py
+++ b/network_provisioning/python/network_config_pb2.py
@@ -15,31 +15,39 @@ import constants_pb2 as constants__pb2
 import network_constants_pb2 as network__constants__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14network_config.proto\x1a\x0f\x63onstants.proto\x1a\x17network_constants.proto\".\n\x0c\x43mdGetStatus\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\"\x83\x03\n\rRespGetStatus\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\x12\x17\n\x06status\x18\x02 \x01(\x0e\x32\x07.Status\x12+\n\x0ewifi_sta_state\x18\n \x01(\x0e\x32\x11.WifiStationStateH\x00\x12+\n\x0cthread_state\x18\x0b \x01(\x0e\x32\x13.ThreadNetworkStateH\x00\x12\x34\n\x10wifi_fail_reason\x18\x14 \x01(\x0e\x32\x18.WifiConnectFailedReasonH\x01\x12-\n\x0ewifi_connected\x18\x15 \x01(\x0b\x32\x13.WifiConnectedStateH\x01\x12\x37\n\x12thread_fail_reason\x18\x16 \x01(\x0e\x32\x19.ThreadAttachFailedReasonH\x01\x12-\n\x0fthread_attached\x18\x17 \x01(\x0b\x32\x12.ThreadAttachStateH\x01\x42\t\n\x07payloadB\x07\n\x05state\"Q\n\rWifiSetConfig\x12\x0c\n\x04ssid\x18\x01 \x01(\x0c\x12\x12\n\npassphrase\x18\x02 \x01(\x0c\x12\r\n\x05\x62ssid\x18\x03 \x01(\x0c\x12\x0f\n\x07\x63hannel\x18\x04 \x01(\x05\"\"\n\x0fThreadSetConfig\x12\x0f\n\x07\x64\x61taset\x18\x01 \x01(\x0c\"\x8b\x01\n\x0c\x43mdSetConfig\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\x12%\n\x0bwifi_config\x18\n \x01(\x0b\x32\x0e.WifiSetConfigH\x00\x12)\n\rthread_config\x18\x0b \x01(\x0b\x32\x10.ThreadSetConfigH\x00\x42\t\n\x07payload\"H\n\rRespSetConfig\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\x12\x17\n\x06status\x18\x02 \x01(\x0e\x32\x07.Status\"0\n\x0e\x43mdApplyConfig\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\"J\n\x0fRespApplyConfig\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\x12\x17\n\x06status\x18\x02 \x01(\x0e\x32\x07.Status\"\xc9\x02\n\x14NetworkConfigPayload\x12\"\n\x03msg\x18\x01 \x01(\x0e\x32\x15.NetworkConfigMsgType\x12\'\n\x0e\x63md_get_status\x18\n \x01(\x0b\x32\r.CmdGetStatusH\x00\x12)\n\x0fresp_get_status\x18\x0b \x01(\x0b\x32\x0e.RespGetStatusH\x00\x12\'\n\x0e\x63md_set_config\x18\x0c \x01(\x0b\x32\r.CmdSetConfigH\x00\x12)\n\x0fresp_set_config\x18\r \x01(\x0b\x32\x0e.RespSetConfigH\x00\x12+\n\x10\x63md_apply_config\x18\x0e \x01(\x0b\x32\x0f.CmdApplyConfigH\x00\x12-\n\x11resp_apply_config\x18\x0f \x01(\x0b\x32\x10.RespApplyConfigH\x00\x42\t\n\x07payload*\xa1\x01\n\x14NetworkConfigMsgType\x12\x14\n\x10TypeCmdGetStatus\x10\x00\x12\x15\n\x11TypeRespGetStatus\x10\x01\x12\x14\n\x10TypeCmdSetConfig\x10\x02\x12\x15\n\x11TypeRespSetConfig\x10\x03\x12\x16\n\x12TypeCmdApplyConfig\x10\x04\x12\x17\n\x13TypeRespApplyConfig\x10\x05\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14network_config.proto\x1a\x0f\x63onstants.proto\x1a\x17network_constants.proto\"\x12\n\x10\x43mdGetWifiStatus\"\xc5\x01\n\x11RespGetWifiStatus\x12\x17\n\x06status\x18\x01 \x01(\x0e\x32\x07.Status\x12)\n\x0ewifi_sta_state\x18\x02 \x01(\x0e\x32\x11.WifiStationState\x12\x34\n\x10wifi_fail_reason\x18\n \x01(\x0e\x32\x18.WifiConnectFailedReasonH\x00\x12-\n\x0ewifi_connected\x18\x0b \x01(\x0b\x32\x13.WifiConnectedStateH\x00\x42\x07\n\x05state\"\x14\n\x12\x43mdGetThreadStatus\"\xca\x01\n\x13RespGetThreadStatus\x12\x17\n\x06status\x18\x01 \x01(\x0e\x32\x07.Status\x12)\n\x0cthread_state\x18\x02 \x01(\x0e\x32\x13.ThreadNetworkState\x12\x37\n\x12thread_fail_reason\x18\n \x01(\x0e\x32\x19.ThreadAttachFailedReasonH\x00\x12-\n\x0fthread_attached\x18\x0b \x01(\x0b\x32\x12.ThreadAttachStateH\x00\x42\x07\n\x05state\"T\n\x10\x43mdSetWifiConfig\x12\x0c\n\x04ssid\x18\x01 \x01(\x0c\x12\x12\n\npassphrase\x18\x02 \x01(\x0c\x12\r\n\x05\x62ssid\x18\x03 \x01(\x0c\x12\x0f\n\x07\x63hannel\x18\x04 \x01(\x05\"%\n\x12\x43mdSetThreadConfig\x12\x0f\n\x07\x64\x61taset\x18\x01 \x01(\x0c\",\n\x11RespSetWifiConfig\x12\x17\n\x06status\x18\x01 \x01(\x0e\x32\x07.Status\".\n\x13RespSetThreadConfig\x12\x17\n\x06status\x18\x01 \x01(\x0e\x32\x07.Status\"\x14\n\x12\x43mdApplyWifiConfig\"\x16\n\x14\x43mdApplyThreadConfig\".\n\x13RespApplyWifiConfig\x12\x17\n\x06status\x18\x01 \x01(\x0e\x32\x07.Status\"0\n\x15RespApplyThreadConfig\x12\x17\n\x06status\x18\x01 \x01(\x0e\x32\x07.Status\"\xd1\x05\n\x14NetworkConfigPayload\x12\"\n\x03msg\x18\x01 \x01(\x0e\x32\x15.NetworkConfigMsgType\x12\x30\n\x13\x63md_get_wifi_status\x18\n \x01(\x0b\x32\x11.CmdGetWifiStatusH\x00\x12\x32\n\x14resp_get_wifi_status\x18\x0b \x01(\x0b\x32\x12.RespGetWifiStatusH\x00\x12\x30\n\x13\x63md_set_wifi_config\x18\x0c \x01(\x0b\x32\x11.CmdSetWifiConfigH\x00\x12\x32\n\x14resp_set_wifi_config\x18\r \x01(\x0b\x32\x12.RespSetWifiConfigH\x00\x12\x34\n\x15\x63md_apply_wifi_config\x18\x0e \x01(\x0b\x32\x13.CmdApplyWifiConfigH\x00\x12\x36\n\x16resp_apply_wifi_config\x18\x0f \x01(\x0b\x32\x14.RespApplyWifiConfigH\x00\x12\x34\n\x15\x63md_get_thread_status\x18\x10 \x01(\x0b\x32\x13.CmdGetThreadStatusH\x00\x12\x36\n\x16resp_get_thread_status\x18\x11 \x01(\x0b\x32\x14.RespGetThreadStatusH\x00\x12\x34\n\x15\x63md_set_thread_config\x18\x12 \x01(\x0b\x32\x13.CmdSetThreadConfigH\x00\x12\x36\n\x16resp_set_thread_config\x18\x13 \x01(\x0b\x32\x14.RespSetThreadConfigH\x00\x12\x38\n\x17\x63md_apply_thread_config\x18\x14 \x01(\x0b\x32\x15.CmdApplyThreadConfigH\x00\x12:\n\x18resp_apply_thread_config\x18\x15 \x01(\x0b\x32\x16.RespApplyThreadConfigH\x00\x42\t\n\x07payload*\xe8\x02\n\x14NetworkConfigMsgType\x12\x18\n\x14TypeCmdGetWifiStatus\x10\x00\x12\x19\n\x15TypeRespGetWifiStatus\x10\x01\x12\x18\n\x14TypeCmdSetWifiConfig\x10\x02\x12\x19\n\x15TypeRespSetWifiConfig\x10\x03\x12\x1a\n\x16TypeCmdApplyWifiConfig\x10\x04\x12\x1b\n\x17TypeRespApplyWifiConfig\x10\x05\x12\x1a\n\x16TypeCmdGetThreadStatus\x10\x06\x12\x1b\n\x17TypeRespGetThreadStatus\x10\x07\x12\x1a\n\x16TypeCmdSetThreadConfig\x10\x08\x12\x1b\n\x17TypeRespSetThreadConfig\x10\t\x12\x1c\n\x18TypeCmdApplyThreadConfig\x10\n\x12\x1d\n\x19TypeRespApplyThreadConfig\x10\x0b\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'network_config_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _NETWORKCONFIGMSGTYPE._serialized_start=1298
-  _NETWORKCONFIGMSGTYPE._serialized_end=1459
-  _CMDGETSTATUS._serialized_start=66
-  _CMDGETSTATUS._serialized_end=112
-  _RESPGETSTATUS._serialized_start=115
-  _RESPGETSTATUS._serialized_end=502
-  _WIFISETCONFIG._serialized_start=504
-  _WIFISETCONFIG._serialized_end=585
-  _THREADSETCONFIG._serialized_start=587
-  _THREADSETCONFIG._serialized_end=621
-  _CMDSETCONFIG._serialized_start=624
-  _CMDSETCONFIG._serialized_end=763
-  _RESPSETCONFIG._serialized_start=765
-  _RESPSETCONFIG._serialized_end=837
-  _CMDAPPLYCONFIG._serialized_start=839
-  _CMDAPPLYCONFIG._serialized_end=887
-  _RESPAPPLYCONFIG._serialized_start=889
-  _RESPAPPLYCONFIG._serialized_end=963
-  _NETWORKCONFIGPAYLOAD._serialized_start=966
-  _NETWORKCONFIGPAYLOAD._serialized_end=1295
+  _NETWORKCONFIGMSGTYPE._serialized_start=1601
+  _NETWORKCONFIGMSGTYPE._serialized_end=1961
+  _CMDGETWIFISTATUS._serialized_start=66
+  _CMDGETWIFISTATUS._serialized_end=84
+  _RESPGETWIFISTATUS._serialized_start=87
+  _RESPGETWIFISTATUS._serialized_end=284
+  _CMDGETTHREADSTATUS._serialized_start=286
+  _CMDGETTHREADSTATUS._serialized_end=306
+  _RESPGETTHREADSTATUS._serialized_start=309
+  _RESPGETTHREADSTATUS._serialized_end=511
+  _CMDSETWIFICONFIG._serialized_start=513
+  _CMDSETWIFICONFIG._serialized_end=597
+  _CMDSETTHREADCONFIG._serialized_start=599
+  _CMDSETTHREADCONFIG._serialized_end=636
+  _RESPSETWIFICONFIG._serialized_start=638
+  _RESPSETWIFICONFIG._serialized_end=682
+  _RESPSETTHREADCONFIG._serialized_start=684
+  _RESPSETTHREADCONFIG._serialized_end=730
+  _CMDAPPLYWIFICONFIG._serialized_start=732
+  _CMDAPPLYWIFICONFIG._serialized_end=752
+  _CMDAPPLYTHREADCONFIG._serialized_start=754
+  _CMDAPPLYTHREADCONFIG._serialized_end=776
+  _RESPAPPLYWIFICONFIG._serialized_start=778
+  _RESPAPPLYWIFICONFIG._serialized_end=824
+  _RESPAPPLYTHREADCONFIG._serialized_start=826
+  _RESPAPPLYTHREADCONFIG._serialized_end=874
+  _NETWORKCONFIGPAYLOAD._serialized_start=877
+  _NETWORKCONFIGPAYLOAD._serialized_end=1598
 # @@protoc_insertion_point(module_scope)

--- a/network_provisioning/python/network_constants_pb2.py
+++ b/network_provisioning/python/network_constants_pb2.py
@@ -13,25 +13,23 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x17network_constants.proto\"v\n\x12WifiConnectedState\x12\x10\n\x08ip4_addr\x18\x01 \x01(\t\x12 \n\tauth_mode\x18\x02 \x01(\x0e\x32\r.WifiAuthMode\x12\x0c\n\x04ssid\x18\x03 \x01(\x0c\x12\r\n\x05\x62ssid\x18\x04 \x01(\x0c\x12\x0f\n\x07\x63hannel\x18\x05 \x01(\x05\"V\n\x11ThreadAttachState\x12\x0e\n\x06pan_id\x18\x01 \x01(\r\x12\x12\n\next_pan_id\x18\x02 \x01(\x0c\x12\x0f\n\x07\x63hannel\x18\x03 \x01(\r\x12\x0c\n\x04name\x18\x04 \x01(\t*1\n\x0bNetworkType\x12\x0f\n\x0bWifiNetwork\x10\x00\x12\x11\n\rThreadNetwork\x10\x01*Y\n\x10WifiStationState\x12\r\n\tConnected\x10\x00\x12\x0e\n\nConnecting\x10\x01\x12\x10\n\x0c\x44isconnected\x10\x02\x12\x14\n\x10\x43onnectionFailed\x10\x03*A\n\x17WifiConnectFailedReason\x12\r\n\tAuthError\x10\x00\x12\x17\n\x13WifiNetworkNotFound\x10\x01*\x84\x01\n\x0cWifiAuthMode\x12\x08\n\x04Open\x10\x00\x12\x07\n\x03WEP\x10\x01\x12\x0b\n\x07WPA_PSK\x10\x02\x12\x0c\n\x08WPA2_PSK\x10\x03\x12\x10\n\x0cWPA_WPA2_PSK\x10\x04\x12\x13\n\x0fWPA2_ENTERPRISE\x10\x05\x12\x0c\n\x08WPA3_PSK\x10\x06\x12\x11\n\rWPA2_WPA3_PSK\x10\x07*U\n\x12ThreadNetworkState\x12\x0c\n\x08\x41ttached\x10\x00\x12\r\n\tAttaching\x10\x01\x12\r\n\tDettached\x10\x02\x12\x13\n\x0f\x41ttachingFailed\x10\x03*I\n\x18ThreadAttachFailedReason\x12\x12\n\x0e\x44\x61tasetInvalid\x10\x00\x12\x19\n\x15ThreadNetworkNotFound\x10\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x17network_constants.proto\"v\n\x12WifiConnectedState\x12\x10\n\x08ip4_addr\x18\x01 \x01(\t\x12 \n\tauth_mode\x18\x02 \x01(\x0e\x32\r.WifiAuthMode\x12\x0c\n\x04ssid\x18\x03 \x01(\x0c\x12\r\n\x05\x62ssid\x18\x04 \x01(\x0c\x12\x0f\n\x07\x63hannel\x18\x05 \x01(\x05\"V\n\x11ThreadAttachState\x12\x0e\n\x06pan_id\x18\x01 \x01(\r\x12\x12\n\next_pan_id\x18\x02 \x01(\x0c\x12\x0f\n\x07\x63hannel\x18\x03 \x01(\r\x12\x0c\n\x04name\x18\x04 \x01(\t*Y\n\x10WifiStationState\x12\r\n\tConnected\x10\x00\x12\x0e\n\nConnecting\x10\x01\x12\x10\n\x0c\x44isconnected\x10\x02\x12\x14\n\x10\x43onnectionFailed\x10\x03*A\n\x17WifiConnectFailedReason\x12\r\n\tAuthError\x10\x00\x12\x17\n\x13WifiNetworkNotFound\x10\x01*\x84\x01\n\x0cWifiAuthMode\x12\x08\n\x04Open\x10\x00\x12\x07\n\x03WEP\x10\x01\x12\x0b\n\x07WPA_PSK\x10\x02\x12\x0c\n\x08WPA2_PSK\x10\x03\x12\x10\n\x0cWPA_WPA2_PSK\x10\x04\x12\x13\n\x0fWPA2_ENTERPRISE\x10\x05\x12\x0c\n\x08WPA3_PSK\x10\x06\x12\x11\n\rWPA2_WPA3_PSK\x10\x07*U\n\x12ThreadNetworkState\x12\x0c\n\x08\x41ttached\x10\x00\x12\r\n\tAttaching\x10\x01\x12\r\n\tDettached\x10\x02\x12\x13\n\x0f\x41ttachingFailed\x10\x03*I\n\x18ThreadAttachFailedReason\x12\x12\n\x0e\x44\x61tasetInvalid\x10\x00\x12\x19\n\x15ThreadNetworkNotFound\x10\x01\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'network_constants_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _NETWORKTYPE._serialized_start=235
-  _NETWORKTYPE._serialized_end=284
-  _WIFISTATIONSTATE._serialized_start=286
-  _WIFISTATIONSTATE._serialized_end=375
-  _WIFICONNECTFAILEDREASON._serialized_start=377
-  _WIFICONNECTFAILEDREASON._serialized_end=442
-  _WIFIAUTHMODE._serialized_start=445
-  _WIFIAUTHMODE._serialized_end=577
-  _THREADNETWORKSTATE._serialized_start=579
-  _THREADNETWORKSTATE._serialized_end=664
-  _THREADATTACHFAILEDREASON._serialized_start=666
-  _THREADATTACHFAILEDREASON._serialized_end=739
+  _WIFISTATIONSTATE._serialized_start=235
+  _WIFISTATIONSTATE._serialized_end=324
+  _WIFICONNECTFAILEDREASON._serialized_start=326
+  _WIFICONNECTFAILEDREASON._serialized_end=391
+  _WIFIAUTHMODE._serialized_start=394
+  _WIFIAUTHMODE._serialized_end=526
+  _THREADNETWORKSTATE._serialized_start=528
+  _THREADNETWORKSTATE._serialized_end=613
+  _THREADATTACHFAILEDREASON._serialized_start=615
+  _THREADATTACHFAILEDREASON._serialized_end=688
   _WIFICONNECTEDSTATE._serialized_start=27
   _WIFICONNECTEDSTATE._serialized_end=145
   _THREADATTACHSTATE._serialized_start=147

--- a/network_provisioning/python/network_ctrl_pb2.py
+++ b/network_provisioning/python/network_ctrl_pb2.py
@@ -12,26 +12,33 @@ _sym_db = _symbol_database.Default()
 
 
 import constants_pb2 as constants__pb2
-import network_constants_pb2 as network__constants__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12network_ctrl.proto\x1a\x0f\x63onstants.proto\x1a\x17network_constants.proto\".\n\x0c\x43mdCtrlReset\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\"/\n\rRespCtrlReset\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\"/\n\rCmdCtrlReprov\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\"0\n\x0eRespCtrlReprov\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\"\x86\x02\n\x12NetworkCtrlPayload\x12 \n\x03msg\x18\x01 \x01(\x0e\x32\x13.NetworkCtrlMsgType\x12\x17\n\x06status\x18\x02 \x01(\x0e\x32\x07.Status\x12\'\n\x0e\x63md_ctrl_reset\x18\x0b \x01(\x0b\x32\r.CmdCtrlResetH\x00\x12)\n\x0fresp_ctrl_reset\x18\x0c \x01(\x0b\x32\x0e.RespCtrlResetH\x00\x12)\n\x0f\x63md_ctrl_reprov\x18\r \x01(\x0b\x32\x0e.CmdCtrlReprovH\x00\x12+\n\x10resp_ctrl_reprov\x18\x0e \x01(\x0b\x32\x0f.RespCtrlReprovH\x00\x42\t\n\x07payload*\x86\x01\n\x12NetworkCtrlMsgType\x12\x14\n\x10TypeCtrlReserved\x10\x00\x12\x14\n\x10TypeCmdCtrlReset\x10\x01\x12\x15\n\x11TypeRespCtrlReset\x10\x02\x12\x15\n\x11TypeCmdCtrlReprov\x10\x03\x12\x16\n\x12TypeRespCtrlReprov\x10\x04\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12network_ctrl.proto\x1a\x0f\x63onstants.proto\"\x12\n\x10\x43mdCtrlWifiReset\"\x13\n\x11RespCtrlWifiReset\"\x13\n\x11\x43mdCtrlWifiReprov\"\x14\n\x12RespCtrlWifiReprov\"\x14\n\x12\x43mdCtrlThreadReset\"\x15\n\x13RespCtrlThreadReset\"\x15\n\x13\x43mdCtrlThreadReprov\"\x16\n\x14RespCtrlThreadReprov\"\x8a\x04\n\x12NetworkCtrlPayload\x12 \n\x03msg\x18\x01 \x01(\x0e\x32\x13.NetworkCtrlMsgType\x12\x17\n\x06status\x18\x02 \x01(\x0e\x32\x07.Status\x12\x30\n\x13\x63md_ctrl_wifi_reset\x18\x0b \x01(\x0b\x32\x11.CmdCtrlWifiResetH\x00\x12\x32\n\x14resp_ctrl_wifi_reset\x18\x0c \x01(\x0b\x32\x12.RespCtrlWifiResetH\x00\x12\x32\n\x14\x63md_ctrl_wifi_reprov\x18\r \x01(\x0b\x32\x12.CmdCtrlWifiReprovH\x00\x12\x34\n\x15resp_ctrl_wifi_reprov\x18\x0e \x01(\x0b\x32\x13.RespCtrlWifiReprovH\x00\x12\x34\n\x15\x63md_ctrl_thread_reset\x18\x0f \x01(\x0b\x32\x13.CmdCtrlThreadResetH\x00\x12\x36\n\x16resp_ctrl_thread_reset\x18\x10 \x01(\x0b\x32\x14.RespCtrlThreadResetH\x00\x12\x36\n\x16\x63md_ctrl_thread_reprov\x18\x11 \x01(\x0b\x32\x14.CmdCtrlThreadReprovH\x00\x12\x38\n\x17resp_ctrl_thread_reprov\x18\x12 \x01(\x0b\x32\x15.RespCtrlThreadReprovH\x00\x42\t\n\x07payload*\x8a\x02\n\x12NetworkCtrlMsgType\x12\x14\n\x10TypeCtrlReserved\x10\x00\x12\x18\n\x14TypeCmdCtrlWifiReset\x10\x01\x12\x19\n\x15TypeRespCtrlWifiReset\x10\x02\x12\x19\n\x15TypeCmdCtrlWifiReprov\x10\x03\x12\x1a\n\x16TypeRespCtrlWifiReprov\x10\x04\x12\x1a\n\x16TypeCmdCtrlThreadReset\x10\x05\x12\x1b\n\x17TypeRespCtrlThreadReset\x10\x06\x12\x1b\n\x17TypeCmdCtrlThreadReprov\x10\x07\x12\x1c\n\x18TypeRespCtrlThreadReprov\x10\x08\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'network_ctrl_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _NETWORKCTRLMSGTYPE._serialized_start=526
-  _NETWORKCTRLMSGTYPE._serialized_end=660
-  _CMDCTRLRESET._serialized_start=64
-  _CMDCTRLRESET._serialized_end=110
-  _RESPCTRLRESET._serialized_start=112
-  _RESPCTRLRESET._serialized_end=159
-  _CMDCTRLREPROV._serialized_start=161
-  _CMDCTRLREPROV._serialized_end=208
-  _RESPCTRLREPROV._serialized_start=210
-  _RESPCTRLREPROV._serialized_end=258
-  _NETWORKCTRLPAYLOAD._serialized_start=261
-  _NETWORKCTRLPAYLOAD._serialized_end=523
+  _NETWORKCTRLMSGTYPE._serialized_start=741
+  _NETWORKCTRLMSGTYPE._serialized_end=1007
+  _CMDCTRLWIFIRESET._serialized_start=39
+  _CMDCTRLWIFIRESET._serialized_end=57
+  _RESPCTRLWIFIRESET._serialized_start=59
+  _RESPCTRLWIFIRESET._serialized_end=78
+  _CMDCTRLWIFIREPROV._serialized_start=80
+  _CMDCTRLWIFIREPROV._serialized_end=99
+  _RESPCTRLWIFIREPROV._serialized_start=101
+  _RESPCTRLWIFIREPROV._serialized_end=121
+  _CMDCTRLTHREADRESET._serialized_start=123
+  _CMDCTRLTHREADRESET._serialized_end=143
+  _RESPCTRLTHREADRESET._serialized_start=145
+  _RESPCTRLTHREADRESET._serialized_end=166
+  _CMDCTRLTHREADREPROV._serialized_start=168
+  _CMDCTRLTHREADREPROV._serialized_end=189
+  _RESPCTRLTHREADREPROV._serialized_start=191
+  _RESPCTRLTHREADREPROV._serialized_end=213
+  _NETWORKCTRLPAYLOAD._serialized_start=216
+  _NETWORKCTRLPAYLOAD._serialized_end=738
 # @@protoc_insertion_point(module_scope)

--- a/network_provisioning/python/network_scan_pb2.py
+++ b/network_provisioning/python/network_scan_pb2.py
@@ -15,37 +15,43 @@ import constants_pb2 as constants__pb2
 import network_constants_pb2 as network__constants__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12network_scan.proto\x1a\x0f\x63onstants.proto\x1a\x17network_constants.proto\"]\n\rWifiScanStart\x12\x10\n\x08\x62locking\x18\x01 \x01(\x08\x12\x0f\n\x07passive\x18\x02 \x01(\x08\x12\x16\n\x0egroup_channels\x18\x03 \x01(\r\x12\x11\n\tperiod_ms\x18\x04 \x01(\r\"9\n\x0fThreadScanStart\x12\x10\n\x08\x62locking\x18\x01 \x01(\x08\x12\x14\n\x0c\x63hannel_mask\x18\x02 \x01(\r\"\x93\x01\n\x0c\x43mdScanStart\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\x12)\n\x0fwifi_scan_start\x18\n \x01(\x0b\x32\x0e.WifiScanStartH\x00\x12-\n\x11thread_scan_start\x18\x0b \x01(\x0b\x32\x10.ThreadScanStartH\x00\x42\t\n\x07payload\"/\n\rRespScanStart\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\"/\n\rCmdScanStatus\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\"]\n\x0eRespScanStatus\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\x12\x15\n\rscan_finished\x18\x02 \x01(\x08\x12\x14\n\x0cresult_count\x18\x03 \x01(\r\"S\n\rCmdScanResult\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\x12\x13\n\x0bstart_index\x18\x02 \x01(\r\x12\r\n\x05\x63ount\x18\x03 \x01(\r\"i\n\x0eWifiScanResult\x12\x0c\n\x04ssid\x18\x01 \x01(\x0c\x12\x0f\n\x07\x63hannel\x18\x02 \x01(\r\x12\x0c\n\x04rssi\x18\x03 \x01(\x05\x12\r\n\x05\x62ssid\x18\x04 \x01(\x0c\x12\x1b\n\x04\x61uth\x18\x05 \x01(\x0e\x32\r.WifiAuthMode\"\x8a\x01\n\x10ThreadScanResult\x12\x0e\n\x06pan_id\x18\x01 \x01(\r\x12\x0f\n\x07\x63hannel\x18\x02 \x01(\r\x12\x0c\n\x04rssi\x18\x03 \x01(\x05\x12\x0b\n\x03lqi\x18\x04 \x01(\r\x12\x10\n\x08\x65xt_addr\x18\x05 \x01(\x0c\x12\x14\n\x0cnetwork_name\x18\x06 \x01(\t\x12\x12\n\next_pan_id\x18\x07 \x01(\x0c\"j\n\nScanResult\x12&\n\x0bwifi_result\x18\n \x01(\x0b\x32\x0f.WifiScanResultH\x00\x12*\n\rthread_result\x18\x0b \x01(\x0b\x32\x11.ThreadScanResultH\x00\x42\x08\n\x06result\"N\n\x0eRespScanResult\x12\x1e\n\x08net_type\x18\x01 \x01(\x0e\x32\x0c.NetworkType\x12\x1c\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x0b.ScanResult\"\xde\x02\n\x12NetworkScanPayload\x12 \n\x03msg\x18\x01 \x01(\x0e\x32\x13.NetworkScanMsgType\x12\x17\n\x06status\x18\x02 \x01(\x0e\x32\x07.Status\x12\'\n\x0e\x63md_scan_start\x18\n \x01(\x0b\x32\r.CmdScanStartH\x00\x12)\n\x0fresp_scan_start\x18\x0b \x01(\x0b\x32\x0e.RespScanStartH\x00\x12)\n\x0f\x63md_scan_status\x18\x0c \x01(\x0b\x32\x0e.CmdScanStatusH\x00\x12+\n\x10resp_scan_status\x18\r \x01(\x0b\x32\x0f.RespScanStatusH\x00\x12)\n\x0f\x63md_scan_result\x18\x0e \x01(\x0b\x32\x0e.CmdScanResultH\x00\x12+\n\x10resp_scan_result\x18\x0f \x01(\x0b\x32\x0f.RespScanResultH\x00\x42\t\n\x07payload*\x9f\x01\n\x12NetworkScanMsgType\x12\x14\n\x10TypeCmdScanStart\x10\x00\x12\x15\n\x11TypeRespScanStart\x10\x01\x12\x15\n\x11TypeCmdScanStatus\x10\x02\x12\x16\n\x12TypeRespScanStatus\x10\x03\x12\x15\n\x11TypeCmdScanResult\x10\x04\x12\x16\n\x12TypeRespScanResult\x10\x05\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12network_scan.proto\x1a\x0f\x63onstants.proto\x1a\x17network_constants.proto\"`\n\x10\x43mdScanWifiStart\x12\x10\n\x08\x62locking\x18\x01 \x01(\x08\x12\x0f\n\x07passive\x18\x02 \x01(\x08\x12\x16\n\x0egroup_channels\x18\x03 \x01(\r\x12\x11\n\tperiod_ms\x18\x04 \x01(\r\"<\n\x12\x43mdScanThreadStart\x12\x10\n\x08\x62locking\x18\x01 \x01(\x08\x12\x14\n\x0c\x63hannel_mask\x18\x02 \x01(\r\"\x13\n\x11RespScanWifiStart\"\x15\n\x13RespScanThreadStart\"\x13\n\x11\x43mdScanWifiStatus\"\x15\n\x13\x43mdScanThreadStatus\"A\n\x12RespScanWifiStatus\x12\x15\n\rscan_finished\x18\x01 \x01(\x08\x12\x14\n\x0cresult_count\x18\x02 \x01(\r\"C\n\x14RespScanThreadStatus\x12\x15\n\rscan_finished\x18\x01 \x01(\x08\x12\x14\n\x0cresult_count\x18\x02 \x01(\r\"7\n\x11\x43mdScanWifiResult\x12\x13\n\x0bstart_index\x18\x01 \x01(\r\x12\r\n\x05\x63ount\x18\x02 \x01(\r\"9\n\x13\x43mdScanThreadResult\x12\x13\n\x0bstart_index\x18\x01 \x01(\r\x12\r\n\x05\x63ount\x18\x02 \x01(\r\"i\n\x0eWiFiScanResult\x12\x0c\n\x04ssid\x18\x01 \x01(\x0c\x12\x0f\n\x07\x63hannel\x18\x02 \x01(\r\x12\x0c\n\x04rssi\x18\x03 \x01(\x05\x12\r\n\x05\x62ssid\x18\x04 \x01(\x0c\x12\x1b\n\x04\x61uth\x18\x05 \x01(\x0e\x32\r.WifiAuthMode\"\x8a\x01\n\x10ThreadScanResult\x12\x0e\n\x06pan_id\x18\x01 \x01(\r\x12\x0f\n\x07\x63hannel\x18\x02 \x01(\r\x12\x0c\n\x04rssi\x18\x03 \x01(\x05\x12\x0b\n\x03lqi\x18\x04 \x01(\r\x12\x10\n\x08\x65xt_addr\x18\x05 \x01(\x0c\x12\x14\n\x0cnetwork_name\x18\x06 \x01(\t\x12\x12\n\next_pan_id\x18\x07 \x01(\x0c\"6\n\x12RespScanWifiResult\x12 \n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x0f.WiFiScanResult\":\n\x14RespScanThreadResult\x12\"\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x11.ThreadScanResult\"\xe6\x05\n\x12NetworkScanPayload\x12 \n\x03msg\x18\x01 \x01(\x0e\x32\x13.NetworkScanMsgType\x12\x17\n\x06status\x18\x02 \x01(\x0e\x32\x07.Status\x12\x30\n\x13\x63md_scan_wifi_start\x18\n \x01(\x0b\x32\x11.CmdScanWifiStartH\x00\x12\x32\n\x14resp_scan_wifi_start\x18\x0b \x01(\x0b\x32\x12.RespScanWifiStartH\x00\x12\x32\n\x14\x63md_scan_wifi_status\x18\x0c \x01(\x0b\x32\x12.CmdScanWifiStatusH\x00\x12\x34\n\x15resp_scan_wifi_status\x18\r \x01(\x0b\x32\x13.RespScanWifiStatusH\x00\x12\x32\n\x14\x63md_scan_wifi_result\x18\x0e \x01(\x0b\x32\x12.CmdScanWifiResultH\x00\x12\x34\n\x15resp_scan_wifi_result\x18\x0f \x01(\x0b\x32\x13.RespScanWifiResultH\x00\x12\x34\n\x15\x63md_scan_thread_start\x18\x10 \x01(\x0b\x32\x13.CmdScanThreadStartH\x00\x12\x36\n\x16resp_scan_thread_start\x18\x11 \x01(\x0b\x32\x14.RespScanThreadStartH\x00\x12\x36\n\x16\x63md_scan_thread_status\x18\x12 \x01(\x0b\x32\x14.CmdScanThreadStatusH\x00\x12\x38\n\x17resp_scan_thread_status\x18\x13 \x01(\x0b\x32\x15.RespScanThreadStatusH\x00\x12\x36\n\x16\x63md_scan_thread_result\x18\x14 \x01(\x0b\x32\x14.CmdScanThreadResultH\x00\x12\x38\n\x17resp_scan_thread_result\x18\x15 \x01(\x0b\x32\x15.RespScanThreadResultH\x00\x42\t\n\x07payload*\xe6\x02\n\x12NetworkScanMsgType\x12\x18\n\x14TypeCmdScanWifiStart\x10\x00\x12\x19\n\x15TypeRespScanWifiStart\x10\x01\x12\x19\n\x15TypeCmdScanWifiStatus\x10\x02\x12\x1a\n\x16TypeRespScanWifiStatus\x10\x03\x12\x19\n\x15TypeCmdScanWifiResult\x10\x04\x12\x1a\n\x16TypeRespScanWifiResult\x10\x05\x12\x1a\n\x16TypeCmdScanThreadStart\x10\x06\x12\x1b\n\x17TypeRespScanThreadStart\x10\x07\x12\x1b\n\x17TypeCmdScanThreadStatus\x10\x08\x12\x1c\n\x18TypeRespScanThreadStatus\x10\t\x12\x1b\n\x17TypeCmdScanThreadResult\x10\n\x12\x1c\n\x18TypeRespScanThreadResult\x10\x0b\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'network_scan_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _NETWORKSCANMSGTYPE._serialized_start=1436
-  _NETWORKSCANMSGTYPE._serialized_end=1595
-  _WIFISCANSTART._serialized_start=64
-  _WIFISCANSTART._serialized_end=157
-  _THREADSCANSTART._serialized_start=159
-  _THREADSCANSTART._serialized_end=216
-  _CMDSCANSTART._serialized_start=219
-  _CMDSCANSTART._serialized_end=366
-  _RESPSCANSTART._serialized_start=368
-  _RESPSCANSTART._serialized_end=415
-  _CMDSCANSTATUS._serialized_start=417
-  _CMDSCANSTATUS._serialized_end=464
-  _RESPSCANSTATUS._serialized_start=466
-  _RESPSCANSTATUS._serialized_end=559
-  _CMDSCANRESULT._serialized_start=561
-  _CMDSCANRESULT._serialized_end=644
-  _WIFISCANRESULT._serialized_start=646
-  _WIFISCANRESULT._serialized_end=751
-  _THREADSCANRESULT._serialized_start=754
-  _THREADSCANRESULT._serialized_end=892
-  _SCANRESULT._serialized_start=894
-  _SCANRESULT._serialized_end=1000
-  _RESPSCANRESULT._serialized_start=1002
-  _RESPSCANRESULT._serialized_end=1080
-  _NETWORKSCANPAYLOAD._serialized_start=1083
-  _NETWORKSCANPAYLOAD._serialized_end=1433
+  _NETWORKSCANMSGTYPE._serialized_start=1674
+  _NETWORKSCANMSGTYPE._serialized_end=2032
+  _CMDSCANWIFISTART._serialized_start=64
+  _CMDSCANWIFISTART._serialized_end=160
+  _CMDSCANTHREADSTART._serialized_start=162
+  _CMDSCANTHREADSTART._serialized_end=222
+  _RESPSCANWIFISTART._serialized_start=224
+  _RESPSCANWIFISTART._serialized_end=243
+  _RESPSCANTHREADSTART._serialized_start=245
+  _RESPSCANTHREADSTART._serialized_end=266
+  _CMDSCANWIFISTATUS._serialized_start=268
+  _CMDSCANWIFISTATUS._serialized_end=287
+  _CMDSCANTHREADSTATUS._serialized_start=289
+  _CMDSCANTHREADSTATUS._serialized_end=310
+  _RESPSCANWIFISTATUS._serialized_start=312
+  _RESPSCANWIFISTATUS._serialized_end=377
+  _RESPSCANTHREADSTATUS._serialized_start=379
+  _RESPSCANTHREADSTATUS._serialized_end=446
+  _CMDSCANWIFIRESULT._serialized_start=448
+  _CMDSCANWIFIRESULT._serialized_end=503
+  _CMDSCANTHREADRESULT._serialized_start=505
+  _CMDSCANTHREADRESULT._serialized_end=562
+  _WIFISCANRESULT._serialized_start=564
+  _WIFISCANRESULT._serialized_end=669
+  _THREADSCANRESULT._serialized_start=672
+  _THREADSCANRESULT._serialized_end=810
+  _RESPSCANWIFIRESULT._serialized_start=812
+  _RESPSCANWIFIRESULT._serialized_end=866
+  _RESPSCANTHREADRESULT._serialized_start=868
+  _RESPSCANTHREADRESULT._serialized_end=926
+  _NETWORKSCANPAYLOAD._serialized_start=929
+  _NETWORKSCANPAYLOAD._serialized_end=1671
 # @@protoc_insertion_point(module_scope)

--- a/network_provisioning/src/network_config.c
+++ b/network_provisioning/src/network_config.c
@@ -33,15 +33,27 @@ static esp_err_t cmd_apply_config_handler(NetworkConfigPayload *req,
 
 static network_prov_config_cmd_t cmd_table[] = {
     {
-        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdGetStatus,
+        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdGetWifiStatus,
         .command_handler = cmd_get_status_handler
     },
     {
-        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdSetConfig,
+        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdSetWifiConfig,
         .command_handler = cmd_set_config_handler
     },
     {
-        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyConfig,
+        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyWifiConfig,
+        .command_handler = cmd_apply_config_handler
+    },
+    {
+        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdGetThreadStatus,
+        .command_handler = cmd_get_status_handler
+    },
+    {
+        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdSetThreadConfig,
+        .command_handler = cmd_set_config_handler
+    },
+    {
+        .cmd_num = NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyThreadConfig,
         .command_handler = cmd_apply_config_handler
     }
 };
@@ -56,25 +68,23 @@ static esp_err_t cmd_get_status_handler(NetworkConfigPayload *req,
         return ESP_ERR_INVALID_STATE;
     }
 
-    RespGetStatus *resp_payload = (RespGetStatus *) malloc(sizeof(RespGetStatus));
-    if (!resp_payload) {
-        ESP_LOGE(TAG, "Error allocating memory");
-        return ESP_ERR_NO_MEM;
-    }
-    resp_get_status__init(resp_payload);
-
-    if (req->cmd_get_status->net_type == NETWORK_TYPE__WifiNetwork) {
+    if (req->msg == NETWORK_CONFIG_MSG_TYPE__TypeCmdGetWifiStatus) {
+        RespGetWifiStatus *resp_payload = (RespGetWifiStatus *) malloc(sizeof(RespGetWifiStatus));
+        if (!resp_payload) {
+            ESP_LOGE(TAG, "Error allocating memory");
+            return ESP_ERR_NO_MEM;
+        }
+        resp_get_wifi_status__init(resp_payload);
 #if CONFIG_ESP_WIFI_ENABLED
         network_prov_config_get_wifi_data_t resp_data;
         if (h->wifi_get_status_handler) {
             if (h->wifi_get_status_handler(&resp_data, &h->ctx) == ESP_OK) {
-                resp_payload->payload_case = RESP_GET_STATUS__PAYLOAD_WIFI_STA_STATE;
                 if (resp_data.wifi_state == NETWORK_PROV_WIFI_STA_CONNECTING) {
                     resp_payload->wifi_sta_state = WIFI_STATION_STATE__Connecting;
-                    resp_payload->state_case = RESP_GET_STATUS__STATE_WIFI_CONNECTED;
+                    resp_payload->state_case = RESP_GET_WIFI_STATUS__STATE_WIFI_CONNECTED;
                 } else if (resp_data.wifi_state == NETWORK_PROV_WIFI_STA_CONNECTED) {
                     resp_payload->wifi_sta_state  = WIFI_STATION_STATE__Connected;
-                    resp_payload->state_case = RESP_GET_STATUS__STATE_WIFI_CONNECTED;
+                    resp_payload->state_case = RESP_GET_WIFI_STATUS__STATE_WIFI_CONNECTED;
                     WifiConnectedState *connected = (WifiConnectedState *)(
                                                         malloc(sizeof(WifiConnectedState)));
                     if (!connected) {
@@ -116,7 +126,7 @@ static esp_err_t cmd_get_status_handler(NetworkConfigPayload *req,
                     connected->auth_mode  = resp_data.conn_info.auth_mode;
                 } else if (resp_data.wifi_state == NETWORK_PROV_WIFI_STA_DISCONNECTED) {
                     resp_payload->wifi_sta_state = WIFI_STATION_STATE__ConnectionFailed;
-                    resp_payload->state_case = RESP_GET_STATUS__STATE_WIFI_FAIL_REASON;
+                    resp_payload->state_case = RESP_GET_WIFI_STATUS__STATE_WIFI_FAIL_REASON;
 
                     if (resp_data.fail_reason == NETWORK_PROV_WIFI_STA_AUTH_ERROR) {
                         resp_payload->wifi_fail_reason = WIFI_CONNECT_FAILED_REASON__AuthError;
@@ -134,18 +144,25 @@ static esp_err_t cmd_get_status_handler(NetworkConfigPayload *req,
 #else
         resp_payload->status = STATUS__InvalidArgument;
 #endif
-    } else if (req->cmd_get_status->net_type == NETWORK_TYPE__ThreadNetwork) {
+        resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_GET_WIFI_STATUS;
+        resp->resp_get_wifi_status = resp_payload;
+    } else if (req->msg == NETWORK_CONFIG_MSG_TYPE__TypeCmdGetThreadStatus) {
+        RespGetThreadStatus *resp_payload = (RespGetThreadStatus *) malloc(sizeof(RespGetThreadStatus));
+        if (!resp_payload) {
+            ESP_LOGE(TAG, "Error allocating memory");
+            return ESP_ERR_NO_MEM;
+        }
+        resp_get_thread_status__init(resp_payload);
 #if CONFIG_OPENTHREAD_ENABLED
         network_prov_config_get_thread_data_t resp_data;
         if (h->thread_get_status_handler) {
             if (h->thread_get_status_handler(&resp_data, &h->ctx) == ESP_OK) {
-                resp_payload->payload_case = RESP_GET_STATUS__PAYLOAD_THREAD_STATE;
                 if (resp_data.thread_state == NETWORK_PROV_THREAD_ATTACHING) {
                     resp_payload->thread_state = THREAD_NETWORK_STATE__Attaching;
-                    resp_payload->state_case = RESP_GET_STATUS__STATE_THREAD_ATTACHED;
+                    resp_payload->state_case = RESP_GET_THREAD_STATUS__STATE_THREAD_ATTACHED;
                 } else if (resp_data.thread_state == NETWORK_PROV_THREAD_ATTACHED) {
                     resp_payload->thread_state  = THREAD_NETWORK_STATE__Attached;
-                    resp_payload->state_case = RESP_GET_STATUS__STATE_THREAD_ATTACHED;
+                    resp_payload->state_case = RESP_GET_THREAD_STATUS__STATE_THREAD_ATTACHED;
                     ThreadAttachState *attached = (ThreadAttachState *)malloc(sizeof(ThreadAttachState));
                     if (!attached) {
                         free(resp_payload);
@@ -175,7 +192,7 @@ static esp_err_t cmd_get_status_handler(NetworkConfigPayload *req,
                     memcpy(attached->name, resp_data.conn_info.name, sizeof(resp_data.conn_info.name));
                 } else if (resp_data.thread_state == NETWORK_PROV_THREAD_DETACHED) {
                     resp_payload->thread_state = THREAD_NETWORK_STATE__AttachingFailed;
-                    resp_payload->state_case = RESP_GET_STATUS__STATE_THREAD_FAIL_REASON;
+                    resp_payload->state_case = RESP_GET_THREAD_STATUS__STATE_THREAD_FAIL_REASON;
 
                     if (resp_data.fail_reason == NETWORK_PROV_THREAD_DATASET_INVALID) {
                         resp_payload->thread_fail_reason = THREAD_ATTACH_FAILED_REASON__DatasetInvalid;
@@ -193,11 +210,9 @@ static esp_err_t cmd_get_status_handler(NetworkConfigPayload *req,
 #else
         resp_payload->status = STATUS__InvalidArgument;
 #endif
-
+        resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_GET_THREAD_STATUS;
+        resp->resp_get_thread_status = resp_payload;
     }
-    resp_payload->net_type = req->cmd_get_status->net_type;
-    resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_GET_STATUS;
-    resp->resp_get_status = resp_payload;
     return ESP_OK;
 }
 
@@ -211,15 +226,13 @@ static esp_err_t cmd_set_config_handler(NetworkConfigPayload *req,
         return ESP_ERR_INVALID_STATE;
     }
 
-    RespSetConfig *resp_payload = (RespSetConfig *) malloc(sizeof(RespSetConfig));
-    if (resp_payload == NULL) {
-        ESP_LOGE(TAG, "Error allocating memory");
-        return ESP_ERR_NO_MEM;
-    }
-    resp_set_config__init(resp_payload);
-
-    if (req->cmd_set_config->net_type == NETWORK_TYPE__WifiNetwork &&
-            req->cmd_set_config->payload_case == CMD_SET_CONFIG__PAYLOAD_WIFI_CONFIG) {
+    if (req->msg == NETWORK_CONFIG_MSG_TYPE__TypeCmdSetWifiConfig) {
+        RespSetWifiConfig *resp_payload = (RespSetWifiConfig *) malloc(sizeof(RespSetWifiConfig));
+        if (resp_payload == NULL) {
+            ESP_LOGE(TAG, "Error allocating memory");
+            return ESP_ERR_NO_MEM;
+        }
+        resp_set_wifi_config__init(resp_payload);
 #if CONFIG_ESP_WIFI_ENABLED
         network_prov_config_set_wifi_data_t req_data;
         memset(&req_data, 0, sizeof(req_data));
@@ -230,24 +243,24 @@ static esp_err_t cmd_set_config_handler(NetworkConfigPayload *req,
          * If any of these conditions are not satisfied, don't invoke the handler and
          * send error status without closing connection */
         resp_payload->status = STATUS__InvalidArgument;
-        if (req->cmd_set_config->wifi_config->bssid.len != 0 &&
-                req->cmd_set_config->wifi_config->bssid.len != sizeof(req_data.bssid)) {
+        if (req->cmd_set_wifi_config->bssid.len != 0 &&
+                req->cmd_set_wifi_config->bssid.len != sizeof(req_data.bssid)) {
             ESP_LOGD(TAG, "Received invalid BSSID");
-        } else if (req->cmd_set_config->wifi_config->ssid.len >= sizeof(req_data.ssid)) {
+        } else if (req->cmd_set_wifi_config->ssid.len >= sizeof(req_data.ssid)) {
             ESP_LOGD(TAG, "Received invalid SSID");
-        } else if (req->cmd_set_config->wifi_config->passphrase.len >= sizeof(req_data.password)) {
+        } else if (req->cmd_set_wifi_config->passphrase.len >= sizeof(req_data.password)) {
             ESP_LOGD(TAG, "Received invalid Passphrase");
         } else {
             /* The received SSID and Passphrase are not NULL terminated so
              * we memcpy over zeroed out arrays. Above length checks ensure
              * that there is atleast 1 extra byte for null termination */
-            memcpy(req_data.ssid, req->cmd_set_config->wifi_config->ssid.data,
-                   req->cmd_set_config->wifi_config->ssid.len);
-            memcpy(req_data.password, req->cmd_set_config->wifi_config->passphrase.data,
-                   req->cmd_set_config->wifi_config->passphrase.len);
-            memcpy(req_data.bssid, req->cmd_set_config->wifi_config->bssid.data,
-                   req->cmd_set_config->wifi_config->bssid.len);
-            req_data.channel = req->cmd_set_config->wifi_config->channel;
+            memcpy(req_data.ssid, req->cmd_set_wifi_config->ssid.data,
+                   req->cmd_set_wifi_config->ssid.len);
+            memcpy(req_data.password, req->cmd_set_wifi_config->passphrase.data,
+                   req->cmd_set_wifi_config->passphrase.len);
+            memcpy(req_data.bssid, req->cmd_set_wifi_config->bssid.data,
+                   req->cmd_set_wifi_config->bssid.len);
+            req_data.channel = req->cmd_set_wifi_config->channel;
             if (h->wifi_set_config_handler(&req_data, &h->ctx) == ESP_OK) {
                 resp_payload->status = STATUS__Success;
             } else {
@@ -257,18 +270,25 @@ static esp_err_t cmd_set_config_handler(NetworkConfigPayload *req,
 #else
         resp_payload->status = STATUS__InvalidArgument;
 #endif // CONFIG_ESP_WIFI_ENABLED
-    } else if (req->cmd_set_config->net_type == NETWORK_TYPE__ThreadNetwork &&
-               req->cmd_set_config->payload_case == CMD_SET_CONFIG__PAYLOAD_THREAD_CONFIG) {
+        resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_SET_WIFI_CONFIG;
+        resp->resp_set_wifi_config = resp_payload;
+    } else if (req->msg == NETWORK_CONFIG_MSG_TYPE__TypeCmdSetThreadConfig) {
+        RespSetThreadConfig *resp_payload = (RespSetThreadConfig *) malloc(sizeof(RespSetThreadConfig));
+        if (resp_payload == NULL) {
+            ESP_LOGE(TAG, "Error allocating memory");
+            return ESP_ERR_NO_MEM;
+        }
+        resp_set_thread_config__init(resp_payload);
 #if CONFIG_OPENTHREAD_ENABLED
         network_prov_config_set_thread_data_t req_data;
         memset(&req_data, 0, sizeof(req_data));
         resp_payload->status = STATUS__InvalidArgument;
-        if (req->cmd_set_config->thread_config->dataset.len > sizeof(req_data.dataset)) {
+        if (req->cmd_set_thread_config->dataset.len > sizeof(req_data.dataset)) {
             ESP_LOGD(TAG, "Received invalid dataset");
         }
-        memcpy(req_data.dataset, req->cmd_set_config->thread_config->dataset.data,
-               req->cmd_set_config->thread_config->dataset.len);
-        req_data.length = req->cmd_set_config->thread_config->dataset.len;
+        memcpy(req_data.dataset, req->cmd_set_thread_config->dataset.data,
+               req->cmd_set_thread_config->dataset.len);
+        req_data.length = req->cmd_set_thread_config->dataset.len;
         if (h->thread_set_config_handler(&req_data, &h->ctx) == ESP_OK) {
             resp_payload->status = STATUS__Success;
         } else {
@@ -277,10 +297,9 @@ static esp_err_t cmd_set_config_handler(NetworkConfigPayload *req,
 #else
         resp_payload->status = STATUS__InvalidArgument;
 #endif // CONFIG_OPENTHREAD_ENABLED
+        resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_SET_THREAD_CONFIG;
+        resp->resp_set_thread_config = resp_payload;
     }
-    resp_payload->net_type = req->cmd_set_config->net_type;
-    resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_SET_CONFIG;
-    resp->resp_set_config = resp_payload;
     return ESP_OK;
 }
 
@@ -293,16 +312,13 @@ static esp_err_t cmd_apply_config_handler(NetworkConfigPayload *req,
         ESP_LOGE(TAG, "Command invoked without handlers");
         return ESP_ERR_INVALID_STATE;
     }
-
-    RespApplyConfig *resp_payload = (RespApplyConfig *) malloc(sizeof(RespApplyConfig));
-    if (!resp_payload) {
-        ESP_LOGE(TAG, "Error allocating memory");
-        return ESP_ERR_NO_MEM;
-    }
-
-    resp_apply_config__init(resp_payload);
-
-    if (req->cmd_apply_config->net_type == NETWORK_TYPE__WifiNetwork) {
+    if (req->msg == NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyWifiConfig) {
+        RespApplyWifiConfig *resp_payload = (RespApplyWifiConfig *) malloc(sizeof(RespApplyWifiConfig));
+        if (!resp_payload) {
+            ESP_LOGE(TAG, "Error allocating memory");
+            return ESP_ERR_NO_MEM;
+        }
+        resp_apply_wifi_config__init(resp_payload);
 #if CONFIG_ESP_WIFI_ENABLED
         if (h->wifi_apply_config_handler && h->wifi_apply_config_handler(&h->ctx) == ESP_OK) {
             resp_payload->status = STATUS__Success;
@@ -312,7 +328,15 @@ static esp_err_t cmd_apply_config_handler(NetworkConfigPayload *req,
 #else
         resp_payload->status = STATUS__InvalidArgument;
 #endif // CONFIG_ESP_WIFI_ENABLED
-    } else if (req->cmd_apply_config->net_type == NETWORK_TYPE__ThreadNetwork) {
+        resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_APPLY_WIFI_CONFIG;
+        resp->resp_apply_wifi_config = resp_payload;
+    } else if (req->msg == NETWORK_CONFIG_MSG_TYPE__TypeCmdApplyThreadConfig) {
+        RespApplyThreadConfig *resp_payload = (RespApplyThreadConfig *) malloc(sizeof(RespApplyThreadConfig));
+        if (!resp_payload) {
+            ESP_LOGE(TAG, "Error allocating memory");
+            return ESP_ERR_NO_MEM;
+        }
+        resp_apply_thread_config__init(resp_payload);
 #if CONFIG_OPENTHREAD_ENABLED
         if (h->thread_apply_config_handler && h->thread_apply_config_handler(&h->ctx) == ESP_OK) {
             resp_payload->status = STATUS__Success;
@@ -322,10 +346,9 @@ static esp_err_t cmd_apply_config_handler(NetworkConfigPayload *req,
 #else
         resp_payload->status = STATUS__InvalidArgument;
 #endif // CONFIG_OPENTHREAD_ENABLED
+        resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_APPLY_THREAD_CONFIG;
+        resp->resp_apply_thread_config = resp_payload;
     }
-
-    resp->payload_case = NETWORK_CONFIG_PAYLOAD__PAYLOAD_RESP_APPLY_CONFIG;
-    resp->resp_apply_config = resp_payload;
     return ESP_OK;
 }
 
@@ -346,62 +369,70 @@ static void network_prov_config_command_cleanup(NetworkConfigPayload *resp, void
     }
 
     switch (resp->msg) {
-    case NETWORK_CONFIG_MSG_TYPE__TypeRespGetStatus: {
-        if (resp->resp_get_status->net_type == NETWORK_TYPE__WifiNetwork) {
+    case NETWORK_CONFIG_MSG_TYPE__TypeRespGetWifiStatus: {
 #if CONFIG_ESP_WIFI_ENABLED
-            switch (resp->resp_get_status->wifi_sta_state) {
-            case WIFI_STATION_STATE__Connecting:
-                break;
-            case WIFI_STATION_STATE__Connected:
-                if (resp->resp_get_status->wifi_connected) {
-                    if (resp->resp_get_status->wifi_connected->ip4_addr) {
-                        free(resp->resp_get_status->wifi_connected->ip4_addr);
-                    }
-                    if (resp->resp_get_status->wifi_connected->bssid.data) {
-                        free(resp->resp_get_status->wifi_connected->bssid.data);
-                    }
-                    if (resp->resp_get_status->wifi_connected->ssid.data) {
-                        free(resp->resp_get_status->wifi_connected->ssid.data);
-                    }
-                    free(resp->resp_get_status->wifi_connected);
+        switch (resp->resp_get_wifi_status->wifi_sta_state) {
+        case WIFI_STATION_STATE__Connecting:
+            break;
+        case WIFI_STATION_STATE__Connected:
+            if (resp->resp_get_wifi_status->wifi_connected) {
+                if (resp->resp_get_wifi_status->wifi_connected->ip4_addr) {
+                    free(resp->resp_get_wifi_status->wifi_connected->ip4_addr);
                 }
-                break;
-            case WIFI_STATION_STATE__ConnectionFailed:
-                break;
-            default:
-                break;
-            }
-#endif
-        } else if (resp->resp_get_status->net_type == NETWORK_TYPE__ThreadNetwork) {
-#if CONFIG_OPENTHREAD_ENABLED
-            switch (resp->resp_get_status->thread_state) {
-            case THREAD_NETWORK_STATE__Attaching:
-                break;
-            case THREAD_NETWORK_STATE__Attached:
-                if (resp->resp_get_status->thread_attached) {
-                    if (resp->resp_get_status->thread_attached->name) {
-                        free(resp->resp_get_status->thread_attached->name);
-                    }
-                    free(resp->resp_get_status->thread_attached);
+                if (resp->resp_get_wifi_status->wifi_connected->bssid.data) {
+                    free(resp->resp_get_wifi_status->wifi_connected->bssid.data);
                 }
-                break;
-            case THREAD_NETWORK_STATE__AttachingFailed:
-                break;
-            default:
-                break;
+                if (resp->resp_get_wifi_status->wifi_connected->ssid.data) {
+                    free(resp->resp_get_wifi_status->wifi_connected->ssid.data);
+                }
+                free(resp->resp_get_wifi_status->wifi_connected);
             }
-#endif
-
+            break;
+        case WIFI_STATION_STATE__ConnectionFailed:
+            break;
+        default:
+            break;
         }
-        free(resp->resp_get_status);
+#endif
+        free(resp->resp_get_wifi_status);
     }
     break;
-    case NETWORK_CONFIG_MSG_TYPE__TypeRespSetConfig: {
-        free(resp->resp_set_config);
+    case NETWORK_CONFIG_MSG_TYPE__TypeRespGetThreadStatus: {
+#if CONFIG_OPENTHREAD_ENABLED
+        switch (resp->resp_get_thread_status->thread_state) {
+        case THREAD_NETWORK_STATE__Attaching:
+            break;
+        case THREAD_NETWORK_STATE__Attached:
+            if (resp->resp_get_thread_status->thread_attached) {
+                if (resp->resp_get_thread_status->thread_attached->name) {
+                    free(resp->resp_get_thread_status->thread_attached->name);
+                }
+                free(resp->resp_get_thread_status->thread_attached);
+            }
+            break;
+        case THREAD_NETWORK_STATE__AttachingFailed:
+            break;
+        default:
+            break;
+        }
+#endif
+        free(resp->resp_get_thread_status);
     }
     break;
-    case NETWORK_CONFIG_MSG_TYPE__TypeRespApplyConfig: {
-        free(resp->resp_apply_config);
+    case NETWORK_CONFIG_MSG_TYPE__TypeRespSetWifiConfig: {
+        free(resp->resp_set_wifi_config);
+    }
+    break;
+    case NETWORK_CONFIG_MSG_TYPE__TypeRespSetThreadConfig: {
+        free(resp->resp_set_thread_config);
+    }
+    break;
+    case NETWORK_CONFIG_MSG_TYPE__TypeRespApplyWifiConfig: {
+        free(resp->resp_apply_wifi_config);
+    }
+    break;
+    case NETWORK_CONFIG_MSG_TYPE__TypeRespApplyThreadConfig: {
+        free(resp->resp_apply_thread_config);
     }
     break;
     default:

--- a/network_provisioning/tool/esp_prov/README.md
+++ b/network_provisioning/tool/esp_prov/README.md
@@ -19,7 +19,7 @@ Usage of `esp-prov` assumes that the provisioning app has specific protocomm end
 ## Usage
 
 ```
-python esp_prov.py --transport < mode of provisioning : softap \ ble \ console > --network_proto < network protocol of provisioning : wifi \ thread > [ Optional parameters... ]
+python esp_prov.py --transport < mode of provisioning : softap \ ble \ console > [ Optional parameters... ]
 ```
 ### Parameters
 
@@ -41,11 +41,6 @@ python esp_prov.py --transport < mode of provisioning : softap \ ble \ console >
         * The client->device commands are printed to STDOUT and device->client messages are accepted via STDIN.
         * This is to be used when the device is accepting provisioning commands on UART console.
       * `httpd` - the script works the same as for `softap`. This could be used on any other network interface than WiFi soft AP, e.g. Ethernet or USB.
-
-* `--network_proto <network_protocol>`
-    - Two options are available:
-      * `wifi` - for Wi-Fi Provisioning
-      * `thread` - for Thread Provisioning
 
 * `--service_name <name>` (Optional)
     - When transport mode is `ble`, this specifies the Bluetooth LE device name to which connection is to be established for provisioned. If not provided, Bluetooth LE scanning is initiated and a list of nearby devices, as seen by the host, is displayed, of which the target device can be chosen.

--- a/network_provisioning/tool/esp_prov/prov/network_ctrl.py
+++ b/network_provisioning/tool/esp_prov/prov/network_ctrl.py
@@ -16,11 +16,10 @@ def print_verbose(security_ctx, data):
 def ctrl_reset_request(network_type, security_ctx):
     # Form protobuf request packet for CtrlReset command
     cmd = proto.network_ctrl_pb2.NetworkCtrlPayload()
-    cmd.msg = proto.network_ctrl_pb2.TypeCmdCtrlReset
     if network_type == 'wifi':
-        cmd.cmd_ctrl_reset.net_type = 0
+        cmd.msg = proto.network_ctrl_pb2.TypeCmdCtrlWifiReset
     elif network_type == 'thread':
-        cmd.cmd_ctrl_reset.net_type = 1
+        cmd.msg = proto.network_ctrl_pb2.TypeCmdCtrlThreadReset
     else:
         raise RuntimeError
     enc_cmd = security_ctx.encrypt_data(cmd.SerializeToString())
@@ -41,11 +40,10 @@ def ctrl_reset_response(security_ctx, response_data):
 def ctrl_reprov_request(network_type, security_ctx):
     # Form protobuf request packet for CtrlReprov command
     cmd = proto.network_ctrl_pb2.NetworkCtrlPayload()
-    cmd.msg = proto.network_ctrl_pb2.TypeCmdCtrlReprov
     if network_type == 'wifi':
-        cmd.cmd_ctrl_reprov.net_type = 0
+        cmd.msg = proto.network_ctrl_pb2.TypeCmdCtrlWifiReprov
     elif network_type == 'thread':
-        cmd.cmd_ctrl_reprov.net_type = 1
+        cmd.msg = proto.network_ctrl_pb2.TypeCmdCtrlThreadReprov
     else:
         raise RuntimeError
     enc_cmd = security_ctx.encrypt_data(cmd.SerializeToString())


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [X] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [X] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] CI passing

# Change description
Change the protobuf files so that the network_provisioning component will stay backward compatible with wifi_provisioning

# Test
- Provision `thread_prov`&`wifi_prov` examples in this component and `wifi_prov_mgr` example in ESP-IDF using `esp_prov.py` script in this component. (So phone Apps using the proto files in this component can provision previous firmware using `wifi_provisioning`)
- Provision `wifi_prov` example in this component and `wifi_prov_mgr` example in ESP-IDF using `esp_prov.py` script in ESP-IDF (So phone Apps using proto files in `wifi_provisioning` component can provision wifi firmware using `network_provisioning`)