### PR TITLE
feat(led_strip): support led strip group based on parlio_tx

### DIFF
--- a/led_strip/CHANGELOG.md
+++ b/led_strip/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.0
+
+- Support for led strip group based on the Parallel IO backend
+  - new interface type led_strip_group_handle
+  - new API led_strip_group_get_strip_handle
+  - new API led_strip_group_del
+
 ## 3.0.0
 
 - Discontinued support for ESP-IDF v4.x

--- a/led_strip/CMakeLists.txt
+++ b/led_strip/CMakeLists.txt
@@ -7,6 +7,10 @@ if(CONFIG_SOC_RMT_SUPPORTED)
     list(APPEND srcs "src/led_strip_rmt_dev.c" "src/led_strip_rmt_encoder.c")
 endif()
 
+if(CONFIG_SOC_PARLIO_SUPPORTED)
+    list(APPEND srcs "src/led_strip_parlio_dev.c")
+endif()
+
 # the SPI backend driver relies on some feature that was available in IDF 5.1
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.1")
     if(CONFIG_SOC_GPSPI_SUPPORTED)
@@ -16,7 +20,7 @@ endif()
 
 # Starting from esp-idf v5.3, the RMT and SPI drivers are moved to separate components
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.3")
-    list(APPEND public_requires "esp_driver_rmt" "esp_driver_spi")
+    list(APPEND public_requires "esp_driver_rmt" "esp_driver_spi" "esp_driver_parlio" "esp_driver_gpio")
 else()
     list(APPEND public_requires "driver")
 endif()

