### PR TITLE
feat(esp_jpeg): Add configuration option for working buffer size

### DIFF
--- a/esp_jpeg/CHANGELOG.md
+++ b/esp_jpeg/CHANGELOG.md
@@ -1,0 +1,28 @@
+## 1.2.0
+
+- Added option to for passing user defined working buffer
+
+## 1.1.0
+
+- Added support for decoding images without Huffman tables
+- Fixed undefined configuration options from Kconfig
+
+## 1.0.5~3
+
+- Added option to swap output color bytes regardless of JD_FORMAT
+
+## 1.0.4
+
+- Added ROM implementation support for ESP32-C6
+
+## 1.0.2
+
+- Fixed compiler warnings
+
+## 1.0.1
+
+- Fixed: exclude ESP32-C2 from list of ROM implementations
+
+## 1.0.0
+
+- Initial version

--- a/esp_jpeg/README.md
+++ b/esp_jpeg/README.md
@@ -1,6 +1,7 @@
 # JPEG Decoder: TJpgDec - Tiny JPEG Decompressor
 
 [![Component Registry](https://components.espressif.com/components/espressif/esp_jpeg/badge.svg)](https://components.espressif.com/components/espressif/esp_jpeg)
+![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 TJpgDec is a lightweight JPEG image decompressor optimized for embedded systems with minimal memory consumption.
 

--- a/esp_jpeg/examples/get_started/sdkconfig.defaults
+++ b/esp_jpeg/examples/get_started/sdkconfig.defaults
@@ -1,0 +1,4 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) 5.5.0 Project Minimal Configuration
+#
+CONFIG_TOUCH_SUPPRESS_DEPRECATE_WARN=y

--- a/esp_jpeg/idf_component.yml
+++ b/esp_jpeg/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 description: "JPEG Decoder: TJpgDec"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_jpeg/
 dependencies:

--- a/esp_jpeg/include/jpeg_decoder.h
+++ b/esp_jpeg/include/jpeg_decoder.h
@@ -49,6 +49,13 @@ typedef struct esp_jpeg_image_cfg_s {
     } flags;
 
     struct {
+        void *working_buffer;       /*!< If set to NULL, a working buffer will be allocated in esp_jpeg_decode().
+                                         Tjpgd does not use dynamic allocation, se we pass this buffer to Tjpgd that uses it as scratchpad */
+        size_t working_buffer_size; /*!< Size of the working buffer. Must be set it working_buffer != NULL.
+                                         Default size is 3.1kB or 65kB if JD_FASTDECODE == 2 */
+    } advanced;
+
+    struct {
         uint32_t read;  /*!< Internal count of read bytes */
     } priv;
 } esp_jpeg_image_cfg_t;


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
Add configuration option for working buffer size
