### PR TITLE
fix(network_provisioning): Consider WIFI_REMOTE for provisioning (IEC-260)

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 17-March-2024
+# 01-April-2025
+
+- Extend provisioning check for `ESP_WIFI_REMOTE_ENABLED` as well along with existing `ESP_WIFI_ENABLED`
+- This enables provisioning for the devices not having native Wi-Fi (e.g., ESP32-P4) and using external/remote Wi-Fi solution such as esp-hosted for Wi-Fi connectivity.
+
+# 17-March-2025
 
 - Update the network provisioning component to work with the protocomm component which fixes incorrect AES-GCM IV usage in security2 scheme.
 

--- a/network_provisioning/CMakeLists.txt
+++ b/network_provisioning/CMakeLists.txt
@@ -9,7 +9,7 @@ set(srcs "src/network_config.c"
         "proto-c/network_ctrl.pb-c.c"
         "proto-c/network_constants.pb-c.c")
 
-if(CONFIG_ESP_WIFI_ENABLED AND CONFIG_ESP_WIFI_SOFTAP_SUPPORT)
+if((CONFIG_ESP_WIFI_ENABLED OR CONFIG_ESP_WIFI_REMOTE_ENABLED) AND CONFIG_ESP_WIFI_SOFTAP_SUPPORT)
     list(APPEND srcs "src/scheme_softap.c")
 endif()
 

--- a/network_provisioning/Kconfig
+++ b/network_provisioning/Kconfig
@@ -2,12 +2,12 @@ menu "Network Provisioning Manager"
 
     choice NETWORK_PROV_NETWORK_TYPE
         prompt "Network Type"
-        default NETWORK_PROV_NETWORK_TYPE_WIFI if ESP_WIFI_ENABLED
+        default NETWORK_PROV_NETWORK_TYPE_WIFI if (ESP_WIFI_ENABLED || ESP_WIFI_REMOTE_ENABLED)
         default NETWORK_PROV_NETWORK_TYPE_THREAD if !ESP_WIFI_ENABLE && OPENTHREAD_ENABLED
 
         config NETWORK_PROV_NETWORK_TYPE_WIFI
             bool "Network Type - Wi-Fi"
-            depends on ESP_WIFI_ENABLED
+            depends on ESP_WIFI_ENABLED || ESP_WIFI_REMOTE_ENABLED
 
         config NETWORK_PROV_NETWORK_TYPE_THREAD
             bool "Network Type - Thread"

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.4"
+version: "1.0.5"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:


### PR DESCRIPTION
- In cases, such as ESP32-P4, we do not have native Wi-Fi and it uses other
   mechanisms., such as esp-hosted.[ esp-wifi-remote ](https://github.com/espressif/esp-wifi-remote)is used in this case.
- Provisioning component currently check if Wi-Fi is natively
   enabled for it to compile wifi_provisioning sources.
   This causes link errors when enabling the provisiong for ESP32-P4
- Extend the check for Wi-Fi remote as well, so the sources are compiled. (The config option itself comes from esp-wifi-remote)

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
This change extends the provisioning support for the devices(such as P4+C6 setup using esp_hosted for connectivity) using Wi-Fi remotes.

- Also bumped up the patch version for network_provisioning component