### PR TITLE
fix(thorvg): exclude some folders to reduce component size

### DIFF
--- a/thorvg/idf_component.yml
+++ b/thorvg/idf_component.yml
@@ -10,3 +10,10 @@ sbom:
   manifests:
     - path: sbom_thorvg.yml
       dest: thorvg
+files:
+  exclude:
+    - "thorvg/docs/**/*"
+    - "thorvg/examples/**/*"
+    - "thorvg/res/**/*"
+    - "thorvg/test/**/*"
+    - "thorvg/web/**/*"


### PR DESCRIPTION
https://github.com/espressif/idf-extra-components/actions/runs/10919154946/job/30306218942?pr=377 — thorvg component archive size is 80 MB, and the upload process times out.

This PR excludes some of the component directories, reducing the archive size to 1.4 MB.

Testing:
- ran `compote component upload --name thorvg --namespace espressif --dry-run`
- unpacked the component archive in `dist` directory and built the example from it

Component version not bumped because the upload after the previous bump wasn't successful.