### PR TITLE
Add ik (inverse kinematic) library into the component list

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -56,6 +56,7 @@ body:
         - thorvg
         - zlib
         - libjpeg-turbo
+        - iklib
         - Other
     validations:
       required: true

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -68,6 +68,7 @@ jobs:
             zlib;
             libpng;
             libjpeg-turbo;
+            iklib;
           namespace: "espressif"
           # API token will only be available in the master branch in the main repository.
           # However, dry-run doesn't require a valid token.

--- a/.gitmodules
+++ b/.gitmodules
@@ -69,3 +69,6 @@
 [submodule "libjpeg-turbo/libjpeg-turbo"]
 	path = libjpeg-turbo/libjpeg-turbo
 	url = https://github.com/libjpeg-turbo/libjpeg-turbo.git
+[submodule "iklib/ik"]
+	path = iklib/ik
+	url = https://github.com/TheComet/ik.git

--- a/.idf_build_apps.toml
+++ b/.idf_build_apps.toml
@@ -23,6 +23,7 @@ manifest_file = [
     "quirc/.build-test-rules.yml",
     "zlib/.build-test-rules.yml",
     "libjpeg-turbo/.build-test-rules.yml",
+    "iklib/.build-test-rules.yml",
     ".build-test-rules.yml",
 ]
 check_warnings = true

--- a/iklib/.build-test-rules.yml
+++ b/iklib/.build-test-rules.yml
@@ -1,0 +1,4 @@
+iklib/examples/hello-ik:
+  enable:
+    - if: (IDF_VERSION_MAJOR >= 5) and (IDF_TARGET in ["esp32", "esp32c3"])
+      reason: "Sufficient to test on one Xtensa and one RISC-V target"

--- a/iklib/CMakeLists.txt
+++ b/iklib/CMakeLists.txt
@@ -1,0 +1,104 @@
+idf_component_register(
+                       # We need the dummy source file so that the component
+                       # library is not an interface library. This allows to
+                       # get the list of include directories from other components
+                       # via INCLUDE_DIRECTORIES property later on.
+                       SRCS dummy.c)
+
+# Determine compilation flags used for building ik (inverse kinematics) library
+# Flags inherited from IDF build system and other IDF components:
+set(idf_include_directories $<TARGET_PROPERTY:idf::iklib,INCLUDE_DIRECTORIES>)
+set(includes "-I$<JOIN:${idf_include_directories}, -I>")
+
+set(c_flags "${includes} ${extra_defines} ")
+set(cxx_flags "${includes} ${extra_defines} ")
+set(common_flags "-ffunction-sections -fdata-sections -fpermissive -lm -Wno-error=enum-int-mismatch -Wno-error=format")
+
+if(CONFIG_IDF_TARGET_ARCH_XTENSA)
+    set(assert_flags "${assert_flags} -mlongcalls ")
+endif()
+
+# We redefine the flags to apply common flags, 
+# like -ffunction-sections -fdata-sections.
+if(CONFIG_COMPILER_OPTIMIZATION_DEFAULT)
+    set(opt_flags "-Og ${common_flags} ${assert_flags}")
+    set(opt_args -DCMAKE_BUILD_TYPE=Release
+                -DCMAKE_C_FLAGS_RELEASE=${opt_flags}
+                -DCMAKE_CXX_FLAGS_RELEASE=${opt_flags})
+elseif(CONFIG_COMPILER_OPTIMIZATION_SIZE)
+    set(opt_flags "-Os ${common_flags} ${assert_flags}")
+    set(opt_args -DCMAKE_BUILD_TYPE=MinSizeRel
+                 -DCMAKE_C_FLAGS_RELEASE=${opt_flags}
+                 -DCMAKE_CXX_FLAGS_RELEASE=${opt_flags})
+elseif(CONFIG_COMPILER_OPTIMIZATION_PERF)   
+    set(opt_flags "-O3 ${common_flags} ${assert_flags}")
+    set(opt_args -DCMAKE_BUILD_TYPE=Release
+                 -DCMAKE_C_FLAGS_RELEASE=${opt_flags}
+                 -DCMAKE_CXX_FLAGS_RELEASE=${opt_flags})
+elseif(COMPILER_OPTIMIZATION_NONE)
+    set(opt_flags "-O0 ${common_flags} ${assert_flags}")
+    set(opt_args -DCMAKE_BUILD_TYPE=Debug
+                 -DCMAKE_C_FLAGS_DEBUG=${opt_flags}
+                 -DCMAKE_CXX_FLAGS_DEBUG=${opt_flags})
+else()
+    message(FATAL_ERROR "Unsupported optimization level")
+endif()
+
+include(ExternalProject)
+
+# Build ik in this directory:
+set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/iklib-build)
+
+set(lib_path ${BINARY_DIR}/install/lib/ik.a)
+add_prebuilt_library(iklib ${lib_path})
+
+# We apply the patch to the ik library to fix the build error.
+find_package(Git REQUIRED)
+execute_process(
+    COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR}/ik apply --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patch/ik_patch.patch
+    RESULT_VARIABLE GIT_PATCH_RESULT
+)
+
+if(NOT GIT_PATCH_RESULT EQUAL "0")
+    message(WARNING "Failed to apply patch! It's possible that the patch is already applied.")
+endif()
+
+# Add jpeg-turbo as a subproject.
+ExternalProject_Add(iklib_proj
+    SOURCE_DIR ${COMPONENT_DIR}/ik
+    BINARY_DIR ${BINARY_DIR}
+    BUILD_BYPRODUCTS ${lib_path}
+    # These two options are set so that Ninja immediately outputs
+    # the subproject build to the terminal. Otherwise it looks like the
+    # build process "hangs" for too long until iklib build is complete.
+    USES_TERMINAL_CONFIGURE TRUE
+    USES_TERMINAL_BUILD TRUE
+    CMAKE_POSITION_INDEPENDENT_CODE ON
+    # Arguments to pass to iklib CMake invocation:
+    CMAKE_ARGS
+        -DCMAKE_C_FLAGS=${c_flags}
+        -DCMAKE_CXX_FLAGS=${cxx_flags}
+        ${opt_args}
+        -DCMAKE_INSTALL_PREFIX=${BINARY_DIR}/install
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+        -DCMAKE_SYSTEM_PROCESSOR=esp32
+        -DENABLE_SHARED=NO
+        -DENABLE_STATIC=YES
+        -DIK_PRECISION=float
+        -DIK_PROFILING=NO
+)
+
+# Attach header files to the component library:
+set_target_properties(${COMPONENT_LIB} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${BINARY_DIR}/install/include)
+
+# Make sure the subproject is built before the component library:
+add_dependencies(${COMPONENT_LIB} iklib_proj)
+
+# Finally, link the interface library to the component library:
+# Attach IDF compoenent dependencies to jpeg libraries
+foreach(dep ${deps})
+    target_link_libraries(iklib INTERFACE idf::${dep})
+endforeach()
+# Attach jpeg-turbo libraries to the component library
+target_link_libraries(${COMPONENT_LIB} INTERFACE iklib)
+

