### PR TITLE
feat(freetype): update to 2.13.3

### DIFF
--- a/freetype/CMakeLists.txt
+++ b/freetype/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SKIP_INSTALL_ALL TRUE)
 set(BUILD_SHARED_LIBS OFF)
 
 add_subdirectory(freetype output)
+
+# https://gitlab.freedesktop.org/freetype/freetype/-/issues/1299
 target_compile_options(freetype PRIVATE "-Wno-dangling-pointer")
 
 target_link_libraries(${COMPONENT_LIB} INTERFACE freetype)

--- a/freetype/idf_component.yml
+++ b/freetype/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.13.0~3"
+version: "2.13.3"
 description: freetype C library
 url: https://github.com/espressif/idf-extra-components/tree/master/freetype
 repository: "https://github.com/espressif/idf-extra-components.git"

--- a/freetype/sbom_freetype.yml
+++ b/freetype/sbom_freetype.yml
@@ -1,7 +1,7 @@
 name: freetype
-version: 2.13.0
+version: 2.13.3
 cpe: cpe:2.3:a:freetype:freetype:{}:*:*:*:*:*:*:*
 supplier: 'Organization: freetype <https://www.freetype.org>'
 description: FreeType is a software font engine
 url: https://github.com/freetype/freetype
-hash: de8b92dd7ec634e9e2b25ef534c54a3537555c11
+hash: 42608f77f20749dd6ddc9e0536788eaad70ea4b5


### PR DESCRIPTION
This PR updates freetype from 2.13.0 to 2.13.3.

Among other changes, this fixes CMake warning:
```
CMake Deprecation Warning at idf-extra-components/freetype/freetype/CMakeLists.txt:113 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

