### PR TITLE
change: exclude CVEs that have already been resolved

### DIFF
--- a/coap/sbom_libcoap.yml
+++ b/coap/sbom_libcoap.yml
@@ -5,3 +5,8 @@ supplier: 'Organization: libcoap <https://libcoap.net/>'
 description: A CoAP (RFC 7252) implementation in C
 url: https://github.com/obgm/libcoap
 hash: 3c720f232f61cf097d7cbd5c0bde2b4c681b1c68
+cve-exclude-list:
+  - cve: CVE-2024-31031
+    reason: Resolved in version 4.3.5-rc1
+  - cve: CVE-2023-51847
+    reason: Resolved in version 4.3.5-rc1

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -5,3 +5,6 @@ supplier: 'Organization: libexpat_project'
 description: Fast streaming XML parser written in C99
 url: https://github.com/libexpat/libexpat/
 hash: fa75b96546c069d17b8f80d91e0f4ef0cde3790d
+cve-exclude-list:
+  - cve: CVE-2024-28757
+    reason: Resolved in version 2.6.2

--- a/nghttp/sbom_nghttp2.yml
+++ b/nghttp/sbom_nghttp2.yml
@@ -5,3 +5,6 @@ supplier: 'Organization: nghttp2 <https://nghttp2.org/'
 description: nghttp2 - HTTP/2 C Library and tools
 url: https://github.com/nghttp2/nghttp2
 hash: d13a5758373931064636c1641db6277db45552dc
+cve-exclude-list:
+  - cve: CVE-2024-28182
+    reason: Resolved in version v1.61.0


### PR DESCRIPTION
These CVEs have not yet been analyzed in the NVD and were identified by the esp-idf-sbom checker during a keyword search in the CVE descriptions. Since the affected components have already been updated to newer versions, these CVEs are no longer relevant to the current version. Therefore, they should be added to the exclude list.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
