### PR TITLE
change(freetype): add CVE-2025-27363 to cve exclude list (IEC-283)

### DIFF
--- a/freetype/sbom_freetype.yml
+++ b/freetype/sbom_freetype.yml
@@ -5,3 +5,6 @@ supplier: 'Organization: freetype <https://www.freetype.org>'
 description: FreeType is a software font engine
 url: https://github.com/freetype/freetype
 hash: 42608f77f20749dd6ddc9e0536788eaad70ea4b5
+cve-exclude-list:
+  - cve: CVE-2025-27363
+    reason: Only affects version 2.13.0 and below

--- a/freetype/sbom_freetype.yml
+++ b/freetype/sbom_freetype.yml
@@ -1,5 +1,5 @@
 name: freetype
-version: 2.13.3
+version: 2.13.3~1
 cpe: cpe:2.3:a:freetype:freetype:{}:*:*:*:*:*:*:*
 supplier: 'Organization: freetype <https://www.freetype.org>'
 description: FreeType is a software font engine


### PR DESCRIPTION
# Change description

Adds CVE-2025-27363 to CVE exclude list. This CVE only affects version 2.13.0 and below as per [NIST](https://nvd.nist.gov/vuln/detail/CVE-2025-27363) database.

The freetype version in use is 2.13.3 which isn't affected by this CVE.