--- a/led_strip/api.md
+++ b/led_strip/api.md
@@ -3,6 +3,7 @@
 ## Header files
 
 - [include/led_strip.h](#file-includeled_striph)
+- [include/led_strip_parlio.h](#file-includeled_strip_parlioh)
 - [include/led_strip_rmt.h](#file-includeled_strip_rmth)
 - [include/led_strip_spi.h](#file-includeled_strip_spih)
 - [include/led_strip_types.h](#file-includeled_strip_typesh)
@@ -16,6 +17,8 @@
 | ---: | :--- |
 |  esp\_err\_t | [**led\_strip\_clear**](#function-led_strip_clear) ([**led\_strip\_handle\_t**](#typedef-led_strip_handle_t) strip) <br>_Clear LED strip (turn off all LEDs)_ |
 |  esp\_err\_t | [**led\_strip\_del**](#function-led_strip_del) ([**led\_strip\_handle\_t**](#typedef-led_strip_handle_t) strip) <br>_Free LED strip resources._ |
+|  esp\_err\_t | [**led\_strip\_group\_del**](#function-led_strip_group_del) ([**led\_strip\_group\_handle\_t**](#typedef-led_strip_group_handle_t) group) <br>_Delete the LED strip group._ |
+|  esp\_err\_t | [**led\_strip\_group\_get\_strip\_handle**](#function-led_strip_group_get_strip_handle) ([**led\_strip\_group\_handle\_t**](#typedef-led_strip_group_handle_t) group, uint8\_t index, [**led\_strip\_handle\_t**](#typedef-led_strip_handle_t) \*ret\_strip) <br>_Get the handle of the LED strip._ |
 |  esp\_err\_t | [**led\_strip\_refresh**](#function-led_strip_refresh) ([**led\_strip\_handle\_t**](#typedef-led_strip_handle_t) strip) <br>_Refresh memory colors to LEDs._ |
 |  esp\_err\_t | [**led\_strip\_set\_pixel**](#function-led_strip_set_pixel) ([**led\_strip\_handle\_t**](#typedef-led_strip_handle_t) strip, uint32\_t index, uint32\_t red, uint32\_t green, uint32\_t blue) <br>_Set RGB for a specific pixel._ |
 |  esp\_err\_t | [**led\_strip\_set\_pixel\_hsv**](#function-led_strip_set_pixel_hsv) ([**led\_strip\_handle\_t**](#typedef-led_strip_handle_t) strip, uint32\_t index, uint16\_t hue, uint8\_t saturation, uint8\_t value) <br>_Set HSV for a specific pixel._ |
@@ -60,6 +63,48 @@ esp_err_t led_strip_del (
 
 - ESP\_OK: Free resources successfully
 - ESP\_FAIL: Free resources failed because error occurred
+
+### function `led_strip_group_del`
+
+_Delete the LED strip group._
+
+```c
+esp_err_t led_strip_group_del (
+    led_strip_group_handle_t group
+) 
+```
+
+**Parameters:**
+
+- `group` Handle of the LED strip group
+
+**Returns:**
+
+- ESP\_OK: Delete the LED strip group successfully
+- ESP\_ERR\_INVALID\_ARG: Invalid argument
+
+### function `led_strip_group_get_strip_handle`
+
+_Get the handle of the LED strip._
+
+```c
+esp_err_t led_strip_group_get_strip_handle (
+    led_strip_group_handle_t group,
+    uint8_t index,
+    led_strip_handle_t *ret_strip
+) 
+```
+
+**Parameters:**
+
+- `group` LED strip group handle
+- `index` Index of the LED strip in the group
+- `ret_strip` Pointer to store the handle of the LED strip
+
+**Returns:**
+
+- ESP\_OK: Get the handle of the LED strip successfully
+- ESP\_ERR\_INVALID\_ARG: Invalid argument
 
 ### function `led_strip_refresh`
 
@@ -177,6 +222,65 @@ Also see `led_strip_set_pixel` if you only want to specify the RGB part of the c
 - ESP\_OK: Set RGBW color for a specific pixel successfully
 - ESP\_ERR\_INVALID\_ARG: Set RGBW color for a specific pixel failed because of an invalid argument
 - ESP\_FAIL: Set RGBW color for a specific pixel failed because other error occurred
+
+## File include/led_strip_parlio.h
+
+## Structures and Types
+
+| Type | Name |
+| ---: | :--- |
+| struct | [**led\_strip\_parlio\_config\_t**](#struct-led_strip_parlio_config_t) <br>_LED Strip PARLIO specific configuration._ |
+
+## Functions
+
+| Type | Name |
+| ---: | :--- |
+|  esp\_err\_t | [**led\_strip\_new\_parlio\_group**](#function-led_strip_new_parlio_group) (const [**led\_strip\_config\_t**](#struct-led_strip_config_t) \*led\_config, const [**led\_strip\_parlio\_config\_t**](#struct-led_strip_parlio_config_t) \*parlio\_config, [**led\_strip\_group\_handle\_t**](#typedef-led_strip_group_handle_t) \*ret\_group) <br>_Create LED strip group based on PARLIO\_TX unit._ |
+
+## Structures and Types Documentation
+
+### struct `led_strip_parlio_config_t`
+
+_LED Strip PARLIO specific configuration._
+
+Variables:
+
+- parlio\_clock\_source\_t clk_src  <br>PARLIO clock source
+
+- uint8\_t strip_count  <br>Number of LED strips. Should be a power of 2 and not larger than SOC\_PARLIO\_TX\_UNIT\_MAX\_DATA\_WIDTH
+
+- gpio\_num\_t strip_gpio_num  <br>GPIO number that used by LED strip
+
+## Functions Documentation
+
+### function `led_strip_new_parlio_group`
+
+_Create LED strip group based on PARLIO\_TX unit._
+
+```c
+esp_err_t led_strip_new_parlio_group (
+    const led_strip_config_t *led_config,
+    const led_strip_parlio_config_t *parlio_config,
+    led_strip_group_handle_t *ret_group
+) 
+```
+
+**Note:**
+
+The strip\_gpio\_num in led\_config no longer takes effect, and other configurations will be shared by all LED strips in the group.
+
+**Parameters:**
+
+- `led_config` LED strip configuration
+- `parlio_config` PARLIO specific configuration
+- `ret_group` Returned LED strip group handle
+
+**Returns:**
+
+- ESP\_OK: create LED strip handle successfully
+- ESP\_ERR\_INVALID\_ARG: create LED strip handle failed because of invalid argument
+- ESP\_ERR\_NOT\_SUPPORTED: create LED strip handle failed because of unsupported configuration
+- ESP\_ERR\_NO\_MEM: create LED strip handle failed because of out of memory
 
 ## File include/led_strip_rmt.h
 
@@ -315,6 +419,7 @@ Although only the MOSI line is used for generating the signal, the whole SPI bus
 | enum  | [**led\_model\_t**](#enum-led_model_t)  <br>_LED strip model._ |
 | struct | [**led\_strip\_config\_t**](#struct-led_strip_config_t) <br>_LED Strip common configurations The common configurations are not specific to any backend peripheral._ |
 | struct | [**led\_strip\_extra\_flags**](#struct-led_strip_config_tled_strip_extra_flags) <br> |
+| typedef struct [**led\_strip\_group\_t**](#struct-led_strip_group_t) \* | [**led\_strip\_group\_handle\_t**](#typedef-led_strip_group_handle_t)  <br>_Type of LED strip group handle._ |
 | typedef struct [**led\_strip\_t**](#struct-led_strip_t) \* | [**led\_strip\_handle\_t**](#typedef-led_strip_handle_t)  <br>_Type of LED strip handle._ |
 
 ## Macros
@@ -366,6 +471,7 @@ _LED strip model._
 enum led_model_t {
     LED_MODEL_WS2812,
     LED_MODEL_SK6812,
+    LED_MODEL_WS2811,
     LED_MODEL_INVALID
 };
 ```
@@ -395,6 +501,14 @@ Variables:
 Variables:
 
 - uint32\_t invert_out  <br>Invert output signal
+
+### typedef `led_strip_group_handle_t`
+
+_Type of LED strip group handle._
+
+```c
+typedef struct led_strip_group_t* led_strip_group_handle_t;
+```
 
 ### typedef `led_strip_handle_t`
 
@@ -438,10 +552,46 @@ _Helper macros to set the color component format._
 
 | Type | Name |
 | ---: | :--- |
+| struct | [**led\_strip\_group\_t**](#struct-led_strip_group_t) <br>_LED strip group interface definition._ |
+| typedef struct [**led\_strip\_group\_t**](#struct-led_strip_group_t) | [**led\_strip\_group\_t**](#typedef-led_strip_group_t)  <br> |
 | struct | [**led\_strip\_t**](#struct-led_strip_t) <br>_LED strip interface definition._ |
-| typedef struct led\_strip\_t | [**led\_strip\_t**](#typedef-led_strip_t)  <br> |
+| typedef struct [**led\_strip\_t**](#struct-led_strip_t) | [**led\_strip\_t**](#typedef-led_strip_t)  <br> |
 
 ## Structures and Types Documentation
+
+### struct `led_strip_group_t`
+
+_LED strip group interface definition._
+
+Variables:
+
+- esp\_err\_t(\* del  <br>_Free LED strip group resources._<br>**Parameters:**
+
+- `group` LED strip group
+
+**Returns:**
+
+- ESP\_OK: Free resources successfully
+- ESP\_FAIL: Free resources failed because error occurred
+
+- esp\_err\_t(\* get_strip_handle  <br>_Get LED strip handle by index._<br>**Parameters:**
+
+- `group` LED strip group
+- `index` LED strip index
+- `ret_strip` Retured LED strip handle
+
+**Returns:**
+
+- ESP\_OK: Success
+- ESP\_ERR\_INVALID\_ARG: Invalid argument
+
+### typedef `led_strip_group_t`
+
+```c
+typedef struct led_strip_group_t led_strip_group_t;
+```
+
+Type of LED group strip
 
 ### struct `led_strip_t`
 

--- a/led_strip/examples/led_strip_parlio_ws2812/CMakeLists.txt
+++ b/led_strip/examples/led_strip_parlio_ws2812/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(COMPONENTS main)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(led_strip_parlio_ws2812)

--- a/led_strip/examples/led_strip_parlio_ws2812/README.md
+++ b/led_strip/examples/led_strip_parlio_ws2812/README.md
@@ -1,0 +1,31 @@
+# LED Strip Example (Parallel IO backend + WS2812)
+
+This example demonstrates how to blink the WS2812 LED using the [led_strip](https://components.espressif.com/component/espressif/led_strip) component.
+
+## How to Use Example
+
+### Hardware Required
+
+* A development board with Espressif SoC
+* A USB cable for Power supply and programming
+* WS2812 LED strip
+
+### Configure the Example
+
+Before project configuration and build, be sure to set the correct chip target using `idf.py set-target <chip_name>`. Then assign the proper GPIO in the [source file](main/led_strip_parlio_ws2812_main.c). If your led strip has multiple LEDs, don't forget update the number.
+
+### Build and Flash
+
+Run `idf.py -p PORT build flash monitor` to build, flash and monitor the project.
+
+(To exit the serial monitor, type ``Ctrl-]``.)
+
+See the [Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/latest/get-started/index.html) for full steps to configure and use ESP-IDF to build projects.
+
+## Example Output
+
+```text
+I (299) gpio: GPIO[14]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
+I (309) example: Created LED strip object with PARLIO backend
+I (309) example: Start blinking LED strip
+```

--- a/led_strip/examples/led_strip_parlio_ws2812/main/CMakeLists.txt
+++ b/led_strip/examples/led_strip_parlio_ws2812/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "led_strip_parlio_ws2812_main.c"
+                       INCLUDE_DIRS ".")

--- a/led_strip/examples/led_strip_parlio_ws2812/main/idf_component.yml
+++ b/led_strip/examples/led_strip_parlio_ws2812/main/idf_component.yml
@@ -1,0 +1,6 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/led_strip:
+    version: '^3'
+    override_path: '../../../'
+  idf: ">=5.1"

--- a/led_strip/examples/led_strip_parlio_ws2812/main/led_strip_parlio_ws2812_main.c
+++ b/led_strip/examples/led_strip_parlio_ws2812/main/led_strip_parlio_ws2812_main.c
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Unlicense OR CC0-1.0
+ */
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "led_strip.h"
+#include "esp_log.h"
+#include "esp_err.h"
+
+// GPIO assignment
+#define LED_STRIP0_GPIO_PIN  0
+#define LED_STRIP1_GPIO_PIN  1
+#define LED_STRIP2_GPIO_PIN  2
+#define LED_STRIP3_GPIO_PIN  3
+
+// Numbers of the LED in the strip
+#define LED_STRIP_LED_COUNT 8
+// Numbers of the strip
+#define LED_STRIP_COUNT 4
+
+static const char *TAG = "example";
+
+led_strip_handle_t *configure_led(void)
+{
+    // LED strip general initialization, according to your led board design
+    led_strip_config_t strip_config = {
+        .max_leds = LED_STRIP_LED_COUNT,      // The number of LEDs in the strip,
+        .led_model = LED_MODEL_WS2812,        // LED strip model
+        // set the color order of the strip: GRB
+        .color_component_format = {
+            .format = {
+                .r_pos = 1, // red is the second byte in the color data
+                .g_pos = 0, // green is the first byte in the color data
+                .b_pos = 2, // blue is the third byte in the color data
+                .num_components = 3, // total 3 color components
+            },
+        },
+        .flags = {
+            .invert_out = false, // don't invert the output signal
+        }
+    };
+
+    // LED strip backend configuration: PARLIO
+    led_strip_parlio_config_t parlio_config = {
+        .clk_src = PARLIO_CLK_SRC_DEFAULT, // different clock source can lead to different power consumption
+        .strip_count = LED_STRIP_COUNT,
+        .strip_gpio_num = {
+            LED_STRIP0_GPIO_PIN,
+            LED_STRIP1_GPIO_PIN,
+            LED_STRIP2_GPIO_PIN,
+            LED_STRIP3_GPIO_PIN,
+        },
+    };
+
+    // LED Strip group handle
+    led_strip_group_handle_t parlio_group;
+    ESP_ERROR_CHECK(led_strip_new_parlio_group(&strip_config, &parlio_config, &parlio_group));
+    led_strip_handle_t *led_strip = calloc(LED_STRIP_COUNT, sizeof(led_strip_handle_t));
+    for (int i = 0; i < LED_STRIP_COUNT; i++) {
+        ESP_ERROR_CHECK(led_strip_group_get_strip_handle(parlio_group, i, &led_strip[i]));
+    }
+
+    ESP_LOGI(TAG, "Created LED strip object with PARLIO backend");
+    return led_strip;
+}
+
+void app_main(void)
+{
+    led_strip_handle_t *led_strip = configure_led();
+    bool led_on_off = false;
+
+    ESP_LOGI(TAG, "Start blinking LED strip");
+    while (1) {
+        if (led_on_off) {
+            /* Set the LED pixel using RGB from 0 (0%) to 255 (100%) for each color */
+            for (int i = 0; i < LED_STRIP_COUNT; i++) {
+                for (int j = 0; j < LED_STRIP_LED_COUNT; j++) {
+                    ESP_ERROR_CHECK(led_strip_set_pixel(led_strip[i], j, 5, 5, 5));
+                }
+            }
+
+            /* Refresh the strip to send data */
+            for (int i = 0; i < LED_STRIP_COUNT; i++) {
+                ESP_ERROR_CHECK(led_strip_refresh(led_strip[i]));
+            }
+            ESP_LOGI(TAG, "LED ON!");
+        } else {
+            /* Set all LED off to clear all pixels */
+            for (int i = 0; i < LED_STRIP_COUNT; i++) {
+                ESP_ERROR_CHECK(led_strip_clear(led_strip[i]));
+            }
+            ESP_LOGI(TAG, "LED OFF!");
+        }
+
+        led_on_off = !led_on_off;
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+}

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.0"
+version: "3.1.0"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/led_strip/include/led_strip.h
+++ b/led_strip/include/led_strip.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,7 @@
 #include "esp_err.h"
 #include "led_strip_rmt.h"
 #include "led_strip_spi.h"
+#include "led_strip_parlio.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,6 +102,30 @@ esp_err_t led_strip_clear(led_strip_handle_t strip);
  *      - ESP_FAIL: Free resources failed because error occurred
  */
 esp_err_t led_strip_del(led_strip_handle_t strip);
+
+/**
+ * @brief Get the handle of the LED strip
+ *
+ * @param group: LED strip group handle
+ * @param index: Index of the LED strip in the group
+ * @param ret_strip: Pointer to store the handle of the LED strip
+ *
+ * @return
+ *      - ESP_OK: Get the handle of the LED strip successfully
+ *      - ESP_ERR_INVALID_ARG: Invalid argument
+ */
+esp_err_t led_strip_group_get_strip_handle(led_strip_group_handle_t group, uint8_t index, led_strip_handle_t *ret_strip);
+
+/**
+ * @brief Delete the LED strip group
+ *
+ * @param group: Handle of the LED strip group
+ *
+ * @return
+ *      - ESP_OK: Delete the LED strip group successfully
+ *      - ESP_ERR_INVALID_ARG: Invalid argument
+ */
+esp_err_t led_strip_group_del(led_strip_group_handle_t group);
 
 #ifdef __cplusplus
 }

--- a/led_strip/include/led_strip_parlio.h
+++ b/led_strip/include/led_strip_parlio.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+#include "driver/parlio_tx.h"
+#include "driver/parlio_types.h"
+#include "led_strip_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief LED Strip PARLIO specific configuration
+ */
+typedef struct {
+    parlio_clock_source_t clk_src; /*!< PARLIO clock source */
+    uint8_t strip_count;              /*!< Number of LED strips. Should be a power of 2 and not larger than SOC_PARLIO_TX_UNIT_MAX_DATA_WIDTH */
+    gpio_num_t strip_gpio_num[SOC_PARLIO_TX_UNIT_MAX_DATA_WIDTH];   /*!< GPIO number that used by LED strip */
+} led_strip_parlio_config_t;
+
+/**
+ * @brief Create LED strip group based on PARLIO_TX unit
+ *
+ * @note The strip_gpio_num in led_config no longer takes effect, and other configurations will be shared by all LED strips in the group.
+ *
+ * @param led_config LED strip configuration
+ * @param parlio_config PARLIO specific configuration
+ * @param ret_group Returned LED strip group handle
+ * @return
+ *      - ESP_OK: create LED strip handle successfully
+ *      - ESP_ERR_INVALID_ARG: create LED strip handle failed because of invalid argument
+ *      - ESP_ERR_NOT_SUPPORTED: create LED strip handle failed because of unsupported configuration
+ *      - ESP_ERR_NO_MEM: create LED strip handle failed because of out of memory
+ */
+esp_err_t led_strip_new_parlio_group(const led_strip_config_t *led_config, const led_strip_parlio_config_t *parlio_config, led_strip_group_handle_t *ret_group);
+
+#ifdef __cplusplus
+}
+#endif

--- a/led_strip/include/led_strip_types.h
+++ b/led_strip/include/led_strip_types.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,6 +15,11 @@ extern "C" {
  * @brief Type of LED strip handle
  */
 typedef struct led_strip_t *led_strip_handle_t;
+
+/**
+ * @brief Type of LED strip group handle
+ */
+typedef struct led_strip_group_t *led_strip_group_handle_t;
 
 /**
  * @brief LED strip model

--- a/led_strip/interface/led_strip_interface.h
+++ b/led_strip/interface/led_strip_interface.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,8 @@ extern "C" {
 #endif
 
 typedef struct led_strip_t led_strip_t; /*!< Type of LED strip */
+
+typedef struct led_strip_group_t led_strip_group_t; /*!< Type of LED group strip */
 
 /**
  * @brief LED strip interface definition
@@ -88,6 +90,35 @@ struct led_strip_t {
      *      - ESP_FAIL: Free resources failed because error occurred
      */
     esp_err_t (*del)(led_strip_t *strip);
+};
+
+
+/**
+ * @brief LED strip group interface definition
+ */
+struct led_strip_group_t {
+    /**
+     * @brief Get LED strip handle by index
+     *
+     * @param group: LED strip group
+     * @param index: LED strip index
+     * @param ret_strip: Retured LED strip handle
+     *
+     * @return
+     *     - ESP_OK: Success
+     *     - ESP_ERR_INVALID_ARG: Invalid argument
+     */
+    esp_err_t (*get_strip_handle)(led_strip_group_t *group, uint8_t index, led_strip_handle_t *ret_strip);
+    /**
+     * @brief Free LED strip group resources
+     *
+     * @param group: LED strip group
+     *
+     * @return
+     *      - ESP_OK: Free resources successfully
+     *      - ESP_FAIL: Free resources failed because error occurred
+     */
+    esp_err_t (*del)(led_strip_group_t *group);
 };
 
 #ifdef __cplusplus

--- a/led_strip/src/led_strip_api.c
+++ b/led_strip/src/led_strip_api.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -91,4 +91,16 @@ esp_err_t led_strip_del(led_strip_handle_t strip)
 {
     ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
     return strip->del(strip);
+}
+
+esp_err_t led_strip_group_get_strip_handle(led_strip_group_handle_t group, uint8_t index, led_strip_handle_t *strip)
+{
+    ESP_RETURN_ON_FALSE(group, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return group->get_strip_handle(group, index, strip);
+}
+
+esp_err_t led_strip_group_del(led_strip_group_handle_t group)
+{
+    ESP_RETURN_ON_FALSE(group, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    return group->del(group);
 }

--- a/led_strip/src/led_strip_parlio_dev.c
+++ b/led_strip/src/led_strip_parlio_dev.c
@@ -1,0 +1,287 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <sys/cdefs.h>
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_rom_gpio.h"
+#include "led_strip.h"
+#include "led_strip_interface.h"
+
+#define LED_STRIP_PARLIO_DEFAULT_RESOLUTION (2.5 * 1000 * 1000) // 2.5MHz resolution
+#define LED_STRIP_PARLIO_DEFAULT_TRANS_QUEUE_SIZE 16
+#define LED_STRIP_PARLIO_RESET_TIME 16 // Reset time between two frames, 16 * 400 ns/bit * 8 bit = 51.2 us
+
+#define DATA_BYTES_PER_COLOR_BYTE 3
+#define DATA_BITS_PER_COLOR_BYTE (DATA_BYTES_PER_COLOR_BYTE * 8)
+
+static const char *TAG = "led_strip_parlio";
+
+typedef struct led_strip_parlio_group_t led_strip_parlio_group_t;
+typedef struct led_strip_parlio_obj led_strip_parlio_obj;
+
+struct led_strip_parlio_obj {
+    led_strip_t base;
+    uint8_t strip_index;
+    led_strip_parlio_group_t *parlio_group;
+};
+
+struct led_strip_parlio_group_t {
+    led_strip_group_t base; // Base object
+    uint8_t strip_count;    // Number of the LED strip channels
+    uint8_t buffer_bytes_per_color;  // PARLIO buffer bytes occupied by 1 color byte
+    uint8_t bytes_per_pixel; // Number of bytes per pixel
+    uint32_t strip_len;     // Number of LEDs in one strip
+    parlio_tx_unit_handle_t tx_unit; // PARLIO TX unit handle
+    led_color_component_format_t component_fmt;  // LED color component format
+    led_strip_parlio_obj *parlio_strip[SOC_PARLIO_TX_UNIT_MAX_DATA_WIDTH]; // PARLIO LED strip object
+    uint8_t *reset_buf;
+    uint8_t pixel_buf[];
+};
+
+static void __led_strip_parlio_bit(uint8_t data, uint8_t *buf, uint8_t strip_count, uint8_t strip_index)
+{
+    // Each color of 1 bit is represented by 3 bits of PARLIO, low_level:100 ,high_level:110
+    // So a color byte occupies 24 data bits of PARLIO.
+    // And buffer byte is share by all strip
+    // 1 data bit occupies (strip_count / 8) buffer bits
+
+    uint8_t buffer_index = 0;
+    uint8_t logic_dilimiter = strip_index;
+    // Reverse count to change LSB to MSB
+    for (int i = 7; i >= 0; i--) {
+        while (logic_dilimiter >= 8) {
+            logic_dilimiter -= 8;
+            buffer_index += 1;
+        }
+        *(buf + buffer_index) |= BIT(logic_dilimiter);
+        logic_dilimiter += strip_count;
+        while (logic_dilimiter >= 8) {
+            logic_dilimiter -= 8;
+            buffer_index += 1;
+        }
+        if (data & BIT(i)) {
+            *(buf + buffer_index) |= BIT(logic_dilimiter);
+        } else {
+            *(buf + buffer_index) &= ~BIT(logic_dilimiter);
+        }
+        // the last color bit is always 0, skip
+        logic_dilimiter += 2 * strip_count;
+    }
+}
+
+static esp_err_t led_strip_parlio_set_pixel(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue)
+{
+    led_strip_parlio_obj *parlio_strip = __containerof(strip, led_strip_parlio_obj, base);
+    led_strip_parlio_group_t *parlio_group = parlio_strip->parlio_group;
+    ESP_RETURN_ON_FALSE(index < parlio_group->strip_len, ESP_ERR_INVALID_ARG, TAG, "index out of maximum number of LEDs");
+    // 1 pixel needs 3 color bytes, 1 color byte needs (DATA_BYTES_PER_COLOR_BYTE * strip_count) bytes
+
+    uint8_t strip_count = parlio_group->strip_count;
+    uint8_t buffer_bytes_per_color = parlio_group->buffer_bytes_per_color;
+    uint32_t start = index * parlio_group->bytes_per_pixel * buffer_bytes_per_color;
+    uint8_t *pixel_buf = parlio_group->pixel_buf;
+    led_color_component_format_t component_fmt = parlio_group->component_fmt;
+
+    __led_strip_parlio_bit(red, &pixel_buf[start + buffer_bytes_per_color * component_fmt.format.r_pos], strip_count, parlio_strip->strip_index);
+    __led_strip_parlio_bit(green, &pixel_buf[start + buffer_bytes_per_color * component_fmt.format.g_pos], strip_count, parlio_strip->strip_index);
+    __led_strip_parlio_bit(blue, &pixel_buf[start + buffer_bytes_per_color * component_fmt.format.b_pos], strip_count, parlio_strip->strip_index);
+    if (component_fmt.format.num_components > 3) {
+        __led_strip_parlio_bit(0, &pixel_buf[start + buffer_bytes_per_color * component_fmt.format.w_pos], strip_count, parlio_strip->strip_index);
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_parlio_set_pixel_rgbw(led_strip_t *strip, uint32_t index, uint32_t red, uint32_t green, uint32_t blue, uint32_t white)
+{
+    led_strip_parlio_obj *parlio_strip = __containerof(strip, led_strip_parlio_obj, base);
+    led_strip_parlio_group_t *parlio_group = parlio_strip->parlio_group;
+    led_color_component_format_t component_fmt = parlio_group->component_fmt;
+    ESP_RETURN_ON_FALSE(index < parlio_group->strip_len, ESP_ERR_INVALID_ARG, TAG, "index out of maximum number of LEDs");
+    ESP_RETURN_ON_FALSE(component_fmt.format.num_components == 4, ESP_ERR_INVALID_ARG, TAG, "led doesn't have 4 components");
+
+    uint8_t strip_count = parlio_group->strip_count;
+    uint8_t buffer_bytes_per_color = parlio_group->buffer_bytes_per_color;
+    uint32_t start = index * parlio_group->bytes_per_pixel * buffer_bytes_per_color;
+    uint8_t *pixel_buf = parlio_group->pixel_buf;
+
+    __led_strip_parlio_bit(red, &pixel_buf[start + buffer_bytes_per_color * component_fmt.format.r_pos], strip_count, parlio_strip->strip_index);
+    __led_strip_parlio_bit(green, &pixel_buf[start + buffer_bytes_per_color * component_fmt.format.g_pos], strip_count, parlio_strip->strip_index);
+    __led_strip_parlio_bit(blue, &pixel_buf[start + buffer_bytes_per_color * component_fmt.format.b_pos], strip_count, parlio_strip->strip_index);
+    __led_strip_parlio_bit(white, &pixel_buf[start + buffer_bytes_per_color * component_fmt.format.w_pos], strip_count, parlio_strip->strip_index);
+
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_parlio_refresh(led_strip_t *strip)
+{
+    led_strip_parlio_obj *parlio_strip = __containerof(strip, led_strip_parlio_obj, base);
+    led_strip_parlio_group_t *parlio_group = parlio_strip->parlio_group;
+    parlio_transmit_config_t transmit_config = {
+        .idle_value = 0x00,
+        .flags.queue_nonblocking = true,
+    };
+    parlio_tx_unit_handle_t tx_unit = parlio_group->tx_unit;
+    uint8_t *tx_buffer = parlio_group->pixel_buf;
+    size_t tx_length = parlio_group->strip_len * parlio_group->bytes_per_pixel * parlio_group->buffer_bytes_per_color * 8;
+    uint8_t *reset_buffer = parlio_group->reset_buf;
+    size_t reset_length = parlio_group->strip_count * LED_STRIP_PARLIO_RESET_TIME * 8;
+    ESP_RETURN_ON_ERROR(parlio_tx_unit_transmit(tx_unit, tx_buffer, tx_length, &transmit_config), TAG, "transmit pixels by PARLIO failed");
+    ESP_RETURN_ON_ERROR(parlio_tx_unit_transmit(tx_unit, reset_buffer, reset_length, &transmit_config), TAG, "transmit pixels by PARLIO failed");
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_parlio_clear(led_strip_t *strip)
+{
+    led_strip_parlio_obj *parlio_strip = __containerof(strip, led_strip_parlio_obj, base);
+    led_strip_parlio_group_t *parlio_group = parlio_strip->parlio_group;
+    uint8_t buffer_bytes_per_color = parlio_group->buffer_bytes_per_color;
+
+    uint8_t *buf = parlio_group->pixel_buf;
+    for (int index = 0; index < parlio_group->strip_len * parlio_group->bytes_per_pixel; index++) {
+        __led_strip_parlio_bit(0, buf, parlio_group->strip_count, parlio_strip->strip_index);
+        buf += buffer_bytes_per_color;
+    }
+
+    return led_strip_parlio_refresh(strip);
+}
+
+static esp_err_t led_strip_parlio_del(led_strip_t *strip)
+{
+    ESP_RETURN_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, TAG, "please call ""led_strip_group_del"" to delete the group");
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_parlio_group_get_strip_handle(led_strip_group_t *strip_group, uint8_t index, led_strip_handle_t *ret_strip)
+{
+    led_strip_parlio_group_t *parlio_group = __containerof(strip_group, led_strip_parlio_group_t, base);
+    ESP_RETURN_ON_FALSE(index <= parlio_group->strip_count, ESP_ERR_INVALID_ARG, TAG, "invalid index");
+    *ret_strip = &parlio_group->parlio_strip[index]->base;
+    return ESP_OK;
+}
+
+static esp_err_t led_strip_parlio_group_del(led_strip_group_t *strip_group)
+{
+    led_strip_parlio_group_t *parlio_group = __containerof(strip_group, led_strip_parlio_group_t, base);
+
+    if (parlio_group->tx_unit) {
+        ESP_RETURN_ON_ERROR(parlio_tx_unit_disable(parlio_group->tx_unit), TAG, "disable parlio_tx failed");
+        ESP_RETURN_ON_ERROR(parlio_del_tx_unit(parlio_group->tx_unit), TAG, "delete parlio_tx failed");
+    }
+    for (int i = 0; i < parlio_group->strip_count; i++) {
+        if (parlio_group->parlio_strip[i]) {
+            free(parlio_group->parlio_strip[i]);
+        }
+    }
+    if (parlio_group->reset_buf) {
+        free(parlio_group->reset_buf);
+    }
+    free(parlio_group);
+
+    return ESP_OK;
+}
+
+esp_err_t led_strip_new_parlio_group(const led_strip_config_t *led_config, const led_strip_parlio_config_t *parlio_config, led_strip_group_handle_t *ret_group)
+{
+    led_strip_parlio_group_t *parlio_group = NULL;
+    led_strip_parlio_obj *parlio_strip = NULL;
+    esp_err_t ret = ESP_OK;
+    ESP_RETURN_ON_FALSE(led_config && parlio_config && ret_group, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+    // strip_count must be power of 2 and less than or equal to SOC_PARLIO_TX_UNIT_MAX_DATA_WIDTH
+    ESP_RETURN_ON_FALSE(parlio_config->strip_count && (parlio_config->strip_count <= SOC_PARLIO_TX_UNIT_MAX_DATA_WIDTH) && ((parlio_config->strip_count & (parlio_config->strip_count - 1)) == 0),
+                        ESP_ERR_INVALID_ARG, TAG, "invalid strip count");
+
+    led_color_component_format_t component_fmt = led_config->color_component_format;
+    // If R/G/B order is not specified, set default GRB order as fallback
+    if (component_fmt.format_id == 0) {
+        component_fmt = LED_STRIP_COLOR_COMPONENT_FMT_GRB;
+    }
+    // check the validation of the color component format
+    uint8_t mask = 0;
+    if (component_fmt.format.num_components == 3) {
+        mask = BIT(component_fmt.format.r_pos) | BIT(component_fmt.format.g_pos) | BIT(component_fmt.format.b_pos);
+        // Check for invalid values
+        ESP_RETURN_ON_FALSE(mask == 0x07, ESP_ERR_INVALID_ARG, TAG, "invalid order argument");
+    } else if (component_fmt.format.num_components == 4) {
+        mask = BIT(component_fmt.format.r_pos) | BIT(component_fmt.format.g_pos) | BIT(component_fmt.format.b_pos) | BIT(component_fmt.format.w_pos);
+        // Check for invalid values
+        ESP_RETURN_ON_FALSE(mask == 0x0F, ESP_ERR_INVALID_ARG, TAG, "invalid order argument");
+    } else {
+        ESP_RETURN_ON_FALSE(false, ESP_ERR_INVALID_ARG, TAG, "invalid number of color components: %d", component_fmt.format.num_components);
+    }
+    // TODO: we assume each color component is 8 bits, may need to support other configurations in the future, e.g. 10bits per color component?
+    uint8_t bytes_per_pixel = component_fmt.format.num_components;
+    uint32_t mem_caps = MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA;
+
+    // buffer is share by all strip
+    uint32_t buffer_bytes_per_color = parlio_config->strip_count * DATA_BYTES_PER_COLOR_BYTE;
+    parlio_group = heap_caps_calloc(1, sizeof(led_strip_parlio_group_t) + led_config->max_leds * bytes_per_pixel * buffer_bytes_per_color, mem_caps);
+    parlio_strip = heap_caps_calloc(parlio_config->strip_count, sizeof(led_strip_parlio_obj), mem_caps);
+    uint8_t *parlio_reset_buf = heap_caps_calloc(1, parlio_config->strip_count * LED_STRIP_PARLIO_RESET_TIME, mem_caps);
+    ESP_GOTO_ON_FALSE(parlio_group && parlio_strip && parlio_reset_buf, ESP_ERR_NO_MEM, err, TAG, "no mem for parlio strip");
+
+    // for backward compatibility, if the user does not set the clk_src, use the default value
+    parlio_clock_source_t clk_src = PARLIO_CLK_SRC_DEFAULT;
+    if (parlio_config->clk_src) {
+        clk_src = parlio_config->clk_src;
+    }
+
+    parlio_tx_unit_config_t parlio_tx_unit_config = {
+        .clk_src = clk_src,
+        .data_width = parlio_config->strip_count,
+        .clk_in_gpio_num = -1,
+        .clk_out_gpio_num = -1,
+        .output_clk_freq_hz = LED_STRIP_PARLIO_DEFAULT_RESOLUTION,
+        .trans_queue_depth = LED_STRIP_PARLIO_DEFAULT_TRANS_QUEUE_SIZE,
+        .max_transfer_size = led_config->max_leds * bytes_per_pixel * buffer_bytes_per_color + LED_STRIP_PARLIO_RESET_TIME * parlio_config->strip_count,
+        .valid_gpio_num = -1,
+    };
+    memcpy(parlio_tx_unit_config.data_gpio_nums, parlio_config->strip_gpio_num, parlio_config->strip_count * sizeof(parlio_config->strip_gpio_num[0]));
+    ESP_LOGW(TAG, "parlio tx unit config: data_width:%d, max_transfer_size:%d", parlio_tx_unit_config.data_width, parlio_tx_unit_config.max_transfer_size);
+
+    ESP_GOTO_ON_ERROR(parlio_new_tx_unit(&parlio_tx_unit_config, &parlio_group->tx_unit), err, TAG, "init parlio unit failed");
+    ESP_GOTO_ON_ERROR(parlio_tx_unit_enable(parlio_group->tx_unit), err, TAG, "enable parlio unit failed");
+    //ensure the reset time is enough
+    esp_rom_delay_us(10);
+
+    parlio_group->buffer_bytes_per_color = buffer_bytes_per_color;
+    parlio_group->component_fmt = component_fmt;
+    parlio_group->bytes_per_pixel = bytes_per_pixel;
+    parlio_group->strip_len = led_config->max_leds;
+    parlio_group->strip_count = parlio_config->strip_count;
+    parlio_group->reset_buf = parlio_reset_buf;
+    parlio_group->base.get_strip_handle = led_strip_parlio_group_get_strip_handle;
+    parlio_group->base.del = led_strip_parlio_group_del;
+
+    for (int i = 0; i < parlio_group->strip_count; i++) {
+        parlio_strip[i].base.set_pixel = led_strip_parlio_set_pixel;
+        parlio_strip[i].base.set_pixel_rgbw = led_strip_parlio_set_pixel_rgbw;
+        parlio_strip[i].base.refresh = led_strip_parlio_refresh;
+        parlio_strip[i].base.clear = led_strip_parlio_clear;
+        parlio_strip[i].base.del = led_strip_parlio_del;
+        parlio_strip[i].strip_index = i;
+        parlio_strip[i].parlio_group = parlio_group;
+        parlio_group->parlio_strip[i] = &parlio_strip[i];
+    }
+    *ret_group = &parlio_group->base;
+    return ESP_OK;
+err:
+    if (parlio_group) {
+        if (parlio_group->tx_unit) {
+            parlio_del_tx_unit(parlio_group->tx_unit);
+        }
+        free(parlio_group);
+    }
+    if (parlio_strip) {
+        free(parlio_strip);
+    }
+    if (parlio_reset_buf) {
+        free(parlio_reset_buf);
+    }
+    return ret;
+}


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
