### PR TITLE
fix(network_prov): fix incorrect AES-GCM IV usage in security2 scheme (IEC-279)

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 17-March-2024
+
+- Update the network provisioning component to work with the protocomm component which fixes incorrect AES-GCM IV usage in security2 scheme.
+
 # 19-June-2024
 
 - Change the proto files to make the network provisioning component stay backward compatible with the wifi_provisioing

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:

--- a/network_provisioning/tool/esp_prov/esp_prov.py
+++ b/network_provisioning/tool/esp_prov/esp_prov.py
@@ -40,9 +40,9 @@ def on_except(err):
         print(err)
 
 
-def get_security(secver, username, password, pop='', verbose=False):
+def get_security(secver, sec_patch_ver, username, password, pop='', verbose=False):
     if secver == 2:
-        return security.Security2(username, password, verbose)
+        return security.Security2(sec_patch_ver, username, password, verbose)
     elif secver == 1:
         return security.Security1(pop, verbose)
     elif secver == 0:
@@ -157,6 +157,27 @@ async def get_version(tp):
         on_except(e)
         response = ''
     return response
+
+
+async def get_sec_patch_ver(tp, verbose=False):
+    response = await get_version(tp)
+
+    if verbose:
+        print('proto-ver response : ', response)
+
+    try:
+        # Interpret this as JSON structure containing
+        # information with security version information
+        info = json.loads(response)
+        try:
+            sec_patch_ver = info['prov']['sec_patch_ver']
+        except KeyError:
+            sec_patch_ver = 0
+        return sec_patch_ver
+
+    except ValueError:
+        # If decoding as JSON fails, we assume default patch level
+        return 0
 
 
 async def establish_session(tp, sec):
@@ -548,6 +569,7 @@ async def main():
         raise RuntimeError('Failed to establish connection')
 
     try:
+        sec_patch_ver = 0
         # If security version not specified check in capabilities
         if args.secver is None:
             # First check if capabilities are supported or not
@@ -569,13 +591,14 @@ async def main():
                 args.sec1_pop = ''
 
         if (args.secver == 2):
+            sec_patch_ver = await get_sec_patch_ver(obj_transport, args.verbose)
             if len(args.sec2_usr) == 0:
                 args.sec2_usr = input('Security Scheme 2 - SRP6a Username required: ')
             if len(args.sec2_pwd) == 0:
                 prompt_str = 'Security Scheme 2 - SRP6a Password required: '
                 args.sec2_pwd = getpass(prompt_str)
 
-        obj_security = get_security(args.secver, args.sec2_usr, args.sec2_pwd, args.sec1_pop, args.verbose)
+        obj_security = get_security(args.secver, sec_patch_ver, args.sec2_usr, args.sec2_pwd, args.sec1_pop, args.verbose)
         if obj_security is None:
             raise ValueError('Invalid Security Version')
 
@@ -593,7 +616,7 @@ async def main():
 
         if await has_capability(obj_transport, 'thread_prov'):
             if args.reset:
-                print('==== Reseting Thread====')
+                print('==== Resetting Thread====')
                 await reset_thread(obj_transport, obj_security)
                 sys.exit()
 
@@ -659,7 +682,7 @@ async def main():
                 print('The device might be using previous wifi_provisioning in ESP-IDF')
 
             if args.reset:
-                print('==== Reseting WiFi====')
+                print('==== Resetting WiFi====')
                 await reset_wifi(obj_transport, obj_security)
                 sys.exit()
 


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [X] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [X] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] CI passing

# Change description
The security2 scheme in protocomm component has been update to fix incorrect AES-GCM IV usage, so we need to update network_provisioning to make it work with the new security2 scheme.
