### PR TITLE
change(ci): add release/v5.4 and release/v5.5 branches to test matrix

### DIFF
--- a/.github/workflows/build_and_run_apps.yml
+++ b/.github/workflows/build_and_run_apps.yml
@@ -76,6 +76,8 @@ jobs:
           - "release-v5.1"
           - "release-v5.2"
           - "release-v5.3"
+          - "release-v5.4"
+          - "release-v5.5"
           - "latest"
         parallel_index: [1,2,3,4,5] # Update --parallel-count below when changing this
     runs-on: ubuntu-22.04
@@ -126,6 +128,8 @@ jobs:
           - "release-v5.1"
           - "release-v5.2"
           - "release-v5.3"
+          - "release-v5.4"
+          - "release-v5.5"
           - "latest"
         runner:
           - runs-on: "esp32"


### PR DESCRIPTION
- Added release/v5.4 (which was created a while ago but I missed to add it here)
- Added release/v5.5, pushed to Github recently

release/v5.0 will be EoL at the end of the month and will be removed then.