### PR TITLE
ci(gh-actions-ver): updated gh actions latest versions (new nodejs) (IEC-136)

### DIFF
--- a/.github/workflows/build_and_run_examples.yml
+++ b/.github/workflows/build_and_run_examples.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - name: Build Examples
@@ -56,8 +56,8 @@ jobs:
       image: python:3.7-buster
       options: --privileged # Privileged mode has access to serial ports
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: example_binaries_${{ matrix.idf_ver }}
       - name: Install Python packages
@@ -87,8 +87,11 @@ jobs:
       image: python:3.7-buster
       options: --privileged # Privileged mode has access to serial ports
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - run: |
+          apt-get update
+          apt-get install -y libstdc++6
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: example_binaries_${{ matrix.idf_ver }}
       - name: Install Python packages

--- a/.github/workflows/build_and_run_test_app.yml
+++ b/.github/workflows/build_and_run_test_app.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
       - name: Build Test Application
@@ -78,8 +78,11 @@ jobs:
       image: python:3.7-buster
       options: --privileged # Privileged mode has access to serial ports
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v2
+      - run: |
+          apt-get update
+          apt-get install -y libstdc++6
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: test_app_bin_${{ matrix.idf_target }}_${{ matrix.idf_ver }}
           path: test_app/build
@@ -90,7 +93,7 @@ jobs:
       - name: Run Test App on target
         working-directory: test_app
         run: pytest --junit-xml=./test_app_results_${{ matrix.idf_target }}_${{ matrix.idf_ver }}.xml --target=${{ matrix.idf_target }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test_app_results_${{ matrix.idf_target }}_${{ matrix.idf_ver }}
@@ -103,7 +106,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download Test results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: test_results
       - name: Publish Test Results


### PR DESCRIPTION
This should fix the issue with incompatible version of nodejs (npm) in GitHub actions.

## Related
- https://github.com/espressif/idf-extra-components/actions/runs/9791007440/job/27045936740?pr=348#step:3:16
