### PR TITLE
[fix] add swap_color_bytes for rgb888. (IEC-160)

### DIFF
--- a/esp_jpeg/idf_component.yml
+++ b/esp_jpeg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.5~2"
+version: "1.0.5~3"
 description: "JPEG Decoder: TJpgDec"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_jpeg/
 dependencies:

--- a/esp_jpeg/jpeg_decoder.c
+++ b/esp_jpeg/jpeg_decoder.c
@@ -162,7 +162,7 @@ static jpeg_decode_out_t jpeg_decode_out_cb(JDEC *dec, void *bitmap, JRECT *rect
                     (JD_FORMAT == 1 && cfg->out_format == JPEG_IMAGE_FORMAT_RGB565) ) {
                 /* Output image format is same as set in TJPGD */
                 for (int b = 0; b < ESP_JPEG_COLOR_BYTES; b++) {
-                    if (JD_FORMAT == 1 && cfg->flags.swap_color_bytes) {
+                    if (cfg->flags.swap_color_bytes) {
                         dst[(y * line * out_color_bytes) + x * out_color_bytes + b] = in[out_color_bytes - b - 1];
                     } else {
                         dst[(y * line * out_color_bytes) + x * out_color_bytes + b] = in[b];


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
add swap_color_bytes for rgb888 to get pixels in rgb/bgr order.
