### PR TITLE
fix(coremark): archive in linker.lf should depend on component name

### DIFF
--- a/coremark/CMakeLists.txt
+++ b/coremark/CMakeLists.txt
@@ -7,9 +7,13 @@ set(srcs coremark/core_list_join.c
          port/core_portme.c
 )
 
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    configure_file(linker.lf.in ${CMAKE_CURRENT_BINARY_DIR}/linker.lf)
+endif()
+
 idf_component_register(SRCS ${srcs}
                        PRIV_INCLUDE_DIRS port coremark
-                       LDFRAGMENTS linker.lf
+                       LDFRAGMENTS ${CMAKE_CURRENT_BINARY_DIR}/linker.lf
                        PRIV_REQUIRES esp_timer)
 
 # compile coremark component with -O3 flag (will override the optimization level which is set globally)

--- a/coremark/idf_component.yml
+++ b/coremark/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.0~1"
 description: CoreMark Benchmark
 url: https://github.com/espressif/idf-extra-components/tree/master/coremark
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/coremark/linker.lf.in
+++ b/coremark/linker.lf.in
@@ -1,4 +1,4 @@
 [mapping:coremark]
-archive: libcoremark.a
+archive: lib${COMPONENT_NAME}.a
 entries:
     * (noflash)


### PR DESCRIPTION
Closes https://github.com/espressif/idf-extra-components/issues/368