### PR TITLE
change(nghttp): adds CVE-2025-30194 to exclude list (IEC-291)

### DIFF
--- a/nghttp/idf_component.yml
+++ b/nghttp/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.65.0"
+version: "1.65.0~1"
 description: "nghttp2 - HTTP/2 C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/nghttp
 dependencies:

--- a/nghttp/sbom_nghttp2.yml
+++ b/nghttp/sbom_nghttp2.yml
@@ -8,3 +8,5 @@ hash: 319bf015de8fa38e21ac271ce2f7d61aa77d90cb
 cve-exclude-list:
   - cve: CVE-2024-28182
     reason: Resolved in version v1.61.0
+  - cve: CVE-2025-30194
+    reason: nghttp2 is not affected by this CVE


### PR DESCRIPTION
Adds [CVE-2025-30194](https://nvd.nist.gov/vuln/detail/CVE-2025-30194) to CVE exclude list. This CVE doesn't affect `nghttp2`. It is only being reported because `nghttp2` was mentioned in the CVE description.
