### PR TITLE
change(coap): exclude CVE-2024-46304

### DIFF
--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.5~1"
+version: "4.3.5~2"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:

--- a/coap/sbom_libcoap.yml
+++ b/coap/sbom_libcoap.yml
@@ -10,3 +10,5 @@ cve-exclude-list:
     reason: Resolved in version 4.3.5-rc1
   - cve: CVE-2023-51847
     reason: Resolved in version 4.3.5-rc1
+  - cve: CVE-2024-46304
+    reason: Resolved in version 4.3.5-rc3


### PR DESCRIPTION
This was fixed by 4851806c09a9 ("scan-build: CI Fail if scan-build warnings") in v4.3.5-rc3.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
