### PR TITLE
Create led_strip_rmt_ws2812.c (IEC-253)

### DIFF
--- a/led_strip/CHANGELOG.md
+++ b/led_strip/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+- Support WS2811 bit timing
+
 ## 3.0.0
 
 - Discontinued support for ESP-IDF v4.x

--- a/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
+++ b/led_strip/examples/led_strip_rmt_ws2812/main/led_strip_rmt_ws2812_main.c
@@ -10,10 +10,23 @@
 #include "esp_log.h"
 #include "esp_err.h"
 
-// GPIO assignment
-#define LED_STRIP_GPIO_PIN  2
+// Set to 1 to use DMA for driving the LED strip, 0 otherwise
+// Please note the RMT DMA feature is only available on chips e.g. ESP32-S3/P4
+#define LED_STRIP_USE_DMA  0
+
+#if LED_STRIP_USE_DMA
+// Numbers of the LED in the strip
+#define LED_STRIP_LED_COUNT 256
+#define LED_STRIP_MEMORY_BLOCK_WORDS 1024 // this determines the DMA block size
+#else
 // Numbers of the LED in the strip
 #define LED_STRIP_LED_COUNT 24
+#define LED_STRIP_MEMORY_BLOCK_WORDS 0 // let the driver choose a proper memory block size automatically
+#endif // LED_STRIP_USE_DMA
+
+// GPIO assignment
+#define LED_STRIP_GPIO_PIN  2
+
 // 10MHz resolution, 1 tick = 0.1us (led strip needs a high resolution)
 #define LED_STRIP_RMT_RES_HZ  (10 * 1000 * 1000)
 
@@ -36,9 +49,9 @@ led_strip_handle_t configure_led(void)
     led_strip_rmt_config_t rmt_config = {
         .clk_src = RMT_CLK_SRC_DEFAULT,        // different clock source can lead to different power consumption
         .resolution_hz = LED_STRIP_RMT_RES_HZ, // RMT counter clock frequency
-        .mem_block_symbols = 0,               // the memory size of each RMT channel, 0 lets the driver decide.
+        .mem_block_symbols = LED_STRIP_MEMORY_BLOCK_WORDS, // the memory block size used by the RMT channel
         .flags = {
-            .with_dma = false, // DMA feature is available on chips like ESP32-S3/P4
+            .with_dma = LED_STRIP_USE_DMA,     // Using DMA can improve performance when driving more LEDs
         }
     };
 

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.0"
+version: "3.0.1"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 issues: https://github.com/espressif/idf-extra-components/issues


### PR DESCRIPTION
Adds a DMA example for the RMT led_strip. Created by [suda-morris](https://github.com/suda-morris)


# Checklist

- [x ] Component contains License
- [ x] Component contains README.md
- [ x] Component contains idf_component.yml file with `url` field defined
- [ x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [- ] _Optional:_ Component contains unit tests - Manually tested espressif solution set for rmt dma mode, then uploaded.
- [ ] CI passing

