### PR TITLE
fix(esp_delta_ota): Fix esp_delta_ota_patch_gen script

### DIFF
--- a/esp_delta_ota/CHANGELOG.md
+++ b/esp_delta_ota/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.1
+
+### Bugfixes:
+- Fixed issue causing `esp_delta_ota_patch_gen.py` to be non-functional on Windows OS.
+- Replaced earlier use of subprocess commands with direct `esptool` module import based method for handling ESP chip-specific operations across all platforms.
+- Replaced earlier use of subprocess commands with direct `detools` module import based method for creating and applying patches.
+
 ## 1.1.0
 
 ### Enhancements:

--- a/esp_delta_ota/idf_component.yml
+++ b/esp_delta_ota/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.1"
 description: "ESP Delta OTA Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_delta_ota
 dependencies:


### PR DESCRIPTION
## Description

- esp_delta_ota_patch_gen.py script not working on windows, as esptool.py and mv command were executed through python and not recognised by windows command shell.

## Fix
- Refactored the esp_delta_ota_patch_gen script
- Integrated the esptool module
- Utilized the detools module apis

## Testing
1. These changes are tested on Windows, Mac and Linux.
2. Calculated the md5 hash for the patch generated by the script before changes and after changes, both output the same hash.