### PR TITLE
Update fmt to 11.0.1, add example

### DIFF
--- a/fmt/LICENSE
+++ b/fmt/LICENSE
@@ -1,0 +1,1 @@
+fmt/LICENSE

--- a/fmt/LICENSE.rst
+++ b/fmt/LICENSE.rst
@@ -1,1 +1,0 @@
-fmt/LICENSE.rst

--- a/fmt/examples/hello_fmt/CMakeLists.txt
+++ b/fmt/examples/hello_fmt/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+set(COMPONENTS main)
+project(hello_fmt)

--- a/fmt/examples/hello_fmt/README.md
+++ b/fmt/examples/hello_fmt/README.md
@@ -1,0 +1,18 @@
+# `fmt` basic example
+
+This is a basic example of using `fmt` library in an ESP-IDF project. It includes `fmt` and prints `Hello, fmt!` on the console.
+
+The example runs on any ESP development board. To build and run the example, follow the same steps as for any other ESP-IDF project. For example, for ESP32-C3:
+
+```bash
+idf.py set-target esp32c3
+idf.py flash monitor
+```
+
+The example should print the following:
+
+```
+I (6074) main_task: Calling app_main()
+Hello, fmt!
+I (6084) main_task: Returned from app_main()
+```

--- a/fmt/examples/hello_fmt/main/CMakeLists.txt
+++ b/fmt/examples/hello_fmt/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "hello_fmt.cpp"
+                    INCLUDE_DIRS ".")

--- a/fmt/examples/hello_fmt/main/hello_fmt.cpp
+++ b/fmt/examples/hello_fmt/main/hello_fmt.cpp
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#include <fmt/core.h>
+
+extern "C" void app_main()
+{
+    fmt::print("Hello, fmt!\n");
+}

--- a/fmt/examples/hello_fmt/main/idf_component.yml
+++ b/fmt/examples/hello_fmt/main/idf_component.yml
@@ -1,0 +1,4 @@
+dependencies:
+  fmt:
+    version: "*"
+    override_path: "../../../"

--- a/fmt/examples/hello_fmt/pytest_fmt.py
+++ b/fmt/examples/hello_fmt/pytest_fmt.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Unlicense OR CC0-1.0
+
+import pytest
+from pytest_embedded import Dut
+
+
+@pytest.mark.supported_targets
+@pytest.mark.generic
+def test_fmt_example(dut: Dut) -> None:
+    dut.expect_exact('Hello, fmt!')

--- a/fmt/idf_component.yml
+++ b/fmt/idf_component.yml
@@ -1,4 +1,4 @@
-version: "10.1.0~1"
+version: "11.0.1"
 description: Formatting library providing a fast and safe alternative to C stdio and C++ iostreams.
 url: https://github.com/espressif/idf-extra-components/tree/master/fmt
 dependencies:

--- a/fmt/sbom_fmt.yml
+++ b/fmt/sbom_fmt.yml
@@ -1,7 +1,7 @@
 name: fmt
-version: 10.1.0
+version: 11.0.1
 cpe: cpe:2.3:a:fmt:fmt:{}:*:*:*:*:*:*:*
 supplier: 'Organization: fmt <https://fmt.dev/latest/index.html>'
 description: A modern formatting library
 url: https://github.com/fmtlib/fmt/
-hash: e57ca2e3685b160617d3d95fcd9e789c4e06ca88
+hash: b50e685db996c167e6c831dcef582aba6e14276a


### PR DESCRIPTION
- Added a simple example to `fmt` component and a test to check that the example works
- Updated `fmt` to 11.0.1
