### PR TITLE
Fixes bug in led_strip_rmt_ws2812 example (IEC-250)

### DIFF
--- a/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
+++ b/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
@@ -36,7 +36,7 @@ led_strip_handle_t configure_led(void)
     led_strip_rmt_config_t rmt_config = {
         .clk_src = RMT_CLK_SRC_DEFAULT,        // different clock source can lead to different power consumption
         .resolution_hz = LED_STRIP_RMT_RES_HZ, // RMT counter clock frequency
-        .mem_block_symbols = 64,               // the memory size of each RMT channel, in words (4 bytes)
+        .mem_block_symbols = 0,               // the memory size of each RMT channel, 0 lets the driver decide.
         .flags = {
             .with_dma = false, // DMA feature is available on chips like ESP32-S3/P4
         }


### PR DESCRIPTION
ESP32S3 mem_block_symbols must be a multiple of 48 on the ESP32S3. Setting this to 0 in the example allows the driver to use this automatically. Right now the example is broken in ESP32-S3.
