### PR TITLE
feat(coap); Support for server keepalives (IEC-254)

### DIFF
--- a/coap/examples/coap_server/main/coap_server_example_main.c
+++ b/coap/examples/coap_server/main/coap_server_example_main.c
@@ -256,6 +256,7 @@ static void coap_example_server(void *p)
         coap_context_set_block_mode(ctx,
                                     COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
         coap_context_set_max_idle_sessions(ctx, 20);
+        coap_context_set_keepalive(ctx, 30);
 
 #ifdef CONFIG_COAP_MBEDTLS_PSK
         /* Need PSK setup before we set up endpoints */

--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.5~2"
+version: "4.3.5~3"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:

--- a/coap/sbom_libcoap.yml
+++ b/coap/sbom_libcoap.yml
@@ -4,7 +4,7 @@ cpe: cpe:2.3:a:libcoap:libcoap:{}:*:*:*:*:*:*:*
 supplier: 'Organization: libcoap <https://libcoap.net/>'
 description: A CoAP (RFC 7252) implementation in C
 url: https://github.com/obgm/libcoap
-hash: 0d240530b4beba90cc86c488e17bd0090437a0dd
+hash: 4d84859620540c8baf06fa094abb9e0ae19da0e7
 cve-exclude-list:
   - cve: CVE-2024-31031
     reason: Resolved in version 4.3.5-rc1


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Addition of support for server initiated CoAP keepalive packets to garbage collect stale observation requests when the client goes away.
