### PR TITLE
change: exclude CVE-2024-50602 from libexpat component

### DIFF
--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.6.4"
+version: "2.6.4~1"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -8,3 +8,5 @@ hash: 2691aff4304a6d7e053199c205620136481b9dd1
 cve-exclude-list:
   - cve: CVE-2024-28757
     reason: Resolved in version 2.6.2
+  - cve: CVE-2024-50602
+    reason: Resolved in version 2.6.4, please see https://github.com/libexpat/libexpat/pull/915


### PR DESCRIPTION


# Checklist

- [X] CI passing

# Change description

This CVE has not yet been processed in the NVD and hence it appears in the IDF SBOM extended scan.
