### PR TITLE
fix(network_prov): Fix warning of unused_function or unused_variable (IEC-227)

### DIFF
--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2"
+version: "1.0.3"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:

--- a/network_provisioning/src/handlers.c
+++ b/network_provisioning/src/handlers.c
@@ -23,6 +23,7 @@
 #include "network_provisioning/manager.h"
 #include "network_provisioning_priv.h"
 
+#if defined(CONFIG_NETWORK_PROV_NETWORK_TYPE_WIFI) || defined(CONFIG_NETWORK_PROV_NETWORK_TYPE_THREAD)
 static const char *TAG = "network_prov_handlers";
 
 /* Provide definition of network_prov_ctx_t */
@@ -40,6 +41,7 @@ static void free_network_prov_ctx(network_prov_ctx_t **ctx)
     free(*ctx);
     *ctx = NULL;
 }
+#endif
 
 #ifdef CONFIG_NETWORK_PROV_NETWORK_TYPE_WIFI
 static wifi_config_t *get_wifi_config(network_prov_ctx_t **ctx)

--- a/network_provisioning/src/network_scan.c
+++ b/network_provisioning/src/network_scan.c
@@ -65,7 +65,7 @@ static esp_err_t cmd_scan_start_handler(NetworkScanPayload *req,
                                         NetworkScanPayload *resp, void *priv_data)
 {
     network_prov_scan_handlers_t *h = (network_prov_scan_handlers_t *) priv_data;
-    if (!priv_data) {
+    if (!h) {
         ESP_LOGE(TAG, "Command invoked without handlers");
         return ESP_ERR_INVALID_STATE;
     }
@@ -175,9 +175,9 @@ static esp_err_t cmd_scan_status_handler(NetworkScanPayload *req,
 static esp_err_t cmd_scan_result_handler(NetworkScanPayload *req,
         NetworkScanPayload *resp, void *priv_data)
 {
-    esp_err_t err;
+    esp_err_t err = ESP_OK;
     network_prov_scan_handlers_t *h = (network_prov_scan_handlers_t *) priv_data;
-    if (!priv_data) {
+    if (!h) {
         ESP_LOGE(TAG, "Command invoked without handlers");
         return ESP_ERR_INVALID_STATE;
     }
@@ -328,9 +328,10 @@ static esp_err_t cmd_scan_result_handler(NetworkScanPayload *req,
         }
 #else // CONFIG_NETWORK_PROV_NETWORK_TYPE_THREAD
         resp->status = STATUS__InvalidArgument;
+        err = ESP_ERR_INVALID_ARG;
 #endif // !CONFIG_NETWORK_PROV_NETWORK_TYPE_THREAD
     }
-    return ESP_OK;
+    return err;
 }
 
 


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [X] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [X] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [X] _Optional:_ Component contains unit tests
- [X] CI passing

# Change description
For some examples which download this managed component of network_provisioning it could never use this component (neither `CONFIG_NETWORK_PROV_NETWORK_TYPE_WIFI` nor `CONFIG_NETWORK_PROV_NETWORK_TYPE_THREAD` not selected ) but the examples would compile the sources in the component. which would result in the warnings of `unused_function` or `unused_variable`.
