### PR TITLE
Clang support for cbor component fix

### DIFF
--- a/cbor/CMakeLists.txt
+++ b/cbor/CMakeLists.txt
@@ -15,8 +15,3 @@ idf_component_register(SRCS "tinycbor/src/cborencoder_close_container_checked.c"
 
 # for open_memstream.c
 set_source_files_properties(tinycbor/src/open_memstream.c PROPERTIES COMPILE_DEFINITIONS "__linux__")
-
-# workaround for the fact that we are passing -ffreestanding to Clang
-if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    target_compile_options(${COMPONENT_LIB} PRIVATE "-U __STDC_HOSTED__")
-endif()

--- a/cbor/idf_component.yml
+++ b/cbor/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.6.0~1"
+version: "0.6.0~2"
 description: "CBOR: Concise Binary Object Representation Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/cbor
 dependencies:


### PR DESCRIPTION
# Change description
1. Updated the CMakelists.txt of cobra component. Removed the check which undefines __STDC_HOSTED__ if clang toolchain is used.
2. Tested with idf releases v5.1, v5.2, v5.3, v5.4 and master.
