### PR TITLE
refactor(1wire): improve the driver to support esp-idf v6

### DIFF
--- a/onewire_bus/CHANGELOG.md
+++ b/onewire_bus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Improve the driver to support esp-idf v6.0
+
 ## 1.0.2
 
 - raise recovery time to support more sensor on longer wire (d0b2b52)

--- a/onewire_bus/CMakeLists.txt
+++ b/onewire_bus/CMakeLists.txt
@@ -1,6 +1,19 @@
-idf_component_register(SRCS "src/onewire_bus_api.c"
-                            "src/onewire_bus_impl_rmt.c"
-                            "src/onewire_crc.c"
-                            "src/onewire_device.c"
+set(srcs "src/onewire_bus_api.c"
+         "src/onewire_crc.c"
+         "src/onewire_device.c")
+
+if(CONFIG_SOC_RMT_SUPPORTED)
+     list(APPEND srcs "src/onewire_bus_impl_rmt.c")
+endif()
+
+set(priv_requires)
+# Starting from esp-idf v5.3, the RMT drivers are moved to separate components
+if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.3")
+    list(APPEND priv_requires "esp_driver_rmt" "esp_driver_gpio")
+else()
+    list(APPEND priv_requires "driver")
+endif()
+
+idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS "include" "interface"
-                       PRIV_REQUIRES driver)
+                       PRIV_REQUIRES ${priv_requires})

