### PR TITLE
feat(esp_encrpte_img): Added the goto ota_end lablel for failure case

### DIFF
--- a/esp_encrypted_img/examples/pre_encrypted_ota/main/pre_encrypted_ota.c
+++ b/esp_encrypted_img/examples/pre_encrypted_ota/main/pre_encrypted_ota.c
@@ -182,6 +182,7 @@ void pre_encrypted_ota_task(void *pvParameter)
     if (!esp_https_ota_is_complete_data_received(https_ota_handle)) {
         // the OTA image was not completely received and user can customise the response to this situation.
         ESP_LOGE(TAG, "Complete data was not received.");
+        goto ota_end;
     } else {
         err = esp_encrypted_img_decrypt_end(decrypt_handle);
         if (err != ESP_OK) {


### PR DESCRIPTION
# Description

1. Added the goto ota_end lable, if data is not received completely. So, that it calls esp_https_ota_abort api.
2. Although right now, it ultimately falls into `ota_end` label, but to make code more clear, added it.

