### PR TITLE
feat(catch2): update to 3.7.0

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -35,7 +35,7 @@ catch2/examples/catch2-test:
   disable:
     - if: IDF_VERSION_MAJOR < 5
       reason: Example relies on WHOLE_ARCHIVE component property which was introduced in IDF v5.0
-    - if: IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 1 and IDF_TARGET == "linux"
+    - if: ((IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR < 1) and IDF_TARGET == "linux")
       reason: Docker container for release/v5.0 doesn't contain a C++ compiler
 
 catch2/examples/catch2-console:

--- a/catch2/examples/catch2-console/pytest_catch2_console.py
+++ b/catch2/examples/catch2-console/pytest_catch2_console.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Unlicense OR CC0-1.0
+
+import pytest
+from pytest_embedded import Dut
+
+
+@pytest.mark.supported_targets
+@pytest.mark.generic
+def test_catch2_console_example(dut: Dut) -> None:
+    dut.expect_exact('Type \'help\' to get the list of commands.')
+    dut.write('test -?\n')
+    dut.expect_exact('For more detailed usage please see the project docs')
+    dut.write('test\n')
+    dut.expect_exact('All tests passed')
+    dut.expect_exact('1 assertion in 1 test case')
+
+

--- a/catch2/examples/catch2-test/pytest_catch2.py
+++ b/catch2/examples/catch2-test/pytest_catch2.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Unlicense OR CC0-1.0
+
+import pytest
+from pytest_embedded import Dut
+
+
+@pytest.mark.supported_targets
+@pytest.mark.generic
+def test_catch2_example(dut: Dut) -> None:
+    dut.expect_exact('All tests passed')
+    dut.expect_exact('1 assertion in 1 test case')
+

--- a/catch2/idf_component.yml
+++ b/catch2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.5.2"
+version: "3.7.0"
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/espressif/idf-extra-components/tree/master/catch2
 repository: https://github.com/espressif/idf-extra-components.git

--- a/catch2/sbom_catch2.yml
+++ b/catch2/sbom_catch2.yml
@@ -1,7 +1,7 @@
 name: catch2
-version: 3.5.2
+version: 3.7.0
 cpe: cpe:2.3:a:catchorg:catch2:{}:*:*:*:*:*:*:*
 supplier: 'Organization: catchorg <https://github.com/catchorg>'
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/catchorg/Catch2
-hash: 05e10dfccc28c7f973727c54f850237d07d5e10f
+hash: 31588bb4f56b638dd5afc28d3ebff9b9dcefb88d


### PR DESCRIPTION
Upstream changes: https://github.com/catchorg/Catch2/compare/v3.5.2...v3.7.0

Have also added pytest cases to check catch2 examples in CI.