### PR TITLE
fix(ci): allow unsecure node version for self hosted runner

### DIFF
--- a/.github/workflows/build_and_run_examples.yml
+++ b/.github/workflows/build_and_run_examples.yml
@@ -50,6 +50,8 @@ jobs:
         idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32"]
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}"]
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
       image: python:3.7-buster
       options: --privileged # Privileged mode has access to serial ports
@@ -79,6 +81,8 @@ jobs:
         idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32"]
     runs-on: [self-hosted, ESP32-ETHERNET-KIT]
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
       image: python:3.7-buster
       options: --privileged # Privileged mode has access to serial ports

--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -72,6 +72,8 @@ jobs:
         idf_ver: ["release-v4.4", "release-v5.0", "release-v5.1", "release-v5.2", "latest"]
         idf_target: ["esp32", "esp32c3", "esp32s3"]
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}"]
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     container:
       image: python:3.7-buster
       options: --privileged # Privileged mode has access to serial ports


### PR DESCRIPTION
Temporary fix for the following error on the self hosted runners:

```
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.28' not found (required by /__e/node20/bin/node)
```

We can revert this change once we fix the runners. 

More on the issue:

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

# Checklist

- [x] CI passing

# Change description
_Please describe your change here_