--- a/iklib/LICENSE
+++ b/iklib/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Alex Murray.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/iklib/README.md
+++ b/iklib/README.md
@@ -1,0 +1,12 @@
+# Jpeg-turbo for ESP-IDF
+
+[![Component Registry](https://components.espressif.com/components/espressif/libjpeg-turbo/badge.svg)](https://components.espressif.com/components/espressif/libjpeg-turbo)
+
+This component ports IK library into the esp-idf.
+
+**IK is an Inverse Kinematic library**
+
+For more information go to https://github.com/TheComet/ik.
+
+For ***pull request***, ***bug reports***, and ***feature requests***, go to https://github.com/TheComet/ik.
+

--- a/iklib/dummy.c
+++ b/iklib/dummy.c
@@ -1,0 +1,5 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */

--- a/iklib/examples/hello-ik/CMakeLists.txt
+++ b/iklib/examples/hello-ik/CMakeLists.txt
@@ -1,0 +1,6 @@
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(hello-ik)

--- a/iklib/examples/hello-ik/main/CMakeLists.txt
+++ b/iklib/examples/hello-ik/main/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "hello-ik.c"
+                    INCLUDE_DIRS "."
+                    REQUIRES iklib)

--- a/iklib/examples/hello-ik/main/hello-ik.c
+++ b/iklib/examples/hello-ik/main/hello-ik.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <ik/ik.h>
+
+int app_main()
+{
+    printf("Hello, IK!\n");
+    /* Create a solver using the FABRIK algorithm */
+    struct ik_solver_t* solver = ik.solver.create(IK_FABRIK);
+
+    /* Create a simple 3-bone structure */
+    struct ik_node_t* root = solver->node->create(0);
+    struct ik_node_t* child1 = solver->node->create_child(root, 1);
+    struct ik_node_t* child2 = solver->node->create_child(child1, 2);
+    struct ik_node_t* child3 = solver->node->create_child(child2, 3);
+
+    /* Set node positions in local space so they form a straight line in the Y direction*/
+    child1->position = ik.vec3.vec3(0, 10, 0);
+    child2->position = ik.vec3.vec3(0, 10, 0);
+    child3->position = ik.vec3.vec3(0, 10, 0);
+
+    /* Attach an effector at the end */
+    struct ik_effector_t* eff = solver->effector->create();
+    solver->effector->attach(eff, child3);
+
+    /* set the target position of the effector to be somewhere within range */
+    eff->target_position = ik.vec3.vec3(2, -3, 5);
+
+    /* We want to calculate rotations as well as positions */
+    solver->flags |= IK_ENABLE_TARGET_ROTATIONS;
+
+    /* Assign our tree to the solver, rebuild data and calculate solution */
+    ik.solver.set_tree(solver, root);
+    ik.solver.rebuild(solver);
+    ik.solver.solve(solver);
+
+    printf("target position: %f, %f, %f\n", eff->target_position.x, eff->target_position.y, eff->target_position.z);
+    printf("target rotation: %f, %f, %f, %f\n\n", eff->target_rotation.x, eff->target_rotation.y, eff->target_rotation.z, eff->target_rotation.w);
+
+    printf("child1 position: %f, %f, %f\n", child1->position.x, child1->position.y, child1->position.z);
+    printf("child2 position: %f, %f, %f\n", child2->position.x, child2->position.y, child2->position.z);
+    printf("child3 position: %f, %f, %f\n", child3->position.x, child3->position.y, child3->position.z);
+    printf("\n");
+    printf("child1 rotation: %f, %f, %f, %f\n", child1->rotation.x, child1->rotation.y, child1->rotation.z, child1->rotation.w);
+    printf("child2 rotation: %f, %f, %f, %f\n", child2->rotation.x, child2->rotation.y, child2->rotation.z, child2->rotation.w);
+    printf("child3 rotation: %f, %f, %f, %f\n", child3->rotation.x, child3->rotation.y, child3->rotation.z, child3->rotation.w);
+    return 0;
+}

--- a/iklib/examples/hello-ik/main/idf_component.yml
+++ b/iklib/examples/hello-ik/main/idf_component.yml
@@ -1,0 +1,10 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/iklib: 
+    version: "^1.1.0"
+    # This line define the local path of the iklib component because this 
+    # example is part of the iklib component. This line is optional.
+    override_path: "../../.."
+  ## Required IDF version
+  idf:
+    version: ">=5.0.0"

--- a/iklib/idf_component.yml
+++ b/iklib/idf_component.yml
@@ -1,0 +1,6 @@
+
+version: "1.1.0~1"
+description: IK library port to ESP
+url: https://github.com/espressif/idf-extra-components/tree/master/ik
+dependencies:
+  idf: ">=5.0.0"

--- a/iklib/patch/ik_patch.patch
+++ b/iklib/patch/ik_patch.patch
@@ -1,0 +1,22 @@
+diff --git a/ik/CMakeLists.txt b/ik/CMakeLists.txt
+index faa98c4..f340e1f 100644
+--- a/ik/CMakeLists.txt
++++ b/ik/CMakeLists.txt
+@@ -289,13 +289,13 @@ target_compile_options (ik_obj
+     >
+     PRIVATE $<$<C_COMPILER_ID:GNU>:
+         -W -Wall -Wextra -Werror -Wshadow -Wconversion -Wno-unused-parameter -Wno-conversion -Wno-implicit-fallthrough
+-        -pedantic -pedantic-errors -fno-strict-aliasing -ffast-math
+-        $<$<BOOL:IK_PROFILING>:-pg -fno-omit-frame-pointer>
++        -fno-strict-aliasing -ffast-math
++        $<$<BOOL:IK_PROFILING>: -fno-omit-frame-pointer>
+     >
+     PRIVATE $<$<C_COMPILER_ID:Clang>:
+         -W -Wall -Wextra -Werror -Wshadow -Wconversion -Wno-unused-parameter -Wno-conversion -Wno-implicit-fallthrough
+-        -pedantic -pedantic-errors -fno-strict-aliasing -ffast-math
+-        $<$<BOOL:IK_PROFILING>:-pg -fno-omit-frame-pointer>
++        -fno-strict-aliasing -ffast-math
++        $<$<BOOL:IK_PROFILING>: -fno-omit-frame-pointer>
+     >
+ )
+ 

--- a/iklib/sbom_iklib.yml
+++ b/iklib/sbom_iklib.yml
@@ -1,0 +1,7 @@
+name: iklib
+version: 1.1.0
+cpe: cpe:1.1.0:a:iklib:iklib:{}:*:*:*:*:*:*:*
+supplier: 'Organization: iklib'
+description: IK is a inverse kinematic library
+url: https://github.com/TheComet/ik
+hash: c472230ecd6958f7a105d7188ebb1e871ef7a8b1


### PR DESCRIPTION
# Checklist

- [x ] Component contains License
- [ x] Component contains README.md
- [ x] Component contains idf_component.yml file with `url` field defined
- [ x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Add an Inverse Kinematic library as a component into the component list.
The component contain simple example.
