### PR TITLE
feat(ci): pass SBOM_CHECK_LOCAL_DB to esp-idf-sbom-action

### DIFF
--- a/.github/workflows/vulnerability_scan.yml
+++ b/.github/workflows/vulnerability_scan.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Vulnerability scan
         env:
+          SBOM_CHECK_LOCAL_DB: ${{ vars.SBOM_CHECK_LOCAL_DB }}
           SBOM_MATTERMOST_WEBHOOK: ${{ secrets.SBOM_MATTERMOST_WEBHOOK }}
           NVDAPIKEY: ${{ secrets.NVDAPIKEY }}
         uses: espressif/esp-idf-sbom-action@master


### PR DESCRIPTION
esp-idf-sbom offers two ways to perform vulnerability scanning. The primary method, which is the default, uses the NVD REST API. The alternative method uses the esp-nvd-mirror repository. If there are issues with accessing the NVD REST API, it can be useful to switch to the esp-nvd-mirror easily. Allow to set the SBOM_CHECK_LOCAL_DB github repository variable to switch to esp-nvd-mirror.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
