### PR TITLE
change: exclude CVE-2024-28757 for libexpat

### DIFF
--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.6.3"
+version: "2.6.3~1"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -5,4 +5,6 @@ supplier: 'Organization: libexpat_project'
 description: Fast streaming XML parser written in C99
 url: https://github.com/libexpat/libexpat/
 hash: 88b3ed553d8ad335559254863a33360d55b9f1d6
-
+cve-exclude-list:
+  - cve: CVE-2024-28757
+    reason: Resolved in version 2.6.2


### PR DESCRIPTION
This CVE has not yet been processed in the NVD and was previously excluded in https://github.com/espressif/idf-extra-components/pull/359. Unfortunately, the update to libexpat version 2.6.3 removed it in https://github.com/espressif/idf-extra-components/pull/372. This change re-adds CVE-2024-28757 to the exclude list.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
