### PR TITLE
Add esp-gcov for code coverage support (IEC-342)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -31,6 +31,7 @@ body:
         - eigen
         - esp_delta_ota
         - esp_encrypted_img
+        - esp_gcov
         - esp_jpeg
         - esp_lcd_qemu_rgb
         - esp_serial_slave_link

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -43,6 +43,7 @@ jobs:
             eigen;
             esp_delta_ota;
             esp_encrypted_img;
+            esp_gcov;
             esp_lcd_qemu_rgb;
             esp_jpeg;
             esp_serial_slave_link;

--- a/.idf_build_apps.toml
+++ b/.idf_build_apps.toml
@@ -8,6 +8,7 @@ manifest_file = [
     "ccomp_timer/.build-test-rules.yml",
     "coremark/.build-test-rules.yml",
     "esp_encrypted_img/.build-test-rules.yml",
+    "esp_gcov/.build-test-rules.yml",
     "esp_jpeg/.build-test-rules.yml",
     "esp_serial_slave_link/.build-test-rules.yml",
     "expat/.build-test-rules.yml",

--- a/esp_gcov/CMakeLists.txt
+++ b/esp_gcov/CMakeLists.txt
@@ -1,0 +1,79 @@
+if(CONFIG_ESP_GCOV_ENABLE)
+    if(NOT CMAKE_C_COMPILER_ID MATCHES "GNU")
+        # TODO: LLVM-214
+        message(FATAL_ERROR "Coverage info is supported only when building with GNU!")
+    endif()
+
+    # Set a name for Gcov library
+    set(GCOV_LIB libgcov_rtio)
+
+    # Set include directory of Gcov internal headers
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -print-file-name=plugin
+                    OUTPUT_VARIABLE gcc_plugin_dir
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_QUIET
+                    RESULT_VARIABLE gcc_plugin_result)
+
+    set_source_files_properties(gcov_rtio.c
+                                PROPERTIES COMPILE_FLAGS "-I${gcc_plugin_dir}/include")
+
+    # Copy libgcov.a with symbols redefinition
+    find_library(GCOV_LIBRARY_PATH gcov ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+
+    # Check if libgcov.a was found
+    if(NOT GCOV_LIBRARY_PATH)
+        message(FATAL_ERROR "GCOV: libgcov.a not found in system directories: ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
+    endif()
+
+    # Verify libgcov.a file exists and is readable
+    if(NOT EXISTS "${GCOV_LIBRARY_PATH}")
+        message(FATAL_ERROR "GCOV: libgcov.a file does not exist")
+    endif()
+
+    # Check if symbol map file exists
+    set(SYMBOL_MAP_FILE "${CMAKE_CURRENT_LIST_DIR}/io_sym.map")
+
+    # Check if objcopy tool exists
+    find_program(OBJCOPY_TOOL "${_CMAKE_TOOLCHAIN_PREFIX}objcopy")
+    if(NOT OBJCOPY_TOOL)
+        message(FATAL_ERROR "GCOV: objcopy tool not found: ${_CMAKE_TOOLCHAIN_PREFIX}objcopy. "
+                           "Make sure your toolchain is properly installed.")
+    endif()
+
+    add_custom_command(OUTPUT ${GCOV_LIB}.a
+                       COMMAND ${OBJCOPY_TOOL}
+                               --redefine-syms ${SYMBOL_MAP_FILE}
+                               ${GCOV_LIBRARY_PATH} ${GCOV_LIB}.a
+                       COMMAND ${CMAKE_COMMAND} -E echo "GCOV: Successfully created modified library: ${GCOV_LIB}.a"
+                       MAIN_DEPENDENCY ${GCOV_LIBRARY_PATH}
+                       DEPENDS ${SYMBOL_MAP_FILE}
+                       VERBATIM
+                       COMMENT "Creating GCOV library with symbol redefinition")
+
+    add_custom_target(${GCOV_LIB}_target DEPENDS ${GCOV_LIB}.a)
+    add_library(${GCOV_LIB} STATIC IMPORTED)
+    set_target_properties(${GCOV_LIB}
+                          PROPERTIES
+                          IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${GCOV_LIB}.a)
+    add_dependencies(${GCOV_LIB} ${GCOV_LIB}_target)
+
+    # Register component with app_trace dependency
+    idf_component_register(SRCS "gcov_rtio.c"
+                          REQUIRES "app_trace"
+                          INCLUDE_DIRS ".")
+
+    # Configure gcov-specific flags
+    target_compile_options(${COMPONENT_LIB} PRIVATE "-fno-profile-arcs" "-fno-test-coverage")
+    target_link_options(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=__gcov_init")
+    target_link_libraries(${COMPONENT_LIB} INTERFACE ${GCOV_LIB} c)
+
+    message(STATUS "GCOV: Component configured successfully")
+    message(STATUS "GCOV: GCC Plugin Dir: ${gcc_plugin_dir}")
+    message(STATUS "GCOV: Original Library: ${GCOV_LIBRARY_PATH}")
+    message(STATUS "GCOV: Modified Library: ${CMAKE_CURRENT_BINARY_DIR}/${GCOV_LIB}.a")
+
+else()
+    # Register empty component when GCOV is disabled
+    idf_component_register(REQUIRES "app_trace")
+    message(STATUS "GCOV: Component registered but GCOV support is disabled")
+endif()

--- a/esp_gcov/Kconfig
+++ b/esp_gcov/Kconfig
@@ -1,0 +1,18 @@
+menu "GNU Code Coverage"
+
+    config ESP_GCOV_ENABLE
+        bool "GCOV to Host Enable"
+        depends on APPTRACE_ENABLE && !APPTRACE_SV_ENABLE
+        select ESP_DEBUG_STUBS_ENABLE
+        default y
+        help
+            Enables support for GCOV data transfer to host.
+
+    config ESP_GCOV_DUMP_TASK_STACK_SIZE
+        int "Gcov dump task stack size"
+        depends on ESP_GCOV_ENABLE
+        default 2048
+        help
+            Configures stack size of Gcov dump task
+
+endmenu

--- a/esp_gcov/LICENSE
+++ b/esp_gcov/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/esp_gcov/README.md
+++ b/esp_gcov/README.md
@@ -1,0 +1,99 @@
+# Gcov (Source Code Coverage)
+
+## Basics of Gcov and Gcovr
+
+Source code coverage is data indicating the count and frequency of every program execution path that has been taken within a program's runtime. [Gcov](https://en.wikipedia.org/wiki/Gcov) is a GCC tool that, when used in concert with the compiler, can generate log files indicating the execution count of each line of a source file. The [Gcovr](https://gcovr.com/) tool is a utility for managing Gcov and generating summarized code coverage results.
+
+Generally, using Gcov to compile and run programs on the host will undergo these steps:
+
+1. Compile the source code using GCC with the `--coverage` option enabled. This will cause the compiler to generate a `.gcno` notes files during compilation. The notes files contain information to reconstruct execution path block graphs and map each block to source code line numbers. Each source file compiled with the `--coverage` option should have their own `.gcno` file of the same name (e.g., a `main.c` will generate a `main.gcno` when compiled).
+
+2. Execute the program. During execution, the program should generate `.gcda` data files. These data files contain the counts of the number of times an execution path was taken. The program will generate a `.gcda` file for each source file compiled with the `--coverage` option (e.g., `main.c` will generate a `main.gcda`).
+
+3. Gcov or Gcovr can be used to generate a code coverage based on the `.gcno`, `.gcda`, and source files. Gcov will generate a text-based coverage report for each source file in the form of a `.gcov` file, whilst Gcovr will generate a coverage report in HTML format.
+
+## Gcov and Gcovr in ESP-IDF
+
+Using Gcov in ESP-IDF is complicated due to the fact that the program is running remotely from the host (i.e., on the target). The code coverage data (i.e., the `.gcda` files) is initially stored on the target itself. OpenOCD is then used to dump the code coverage data from the target to the host via JTAG during runtime. Using Gcov in ESP-IDF can be split into the following steps.
+
+1. [Setting Up a Project for Gcov](#setting-up-a-project-for-gcov)
+2. [Dumping Code Coverage Data](#dumping-code-coverage-data)
+3. [Generating Coverage Report](#generating-coverage-report)
+
+## Setting Up a Project for Gcov
+
+### Compiler Option
+
+In order to obtain code coverage data in a project, one or more source files within the project must be compiled with the `--coverage` option. In ESP-IDF, this can be achieved at the component level or the individual source file level:
+
+- To cause all source files in a component to be compiled with the `--coverage` option, you can add `target_compile_options(${COMPONENT_LIB} PRIVATE --coverage)` to the `CMakeLists.txt` file of the component.
+- To cause a select number of source files (e.g., `source1.c` and `source2.c`) in the same component to be compiled with the `--coverage` option, you can add `set_source_files_properties(source1.c source2.c PROPERTIES COMPILE_FLAGS --coverage)` to the `CMakeLists.txt` file of the component.
+
+When a source file is compiled with the `--coverage` option (e.g., `gcov_example.c`), the compiler will generate the `gcov_example.gcno` file in the project's build directory.
+
+### Project Configuration
+
+Before building a project with source code coverage, make sure that the following project configuration options are enabled by running `idf.py menuconfig`.
+
+- Enable the application tracing module by selecting `Trace Memory` for the `CONFIG_APPTRACE_DESTINATION1` option.
+- Enable Gcov to the host via the `CONFIG_APPTRACE_GCOV_ENABLE`.
+
+## Dumping Code Coverage Data
+
+Once a project has been complied with the `--coverage` option and flashed onto the target, code coverage data will be stored internally on the target (i.e., in trace memory) whilst the application runs. The process of transferring code coverage data from the target to the host is known as dumping.
+
+The dumping of coverage data is done via OpenOCD (see JTAG Debugging documentation on how to setup and run OpenOCD). A dump is triggered by issuing commands to OpenOCD, therefore a telnet session to OpenOCD must be opened to issue such commands (run `telnet localhost 4444`). Note that GDB could be used instead of telnet to issue commands to OpenOCD, however all commands issued from GDB will need to be prefixed as `mon <oocd_command>`.
+
+When the target dumps code coverage data, the `.gcda` files are stored in the project's build directory. For example, if `gcov_example_main.c` of the `main` component is compiled with the `--coverage` option, then dumping the code coverage data would generate a `gcov_example_main.gcda` in `build/esp-idf/main/CMakeFiles/__idf_main.dir/gcov_example_main.c.gcda`. Note that the `.gcno` files produced during compilation are also placed in the same directory.
+
+The dumping of code coverage data can be done multiple times throughout an application's lifetime. Each dump will simply update the `.gcda` file with the newest code coverage information. Code coverage data is accumulative, thus the newest data will contain the total execution count of each code path over the application's entire lifetime.
+
+ESP-IDF supports two methods of dumping code coverage data form the target to the host:
+
+* Instant Run-Time Dump
+* Hard-coded Dump
+
+### Instant Run-Time Dump
+
+An Instant Run-Time Dump is triggered by calling the `esp gcov` OpenOCD command (via a telnet session). Once called, OpenOCD will immediately preempt the {IDF_TARGET_NAME}'s current state and execute a built-in ESP-IDF Gcov debug stub function. The debug stub function will handle the dumping of data to the host. Upon completion, the {IDF_TARGET_NAME} will resume its current state.
+
+### Hard-coded Dump
+
+A Hard-coded Dump is triggered by the application itself by calling `esp_gcov_dump()` from somewhere within the application. When called, the application will halt and wait for OpenOCD to connect and retrieve the code coverage data. Once `esp_gcov_dump()` is called, the host must execute the `esp gcov dump` OpenOCD command (via a telnet session). The `esp gcov dump` command will cause OpenOCD to connect to the {IDF_TARGET_NAME}, retrieve the code coverage data, then disconnect from the {IDF_TARGET_NAME}, thus allowing the application to resume. Hard-coded Dumps can also be triggered multiple times throughout an application's lifetime.
+
+Hard-coded dumps are useful if code coverage data is required at certain points of an application's lifetime by placing `esp_gcov_dump()` where necessary (e.g., after application initialization, during each iteration of an application's main loop).
+
+GDB can be used to set a breakpoint on `esp_gcov_dump()`, then call `mon esp gcov dump` automatically via the use a `gdbinit` script (see Using GDB from JTAG debugging documentation).
+
+The following GDB script will add a breakpoint at `esp_gcov_dump()`, then call the `mon esp gcov dump` OpenOCD command.
+
+```
+b esp_gcov_dump
+commands
+mon esp gcov dump
+end
+```
+
+> **Note:** All OpenOCD commands should be invoked in GDB as: `mon <oocd_command>`.
+
+## Generating Coverage Report
+
+Once the code coverage data has been dumped, the `.gcno`, `.gcda` and the source files can be used to generate a code coverage report. A code coverage report is simply a report indicating the number of times each line in a source file has been executed.
+
+Both Gcov and Gcovr can be used to generate code coverage reports. Gcov is provided along with the Xtensa toolchain, whilst Gcovr may need to be installed separately. For details on how to use Gcov or Gcovr, refer to [Gcov documentation](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) and [Gcovr documentation](https://gcovr.com/).
+
+### Adding Gcovr Build Target to Project
+
+To make report generation more convenient, users can define additional build targets in their projects such that the report generation can be done with a single build command.
+
+Add the following lines to the `CMakeLists.txt` file of your project.
+
+```cmake
+idf_create_coverage_report(${CMAKE_CURRENT_BINARY_DIR}/coverage_report)
+idf_clean_coverage_report(${CMAKE_CURRENT_BINARY_DIR}/coverage_report)
+```
+
+The following commands can now be used:
+
+* `cmake --build build/ --target gcovr-report` will generate an HTML coverage report in `$(BUILD_DIR_BASE)/coverage_report/html` directory.
+* `cmake --build build/ --target cov-data-clean` will remove all coverage data files.

--- a/esp_gcov/esp_gcov.h
+++ b/esp_gcov/esp_gcov.h
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/**
+ * @brief Triggers gcov info dump.
+ *        This function waits for the host to connect to target before dumping data.
+ */
+void esp_gcov_dump(void);

--- a/esp_gcov/gcov_rtio.c
+++ b/esp_gcov/gcov_rtio.c
@@ -1,0 +1,193 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This module implements runtime file I/O API for GCOV.
+
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_app_trace.h"
+#include "esp_freertos_hooks.h"
+#include "esp_dbg_stubs.h"
+#include "esp_private/esp_ipc.h"
+#include "esp_log.h"
+
+#define ESP_GCOV_DOWN_BUF_SIZE  4200
+
+static const char *TAG = "esp_gcov_rtio";
+static volatile bool s_create_gcov_task = false;
+static volatile bool s_gcov_task_running = false;
+
+extern void __gcov_dump(void);
+extern void __gcov_reset(void);
+
+void gcov_dump_task(void *pvParameter)
+{
+    int dump_result = 0;
+    bool *running = (bool *)pvParameter;
+
+    ESP_EARLY_LOGV(TAG, "%s stack use in %d", __FUNCTION__, uxTaskGetStackHighWaterMark(NULL));
+
+    ESP_EARLY_LOGV(TAG, "Alloc apptrace down buf %d bytes", ESP_GCOV_DOWN_BUF_SIZE);
+    void *down_buf = malloc(ESP_GCOV_DOWN_BUF_SIZE);
+    if (down_buf == NULL) {
+        ESP_EARLY_LOGE(TAG, "Could not allocate memory for the buffer");
+        dump_result = ESP_ERR_NO_MEM;
+        goto gcov_exit;
+    }
+    ESP_EARLY_LOGV(TAG, "Config apptrace down buf");
+    esp_err_t res = esp_apptrace_down_buffer_config(ESP_APPTRACE_DEST_JTAG, down_buf, ESP_GCOV_DOWN_BUF_SIZE);
+    if (res != ESP_OK) {
+        ESP_EARLY_LOGE(TAG, "Failed to config apptrace down buf (%d)!", res);
+        dump_result = res;
+        goto gcov_exit;
+    }
+    ESP_EARLY_LOGV(TAG, "Dump data...");
+    __gcov_dump();
+    // reset dump status to allow incremental data accumulation
+    __gcov_reset();
+    free(down_buf);
+    ESP_EARLY_LOGV(TAG, "Finish file transfer session");
+    dump_result = esp_apptrace_fstop(ESP_APPTRACE_DEST_JTAG);
+    if (dump_result != ESP_OK) {
+        ESP_EARLY_LOGE(TAG, "Failed to send files transfer stop cmd (%d)!", dump_result);
+    }
+
+gcov_exit:
+    ESP_EARLY_LOGV(TAG, "dump_result %d", dump_result);
+    if (running) {
+        *running = false;
+    }
+
+    ESP_EARLY_LOGV(TAG, "%s stack use out %d", __FUNCTION__, uxTaskGetStackHighWaterMark(NULL));
+
+    vTaskDelete(NULL);
+}
+
+void gcov_create_task(void *arg)
+{
+    ESP_EARLY_LOGV(TAG, "%s", __FUNCTION__);
+    xTaskCreatePinnedToCore(&gcov_dump_task, "gcov_dump_task", CONFIG_ESP_GCOV_DUMP_TASK_STACK_SIZE,
+                            (void *)&s_gcov_task_running, configMAX_PRIORITIES - 1, NULL, 0);
+}
+
+static IRAM_ATTR
+void gcov_create_task_tick_hook(void)
+{
+    if (s_create_gcov_task) {
+        if (esp_ipc_call_nonblocking(xPortGetCoreID(), &gcov_create_task, NULL) == ESP_OK) {
+            s_create_gcov_task = false;
+        }
+    }
+}
+
+/**
+ * @brief Triggers gcov info dump task
+ *        This function is to be called by OpenOCD, not by normal user code.
+ * TODO: what about interrupted flash access (when cache disabled)
+ *
+ * @return ESP_OK on success, otherwise see esp_err_t
+ */
+static int esp_dbg_stub_gcov_entry(void)
+{
+    /* we are in isr context here */
+    s_create_gcov_task = true;
+    return ESP_OK;
+}
+
+void gcov_rtio_init(void)
+{
+    uint32_t stub_entry = 0;
+    ESP_EARLY_LOGV(TAG, "%s", __FUNCTION__);
+    assert(esp_dbg_stub_entry_get(ESP_DBG_STUB_ENTRY_GCOV, &stub_entry) == ESP_OK);
+    if (stub_entry != 0) {
+        /* "__gcov_init()" can be called several times. We must avoid multiple tick hook registration */
+        return;
+    }
+    esp_dbg_stub_entry_set(ESP_DBG_STUB_ENTRY_GCOV, (uint32_t)&esp_dbg_stub_gcov_entry);
+    assert(esp_dbg_stub_entry_get(ESP_DBG_STUB_ENTRY_CAPABILITIES, &stub_entry) == ESP_OK);
+    esp_dbg_stub_entry_set(ESP_DBG_STUB_ENTRY_CAPABILITIES, stub_entry | ESP_DBG_STUB_CAP_GCOV_TASK);
+    esp_register_freertos_tick_hook(gcov_create_task_tick_hook);
+}
+
+void esp_gcov_dump(void)
+{
+    ESP_EARLY_LOGV(TAG, "%s", __FUNCTION__);
+
+    while (!esp_apptrace_host_is_connected(ESP_APPTRACE_DEST_JTAG)) {
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+
+    /* We are not in isr context here. Waiting for the completion is safe */
+    s_gcov_task_running = true;
+    s_create_gcov_task = true;
+    while (s_gcov_task_running) {
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+}
+
+void *gcov_rtio_fopen(const char *path, const char *mode)
+{
+    ESP_EARLY_LOGV(TAG, "%s '%s' '%s'", __FUNCTION__, path, mode);
+    void *f = esp_apptrace_fopen(ESP_APPTRACE_DEST_JTAG, path, mode);
+    ESP_EARLY_LOGV(TAG, "%s ret %p", __FUNCTION__, f);
+    return f;
+}
+
+int gcov_rtio_fclose(void *stream)
+{
+    ESP_EARLY_LOGV(TAG, "%s", __FUNCTION__);
+    return esp_apptrace_fclose(ESP_APPTRACE_DEST_JTAG, stream);
+}
+
+size_t gcov_rtio_fread(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    ESP_EARLY_LOGV(TAG, "%s read %u", __FUNCTION__, size * nmemb);
+    size_t sz = esp_apptrace_fread(ESP_APPTRACE_DEST_JTAG, ptr, size, nmemb, stream);
+    ESP_EARLY_LOGV(TAG, "%s actually read %u", __FUNCTION__, sz);
+    return sz;
+}
+
+size_t gcov_rtio_fwrite(const void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    ESP_EARLY_LOGV(TAG, "%s", __FUNCTION__);
+    return esp_apptrace_fwrite(ESP_APPTRACE_DEST_JTAG, ptr, size, nmemb, stream);
+}
+
+int gcov_rtio_fseek(void *stream, long offset, int whence)
+{
+    int ret = esp_apptrace_fseek(ESP_APPTRACE_DEST_JTAG, stream, offset, whence);
+    ESP_EARLY_LOGV(TAG, "%s(%p %ld %d) = %d", __FUNCTION__, stream, offset, whence, ret);
+    return ret;
+}
+
+long gcov_rtio_ftell(void *stream)
+{
+    long ret = esp_apptrace_ftell(ESP_APPTRACE_DEST_JTAG, stream);
+    ESP_EARLY_LOGV(TAG, "%s(%p) = %ld", __FUNCTION__, stream, ret);
+    return ret;
+}
+
+int gcov_rtio_feof(void *stream)
+{
+    int ret = esp_apptrace_feof(ESP_APPTRACE_DEST_JTAG, stream);
+    ESP_EARLY_LOGV(TAG, "%s(%p) = %d", __FUNCTION__, stream, ret);
+    return ret;
+}
+
+void gcov_rtio_setbuf(void *arg1 __attribute__((unused)), void *arg2 __attribute__((unused)))
+{
+    return;
+}
+
+/* Wrappers for Gcov functions */
+
+extern void __real___gcov_init(void *info);
+void __wrap___gcov_init(void *info)
+{
+    __real___gcov_init(info);
+    gcov_rtio_init();
+}

--- a/esp_gcov/idf_component.yml
+++ b/esp_gcov/idf_component.yml
@@ -1,0 +1,7 @@
+version: 1.0.0
+description: Gcov (Source Code Coverage) component for ESP-IDF
+url: https://github.com/espressif/idf-extra-components/tree/master/esp_gcov
+issues: https://github.com/espressif/idf-extra-components/issues
+repository: https://github.com/espressif/idf-extra-components.git
+dependencies:
+  idf: ">=6.0"

--- a/esp_gcov/io_sym.map
+++ b/esp_gcov/io_sym.map
@@ -1,0 +1,8 @@
+fopen          gcov_rtio_fopen
+fclose         gcov_rtio_fclose
+fwrite         gcov_rtio_fwrite
+fread          gcov_rtio_fread
+fseek          gcov_rtio_fseek
+ftell          gcov_rtio_ftell
+setbuf         gcov_rtio_setbuf
+feof           gcov_rtio_feof

--- a/esp_gcov/project_include.cmake
+++ b/esp_gcov/project_include.cmake
@@ -1,0 +1,35 @@
+# idf_create_coverage_report
+#
+# Create coverage report.
+function(idf_create_coverage_report report_dir)
+    set(gcov_tool ${_CMAKE_TOOLCHAIN_PREFIX}gcov)
+    idf_build_get_property(project_name PROJECT_NAME)
+    idf_build_get_property(project_dir PROJECT_DIR)
+
+    file(TO_NATIVE_PATH "${report_dir}" _report_dir)
+    file(TO_NATIVE_PATH "${project_dir}" _project_dir)
+    file(TO_NATIVE_PATH "${report_dir}/html/index.html" _index_path)
+
+    add_custom_target(pre-cov-report
+        COMMENT "Generating coverage report in: ${_report_dir}"
+        COMMAND ${CMAKE_COMMAND} -E echo "Using gcov: ${gcov_tool}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${_report_dir}/html
+        )
+
+    add_custom_target(gcovr-report
+        COMMAND gcovr -r ${_project_dir} --gcov-executable ${gcov_tool} -s --html-details ${_index_path}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS pre-cov-report
+        )
+endfunction()
+
+# idf_clean_coverage_report
+#
+# Clean coverage report.
+function(idf_clean_coverage_report report_dir)
+    file(TO_CMAKE_PATH "${report_dir}" _report_dir)
+
+    add_custom_target(cov-data-clean
+        COMMENT "Clean coverage report in: ${_report_dir}"
+        COMMAND ${CMAKE_COMMAND} -E remove_directory ${_report_dir})
+endfunction()


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

Add esp-gcov component for ESP-IDF code coverage support
