### PR TITLE
feat(conftest): Added root level conftest file

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=W0621  # redefined-outer-name
+#
+# IDF is using [pytest](https://github.com/pytest-dev/pytest) and
+# [pytest-embedded plugin](https://github.com/espressif/pytest-embedded) as its test framework.
+#
+# if you found any bug or have any question,
+# please report to https://github.com/espressif/pytest-embedded/issues
+# or discuss at https://github.com/espressif/pytest-embedded/discussions
+import logging
+import os
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from pytest_embedded.plugin import multi_dut_fixture
+
+@pytest.fixture
+@multi_dut_fixture
+def build_dir(target: str, config: str) -> str:
+    return f'build_{target}_{config}'
+
+@pytest.fixture
+@multi_dut_fixture
+def config(request: FixtureRequest) -> str:
+    return getattr(request, 'param', None) or "default"


### PR DESCRIPTION
Added the conftest.py file at root level of repo, the fixture and configuratuions can be used all over repo.

# Description

- Added the conftest.py file at the root level. Added the config and build_dir fixture in the conftest.py. 
- Tested the file using in pre_encrypted_ota example pytest ([PR](https://github.com/espressif/idf-extra-components/pull/398)).
