### PR TITLE
feat(spi_nand_flash): Add QIO mode support

### DIFF
--- a/spi_nand_flash/examples/nand_flash_debug_app/main/spi_nand_flash_debug_app_main.c
+++ b/spi_nand_flash/examples/nand_flash_debug_app/main/spi_nand_flash_debug_app_main.c
@@ -59,12 +59,16 @@ static void example_init_nand_flash(spi_nand_flash_device_t **out_handle, spi_de
     ESP_LOGI(TAG, "DMA CHANNEL: %d", SPI_DMA_CHAN);
     ESP_ERROR_CHECK(spi_bus_initialize(HOST_ID, &bus_config, SPI_DMA_CHAN));
 
+    // spi_flags = SPI_DEVICE_HALFDUPLEX -> half duplex
+    // spi_flags = 0 -> full_duplex
+    const uint32_t spi_flags = SPI_DEVICE_HALFDUPLEX;
+
     spi_device_interface_config_t devcfg = {
         .clock_speed_hz = EXAMPLE_FLASH_FREQ_KHZ * 1000,
         .mode = 0,
         .spics_io_num = PIN_CS,
         .queue_size = 10,
-        .flags = SPI_DEVICE_HALFDUPLEX,
+        .flags = spi_flags,
     };
 
     spi_device_handle_t spi;
@@ -72,6 +76,8 @@ static void example_init_nand_flash(spi_nand_flash_device_t **out_handle, spi_de
 
     spi_nand_flash_config_t nand_flash_config = {
         .device_handle = spi,
+        .io_mode = SPI_NAND_IO_MODE_SIO,
+        .flags = spi_flags
     };
     spi_nand_flash_device_t *nand_flash_device_handle;
     ESP_ERROR_CHECK(spi_nand_flash_init_device(&nand_flash_config, &nand_flash_device_handle));

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.10.0"
+version: "0.11.0"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/include/spi_nand_flash.h
+++ b/spi_nand_flash/include/spi_nand_flash.h
@@ -31,6 +31,8 @@ typedef enum {
     SPI_NAND_IO_MODE_SIO = 0,
     SPI_NAND_IO_MODE_DOUT,
     SPI_NAND_IO_MODE_DIO,
+    SPI_NAND_IO_MODE_QOUT,
+    SPI_NAND_IO_MODE_QIO,
 } spi_nand_flash_io_mode_t;
 
 /** @brief Structure to describe how to configure the nand access layer.

--- a/spi_nand_flash/priv_include/nand.h
+++ b/spi_nand_flash/priv_include/nand.h
@@ -53,6 +53,8 @@ typedef struct {
     uint32_t erase_block_delay_us;
     uint32_t program_page_delay_us;
     ecc_data_t ecc_data;
+    uint8_t has_quad_enable_bit;    // 1 if the chip supports enabling QIO/QOUT mode using bit 0 of 0xB0 (REG_CONFIG), 0 otherwise
+    uint8_t quad_enable_bit_pos;
 } spi_nand_chip_t;
 
 typedef struct {

--- a/spi_nand_flash/priv_include/spi_nand_oper.h
+++ b/spi_nand_flash/priv_include/spi_nand_oper.h
@@ -44,6 +44,7 @@ typedef struct spi_nand_transaction_t spi_nand_transaction_t;
 #define CMD_READ_X4         0x6B
 #define CMD_ERASE_BLOCK     0xD8
 #define CMD_READ_DIO        0xBB
+#define CMD_READ_QIO        0xEB
 
 #define REG_PROTECT         0xA0
 #define REG_CONFIG          0xB0

--- a/spi_nand_flash/src/nand_alliance.c
+++ b/spi_nand_flash/src/nand_alliance.c
@@ -24,6 +24,8 @@ esp_err_t spi_nand_alliance_init(spi_nand_flash_device_t *dev)
         .flags = SPI_TRANS_USE_RXDATA,
     };
     spi_nand_execute_transaction(dev, &t);
+    dev->chip.has_quad_enable_bit = 1;
+    dev->chip.quad_enable_bit_pos = 0;
     dev->chip.erase_block_delay_us = 3000;
     dev->chip.program_page_delay_us = 630;
     ESP_LOGD(TAG, "%s: device_id: %x\n", __func__, device_id);

--- a/spi_nand_flash/src/nand_gigadevice.c
+++ b/spi_nand_flash/src/nand_gigadevice.c
@@ -24,6 +24,8 @@ esp_err_t spi_nand_gigadevice_init(spi_nand_flash_device_t *dev)
         .flags = SPI_TRANS_USE_RXDATA,
     };
     spi_nand_execute_transaction(dev, &t);
+    dev->chip.has_quad_enable_bit = 1;
+    dev->chip.quad_enable_bit_pos = 0;
     dev->chip.read_page_delay_us = 25;
     dev->chip.erase_block_delay_us = 3200;
     dev->chip.program_page_delay_us = 380;

--- a/spi_nand_flash/src/nand_micron.c
+++ b/spi_nand_flash/src/nand_micron.c
@@ -24,6 +24,8 @@ esp_err_t spi_nand_micron_init(spi_nand_flash_device_t *dev)
         .flags = SPI_TRANS_USE_RXDATA,
     };
     spi_nand_execute_transaction(dev, &t);
+    dev->chip.has_quad_enable_bit = 0;
+    dev->chip.quad_enable_bit_pos = 0;
     dev->chip.ecc_data.ecc_status_reg_len_in_bits = 3;
     dev->chip.erase_block_delay_us = 2000;
     ESP_LOGD(TAG, "%s: device_id: %x\n", __func__, device_id);

--- a/spi_nand_flash/src/nand_winbond.c
+++ b/spi_nand_flash/src/nand_winbond.c
@@ -24,6 +24,8 @@ esp_err_t spi_nand_winbond_init(spi_nand_flash_device_t *dev)
         .flags = SPI_TRANS_USE_RXDATA,
     };
     spi_nand_execute_transaction(dev, &t);
+    dev->chip.has_quad_enable_bit = 0;
+    dev->chip.quad_enable_bit_pos = 0;
     uint16_t device_id = (device_id_buf[0] << 8) + device_id_buf[1];
     dev->chip.read_page_delay_us = 10;
     dev->chip.erase_block_delay_us = 2500;

--- a/spi_nand_flash/test_app/main/test_spi_nand_flash.c
+++ b/spi_nand_flash/test_app/main/test_spi_nand_flash.c
@@ -241,6 +241,16 @@ TEST_CASE("read and write nand flash sectors (dout)", "[spi_nand_flash]")
     test_write_nand_flash_sectors(SPI_NAND_IO_MODE_DOUT, SPI_DEVICE_HALFDUPLEX);
 }
 
+TEST_CASE("read and write nand flash sectors (qio)", "[spi_nand_flash]")
+{
+    test_write_nand_flash_sectors(SPI_NAND_IO_MODE_QIO, SPI_DEVICE_HALFDUPLEX);
+}
+
+TEST_CASE("read and write nand flash sectors (qout)", "[spi_nand_flash]")
+{
+    test_write_nand_flash_sectors(SPI_NAND_IO_MODE_QOUT, SPI_DEVICE_HALFDUPLEX);
+}
+
 static void test_copy_nand_flash_sectors(spi_nand_flash_io_mode_t mode, uint8_t flags)
 {
     spi_nand_flash_device_t *nand_flash_device_handle;
@@ -279,6 +289,16 @@ TEST_CASE("copy nand flash sectors (dio)", "[spi_nand_flash]")
 TEST_CASE("copy nand flash sectors (dout)", "[spi_nand_flash]")
 {
     test_copy_nand_flash_sectors(SPI_NAND_IO_MODE_DOUT, SPI_DEVICE_HALFDUPLEX);
+}
+
+TEST_CASE("copy nand flash sectors (qio)", "[spi_nand_flash]")
+{
+    test_copy_nand_flash_sectors(SPI_NAND_IO_MODE_QIO, SPI_DEVICE_HALFDUPLEX);
+}
+
+TEST_CASE("copy nand flash sectors (qout)", "[spi_nand_flash]")
+{
+    test_copy_nand_flash_sectors(SPI_NAND_IO_MODE_QOUT, SPI_DEVICE_HALFDUPLEX);
 }
 
 static void test_nand_operations(spi_nand_flash_io_mode_t mode, uint8_t flags)
@@ -347,6 +367,16 @@ TEST_CASE("verify nand_prog, nand_read, nand_copy, nand_is_free works (bypassing
 TEST_CASE("verify nand_prog, nand_read, nand_copy, nand_is_free works (bypassing dhara) (dout)", "[spi_nand_flash]")
 {
     test_nand_operations(SPI_NAND_IO_MODE_DOUT, SPI_DEVICE_HALFDUPLEX);
+}
+
+TEST_CASE("verify nand_prog, nand_read, nand_copy, nand_is_free works (bypassing dhara) (qio)", "[spi_nand_flash]")
+{
+    test_nand_operations(SPI_NAND_IO_MODE_QIO, SPI_DEVICE_HALFDUPLEX);
+}
+
+TEST_CASE("verify nand_prog, nand_read, nand_copy, nand_is_free works (bypassing dhara) (qout)", "[spi_nand_flash]")
+{
+    test_nand_operations(SPI_NAND_IO_MODE_QOUT, SPI_DEVICE_HALFDUPLEX);
 }
 
 TEST_CASE("Fail safe test if chip is not detected", "[spi_nand_flash]")


### PR DESCRIPTION
# Change description
spi_nand_flash: Added QIO and QOUT spi mode support

Performance Comparison across all SPI modes on 40M SPI bus frequency:

```
SIO:
Wrote 131072 bytes in 111909 us, avg 1171.24 kB/s
Read 131072 bytes in 41334 us, avg 3171.05 kB/s

DIO:
Wrote 131072 bytes in 115245 us, avg 1137.33 kB/s
Read 131072 bytes in 27383 us, avg 4786.62 kB/s

DOUT:
Wrote 131072 bytes in 115222 us, avg 1137.56 kB/s
Read 131072 bytes in 27414 us, avg 4781.21 kB/s

QIO:
Wrote 131072 bytes in 90107 us, avg 1454.63 kB/s
Read 131072 bytes in 20829 us, avg 6292.76 kB/s

QOUT:
Wrote 131072 bytes in 90098 us, avg 1454.77 kB/s
Read 131072 bytes in 20848 us, avg 6287.03 kB/s
```