### PR TITLE
updated nghttp2 component (IEC-132)

### DIFF
--- a/nghttp/CMakeLists.txt
+++ b/nghttp/CMakeLists.txt
@@ -11,7 +11,7 @@ set(srcs
     "nghttp2/lib/nghttp2_http.c"
     "nghttp2/lib/nghttp2_map.c"
     "nghttp2/lib/nghttp2_mem.c"
-    "nghttp2/lib/nghttp2_npn.c"
+    "nghttp2/lib/nghttp2_alpn.c"
     "nghttp2/lib/nghttp2_option.c"
     "nghttp2/lib/nghttp2_outbound_item.c"
     "nghttp2/lib/nghttp2_pq.c"

--- a/nghttp/idf_component.yml
+++ b/nghttp/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.58.0"
+version: "1.62.1"
 description: "nghttp2 - HTTP/2 C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/nghttp
 dependencies:

--- a/nghttp/port/include/nghttp2/nghttp2ver.h
+++ b/nghttp/port/include/nghttp2/nghttp2ver.h
@@ -29,7 +29,7 @@
  * @macro
  * Version number of the nghttp2 library release
  */
-#define NGHTTP2_VERSION "1.58.0"
+#define NGHTTP2_VERSION "1.62.1"
 
 /**
  * @macro
@@ -37,6 +37,6 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define NGHTTP2_VERSION_NUM 0x013a00
+#define NGHTTP2_VERSION_NUM 0x013e01
 
 #endif /* NGHTTP2VER_H */

--- a/nghttp/sbom_nghttp2.yml
+++ b/nghttp/sbom_nghttp2.yml
@@ -1,7 +1,7 @@
 name: nghttp2
-version: 1.58.0
+version: 1.62.1
 cpe: cpe:2.3:a:nghttp2:nghttp2:{}:*:*:*:*:*:*:*
 supplier: 'Organization: nghttp2 <https://nghttp2.org/'
 description: nghttp2 - HTTP/2 C Library and tools
 url: https://github.com/nghttp2/nghttp2
-hash: e2bc59bec9004bca47df961cbbad20664d7e53b2
+hash: d13a5758373931064636c1641db6277db45552dc


### PR DESCRIPTION
Updated the nghttp2 submodule from v1.58.0 or v1.62.1. 

Testing -
   Tested this component using the example which is in sh2lib component. Checked whether this example runs before and           after upgrading the nghttp2


Binary size (http2_request.bin) -
        Before - 1015120 Bytes
        After - 1015536 Bytes
        
Library Size (libnghttp.a) -
       Before - 82712 Bytes
       After - 83087 Bytes

Link to changelog -
https://github.com/nghttp2/nghttp2/releases/tag/v1.62.1