### PR TITLE
fmt: fix link to parent project in README.md (IEC-145)

### DIFF
--- a/fmt/README.md
+++ b/fmt/README.md
@@ -5,6 +5,6 @@
 **fmt** is an open-source formatting library providing a fast and safe
 alternative to C stdio and C++ iostreams.
 
-See the project [README](https://github.com/fmtlib/fmt/blob/master/README.rst) for details.
+See the project [README](https://github.com/fmtlib/fmt/blob/master/README.md) for details.
 
 


### PR DESCRIPTION


# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
An embarrassingly simple "fix". The correct link is

https://github.com/fmtlib/fmt/blob/master/README.md not
https://github.com/fmtlib/fmt/blob/master/README.rst

...and apparently has been since fmt was uploaded to Github in 2012.