--- a/onewire_bus/README.md
+++ b/onewire_bus/README.md
@@ -3,3 +3,7 @@
 [![Component Registry](https://components.espressif.com/components/espressif/onewire_bus/badge.svg)](https://components.espressif.com/components/espressif/onewire_bus)
 
 This directory contains an implementation for Dallas 1-Wire bus by different peripherals. Currently only RMT is supported as the backend.
+
+## Appendix
+
+* [DS18B20 device driver based on the 1-Wire Bus driver](https://components.espressif.com/components/espressif/ds18b20) and the [DS18B20 Example](https://github.com/espressif/esp-bsp/tree/master/components/ds18b20/examples/ds18b20-read)

--- a/onewire_bus/idf_component.yml
+++ b/onewire_bus/idf_component.yml
@@ -1,5 +1,5 @@
-version: "1.0.2"
-description: Driver for Dalas 1-Wire bus
+version: "1.0.3"
+description: Driver for Dallas 1-Wire bus
 url: https://github.com/espressif/idf-extra-components/tree/master/onewire_bus
 issues: "https://github.com/espressif/idf-extra-components/issues"
 dependencies:

--- a/onewire_bus/src/onewire_bus_impl_rmt.c
+++ b/onewire_bus/src/onewire_bus_impl_rmt.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,8 +12,11 @@
 #include "esp_attr.h"
 #include "driver/rmt_tx.h"
 #include "driver/rmt_rx.h"
+#include "driver/gpio.h"
+#include "esp_private/gpio.h"
 #include "onewire_bus_impl_rmt.h"
 #include "onewire_bus_interface.h"
+#include "esp_idf_version.h"
 
 static const char *TAG = "1-wire.rmt";
 
@@ -113,6 +116,8 @@ typedef struct {
     onewire_bus_t base; /*!< base class */
     rmt_channel_handle_t tx_channel; /*!< rmt tx channel handler */
     rmt_channel_handle_t rx_channel; /*!< rmt rx channel handler */
+
+    gpio_num_t data_gpio_num; /*!< GPIO number for 1-wire bus */
 
     rmt_encoder_handle_t tx_bytes_encoder; /*!< used to encode commands and data */
     rmt_encoder_handle_t tx_copy_encoder; /*!< used to encode reset pulse and bits */
@@ -253,6 +258,7 @@ esp_err_t onewire_new_bus_rmt(const onewire_bus_config_t *bus_config, const onew
 
     bus_rmt = calloc(1, sizeof(onewire_bus_rmt_obj_t));
     ESP_RETURN_ON_FALSE(bus_rmt, ESP_ERR_NO_MEM, TAG, "no mem for onewire_bus_rmt_obj_t");
+    bus_rmt->data_gpio_num = GPIO_NUM_NC;
 
     // create rmt bytes encoder to transmit 1-wire commands and data
     rmt_bytes_encoder_config_t bytes_encoder_config = {
@@ -268,7 +274,7 @@ esp_err_t onewire_new_bus_rmt(const onewire_bus_config_t *bus_config, const onew
     ESP_GOTO_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_config, &bus_rmt->tx_copy_encoder),
                       err, TAG, "create copy encoder failed");
 
-    // Note: must create rmt rx channel before tx channel
+    // create RX and TX channels and bind them to the same GPIO
     rmt_rx_channel_config_t onewire_rx_channel_cfg = {
         .clk_src = RMT_CLK_SRC_DEFAULT,
         .resolution_hz = ONEWIRE_RMT_RESOLUTION_HZ,
@@ -278,18 +284,25 @@ esp_err_t onewire_new_bus_rmt(const onewire_bus_config_t *bus_config, const onew
     ESP_GOTO_ON_ERROR(rmt_new_rx_channel(&onewire_rx_channel_cfg, &bus_rmt->rx_channel),
                       err, TAG, "create rmt rx channel failed");
 
-    // create rmt tx channel
     rmt_tx_channel_config_t onewire_tx_channel_cfg = {
         .clk_src = RMT_CLK_SRC_DEFAULT,
         .resolution_hz = ONEWIRE_RMT_RESOLUTION_HZ,
         .gpio_num = bus_config->bus_gpio_num,
         .mem_block_symbols = ONEWIRE_RMT_DEFAULT_MEM_BLOCK_SYMBOLS,
         .trans_queue_depth = ONEWIRE_RMT_DEFAULT_TRANS_QUEUE_SIZE,
-        .flags.io_loop_back = true, // make tx channel coexist with rx channel on the same gpio pin
-        .flags.io_od_mode = true,   // enable open-drain mode for 1-wire bus
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+        .flags.io_loop_back = true,
+        .flags.io_od_mode = true,
+#endif
     };
     ESP_GOTO_ON_ERROR(rmt_new_tx_channel(&onewire_tx_channel_cfg, &bus_rmt->tx_channel),
                       err, TAG, "create rmt tx channel failed");
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    bus_rmt->data_gpio_num = bus_config->bus_gpio_num;
+    // enable open-drain mode for 1-wire bus
+    gpio_od_enable(bus_rmt->data_gpio_num);
+#endif
 
     // allocate rmt rx symbol buffer, one RMT symbol represents one bit, so x8
     bus_rmt->rx_symbols_buf = malloc(rmt_config->max_rx_bytes * sizeof(rmt_symbol_word_t) * 8);
@@ -366,6 +379,11 @@ static esp_err_t onewire_bus_rmt_destroy(onewire_bus_rmt_obj_t *bus_rmt)
     if (bus_rmt->rx_symbols_buf) {
         free(bus_rmt->rx_symbols_buf);
     }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    if (bus_rmt->data_gpio_num != GPIO_NUM_NC) {
+        gpio_od_disable(bus_rmt->data_gpio_num);
+    }
+#endif
     free(bus_rmt);
     return ESP_OK;
 }


### PR DESCRIPTION
The rmt driver in esp-idf v6.0 removes some deprecated config options like io_loop_back and io_od_mode. This PR is to adapt that change.

Tested passed locally with the following packages:

```
NOTICE: [1/3] ds18b20 (0.1.2) (/home/morris/esp/esp-bsp/components/ds18b20)
NOTICE: [2/3] onewire_bus (1.0.3) (/home/morris/esp/idf-extra-components/onewire_bus)
NOTICE: [3/3] idf (6.0.0)
```
