### PR TITLE
feat(nghttp): Upgrade the nghttp2 to 1.65.0

### DIFF
--- a/nghttp/idf_component.yml
+++ b/nghttp/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.62.1"
+version: "1.65.0"
 description: "nghttp2 - HTTP/2 C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/nghttp
 dependencies:

--- a/nghttp/port/include/nghttp2/nghttp2ver.h
+++ b/nghttp/port/include/nghttp2/nghttp2ver.h
@@ -29,7 +29,7 @@
  * @macro
  * Version number of the nghttp2 library release
  */
-#define NGHTTP2_VERSION "1.62.1"
+#define NGHTTP2_VERSION "1.65.0"
 
 /**
  * @macro
@@ -37,6 +37,6 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define NGHTTP2_VERSION_NUM 0x013e01
+#define NGHTTP2_VERSION_NUM 0x014100
 
 #endif /* NGHTTP2VER_H */

--- a/nghttp/sbom_nghttp2.yml
+++ b/nghttp/sbom_nghttp2.yml
@@ -1,10 +1,10 @@
 name: nghttp2
-version: 1.62.1
+version: 1.65.0
 cpe: cpe:2.3:a:nghttp2:nghttp2:{}:*:*:*:*:*:*:*
 supplier: 'Organization: nghttp2 <https://nghttp2.org/'
 description: nghttp2 - HTTP/2 C Library and tools
 url: https://github.com/nghttp2/nghttp2
-hash: d13a5758373931064636c1641db6277db45552dc
+hash: 319bf015de8fa38e21ac271ce2f7d61aa77d90cb
 cve-exclude-list:
   - cve: CVE-2024-28182
     reason: Resolved in version v1.61.0


### PR DESCRIPTION
# Description
- Upgraded the nghttp2 to 1.65.0
- Checked the CVE using esp-idf-sbom tool

Closes https://github.com/espressif/idf-extra-components/issues/490