### PR TITLE
fix(esp_gcov): ipc enabled by default (IEC-345)

### DIFF
--- a/esp_gcov/Kconfig.gcov
+++ b/esp_gcov/Kconfig.gcov
@@ -4,6 +4,7 @@ menu "GNU Code Coverage"
         bool "GCOV to Host Enable"
         depends on APPTRACE_ENABLE && !APPTRACE_SV_ENABLE
         select ESP_DEBUG_STUBS_ENABLE
+        select ESP_IPC_ENABLE
         default y
         help
             Enables support for GCOV data transfer to host.

--- a/esp_gcov/idf_component.yml
+++ b/esp_gcov/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.0
+version: 1.0.1
 description: Gcov (Source Code Coverage) component for ESP-IDF
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_gcov
 issues: https://github.com/espressif/idf-extra-components/issues


### PR DESCRIPTION
Enable IPC by default from the esp_gcov component to avoid external config dependency in the IDF.

Kconfig file renamed as Kconfig.gcov to allow importing from app_trace/Kconfig file