### PR TITLE
ci: fix pyclang install

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -24,6 +24,7 @@ jobs:
           curl -sSL https://github.com/psastras/sarif-rs/releases/download/clang-tidy-sarif-v0.3.3/clang-tidy-sarif-x86_64-unknown-linux-gnu -o clang-tidy-sarif
           chmod +x clang-tidy-sarif
       - name: Install pyclang
+        shell: bash
         run: |
           . ${IDF_PATH}/export.sh
           pip install pyclang~=0.2.0


### PR DESCRIPTION
The issue is that recent modifications[1] to the ESP-IDF export scripts allow them to identify the export script path only for bash and zsh. For other shells, the export must be executed from within the ESP-IDF directory.

The problem is because the default shell in a GitHub step inside a container is sh instead of bash[2].

> The default shell for run steps inside a container is sh instead of
bash. This can be overridden with jobs.<job_id>.defaults.run or jobs.<job_id>.steps[*].shell.

[1] https://github.com/espressif/esp-idf/commit/cad15b50c40ba1fcb1f63c106805f498c3fc971c
[2] https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainer

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
