### PR TITLE
fix(network_prov): fix provisioning over softap (IEC-161)

### DIFF
--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:

--- a/network_provisioning/src/scheme_softap.c
+++ b/network_provisioning/src/scheme_softap.c
@@ -182,7 +182,7 @@ const network_prov_scheme_t network_prov_scheme_softap = {
     .delete_config       = delete_config,
     .set_config_service  = set_config_service,
     .set_config_endpoint = set_config_endpoint,
-#ifdef NETWORK_PROV_NETWORK_TYPE_WIFI
+#ifdef CONFIG_NETWORK_PROV_NETWORK_TYPE_WIFI
     .wifi_mode           = WIFI_MODE_APSTA
 #endif
 };


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [X] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [X] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [X] CI passing

# Change description
There is an issue for network_prov_scheme_softap. Fix it in this PR.
