### PR TITLE
catch2 updates

### DIFF
--- a/catch2/CMakeLists.txt
+++ b/catch2/CMakeLists.txt
@@ -15,7 +15,7 @@ idf_build_get_property(target IDF_TARGET)
 if(NOT target STREQUAL "linux")
     target_link_libraries(${catch_target} PUBLIC idf::pthread)
     # Work around a linking dependency issue in ESP-IDF
-    target_link_libraries(${COMPONENT_LIB} PUBLIC "-Wl,-u getentropy")
+    target_link_options(${COMPONENT_LIB} INTERFACE "-u getentropy")
 endif()
 
 # If console component is present in the build, include the console

--- a/catch2/idf_component.yml
+++ b/catch2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.7.0"
+version: "3.7.1"
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/espressif/idf-extra-components/tree/master/catch2
 repository: https://github.com/espressif/idf-extra-components.git

--- a/catch2/sbom_catch2.yml
+++ b/catch2/sbom_catch2.yml
@@ -1,7 +1,7 @@
 name: catch2
-version: 3.7.0
+version: 3.7.1
 cpe: cpe:2.3:a:catchorg:catch2:{}:*:*:*:*:*:*:*
 supplier: 'Organization: catchorg <https://github.com/catchorg>'
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/catchorg/Catch2
-hash: 31588bb4f56b638dd5afc28d3ebff9b9dcefb88d
+hash: fa43b77429ba76c462b1898d6cd2f2d7a9416b14


### PR DESCRIPTION
- Fixed linking flags specified in a way incompatible with clang-based toolchain (esp-18.1.2_20240912)
   - Catch2 still doesn't work with clang-based toolchain if exceptions are enabled, but at least the build succeeds. Remaining issue to be fixed on clang toolchain side.
- Upgraded Catch2 from 3.7.0 to 3.7.1