### PR TITLE
fix(spi_nand_flash): add dhara to public dependencies (+minor changes)

### DIFF
--- a/spi_nand_flash/CMakeLists.txt
+++ b/spi_nand_flash/CMakeLists.txt
@@ -4,7 +4,17 @@ set(srcs "src/nand.c"
          "vfs/vfs_fat_spinandflash.c"
          "diskio/diskio_nand.c")
 
+set(reqs fatfs)
+
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER "5.3")
+    list(APPEND reqs esp_driver_spi)
+else()
+    list(APPEND reqs driver)
+endif()
+
+set(priv_reqs vfs)
+
 idf_component_register(SRCS ${srcs}
         INCLUDE_DIRS include vfs diskio
-        REQUIRES driver fatfs vfs
-        )
+        REQUIRES ${reqs}
+        PRIV_REQUIRES ${priv_reqs})

--- a/spi_nand_flash/examples/nand_flash/main/spi_nand_flash_example_main.c
+++ b/spi_nand_flash/examples/nand_flash/main/spi_nand_flash_example_main.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "esp_vfs.h"
 #include "esp_system.h"
 #include "soc/spi_pins.h"
 #include "esp_vfs_fat_nand.h"

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -9,3 +9,4 @@ dependencies:
   dhara:
     version: "0.1.*"
     override_path: "../dhara"
+    require: public

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.3.1"
+version: "0.4.0"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/sbom_dhara.yml
+++ b/spi_nand_flash/sbom_dhara.yml
@@ -1,7 +1,0 @@
-name: dhara
-version: 1b166e41b74b4a62ee6001ba5fab7a8805e80ea2 
-cpe: cpe:2.3:a:dhara:dhara:{}:*:*:*:*:*:*:*
-supplier: 'Organization: dhara'
-description: NAND Flash translation layer for small MCUs
-url: https://github.com/dlbeer/dhara
-hash: 1b166e41b74b4a62ee6001ba5fab7a8805e80ea2

--- a/spi_nand_flash/test_app/CMakeLists.txt
+++ b/spi_nand_flash/test_app/CMakeLists.txt
@@ -1,8 +1,6 @@
 # This is the project CMakeLists.txt file for the test subproject
 cmake_minimum_required(VERSION 3.5)
 
-set(EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/tools/unit-test-app/components")
-
 set(COMPONENTS main)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/spi_nand_flash/test_app/main/CMakeLists.txt
+++ b/spi_nand_flash/test_app/main/CMakeLists.txt
@@ -1,8 +1,14 @@
 set(src "test_app_main.c" "test_spi_nand_flash.c")
 
+set(priv_reqs unity esp_timer)
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER "5.3")
+    list(APPEND priv_reqs esp_driver_spi)
+else()
+    list(APPEND priv_reqs driver)
+endif()
+
 idf_component_register(SRCS ${src}
                        PRIV_INCLUDE_DIRS .
-                       PRIV_REQUIRES test_utils vfs fatfs spiffs unity lwip wear_levelling cmock driver
-                       REQUIRES dhara
+                       PRIV_REQUIRES ${priv_reqs}
                        WHOLE_ARCHIVE
                        )

--- a/spi_nand_flash/test_app/main/test_app_main.c
+++ b/spi_nand_flash/test_app/main/test_app_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
@@ -18,7 +18,7 @@ void setUp(void)
 void tearDown(void)
 {
     esp_reent_cleanup();    //clean up some of the newlib's lazy allocations
-    unity_utils_evaluate_leaks_direct(0);
+    unity_utils_evaluate_leaks_direct(20);
 }
 
 void app_main(void)


### PR DESCRIPTION
* add dhara to public requirements

   Since 892d994e8b3ee1bdf32ca49513a709c44ee9c12f, spi_nand_flash.h includes dhara/map.h, so dhara should be a public dependency of spi_nand_flash.

   Other changes:
   - move vfs to private requirements (it didn't have to be public)
   - depend specifically on `esp_driver_spi` instead of `driver` when building for IDF >=5.3
* fix memory leaks in test (free temporary buffers) and raise leak threshold to not detect esp_intr_alloc lazy allocation as a leak
* add read/write performance output to the test case
* remove unused sbom_dhara.yml file from spi_nand_flash component
* version changed from 0.3.1 to 0.4.0 since removing `vfs` from the public requirements is technically a breaking change