### PR TITLE
refactor(tjpgd): simplify the example to decouple it from bsp packages

### DIFF
--- a/esp_jpeg/examples/get_started/README.md
+++ b/esp_jpeg/examples/get_started/README.md
@@ -1,8 +1,10 @@
 # LCD tjpgd example
 
+## Overview
+
 This example shows how to decode a jpeg image and display it on an SPI-interfaced LCD, and rotates the image periodically.
 
-Example using initialization of the LCD from [ESP-BSP](https://github.com/espressif/esp-bsp) project. For change the Espressif's board, go to [idf_component.yml](main/idf_component.yml) and change `esp-box` to another board from BSP.
+If you want to adapt this example to another type of display or pinout, check [lcd_tjpgd_example_main.c](main/lcd_tjpgd_example_main.c) for comments with some implementation details.
 
 ## How to Use Example
 
@@ -39,7 +41,18 @@ The connection between ESP Board and the LCD is as follows:
       +---------+              +---------------------------------+
 ```
 
-The GPIO numbers used by this example is taken from BSP.
+The GPIO number used by this example can be changed in [lcd_tjpgd_example_main.c](main/lcd_tjpgd_example_main.c), where:
+
+| GPIO number              | LCD pin |
+| ------------------------ | ------- |
+| EXAMPLE_PIN_NUM_PCLK     | SCK     |
+| EXAMPLE_PIN_NUM_CS       | CS      |
+| EXAMPLE_PIN_NUM_DC       | DC      |
+| EXAMPLE_PIN_NUM_RST      | RST     |
+| EXAMPLE_PIN_NUM_DATA0    | MOSI    |
+| EXAMPLE_PIN_NUM_BK_LIGHT | BCKL    |
+
+Especially, please pay attention to the level used to turn on the LCD backlight, some LCD module needs a low level to turn it on, while others take a high level. You can change the backlight level macro `EXAMPLE_LCD_BK_LIGHT_ON_LEVEL` in [lcd_tjpgd_example_main.c](main/lcd_tjpgd_example_main.c).
 
 ### Build and Flash
 

--- a/esp_jpeg/examples/get_started/main/CMakeLists.txt
+++ b/esp_jpeg/examples/get_started/main/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(srcs "pretty_effect.c"
-    "lcd_tjpgd_example_main.c"
-    "decode_image.c"
+         "lcd_tjpgd_example_main.c"
+         "decode_image.c"
     )
 
 idf_component_register(SRCS ${srcs}
-                    INCLUDE_DIRS "."
-                    EMBED_FILES image.jpg
-                    PRIV_REQUIRES esp_lcd)
+                       INCLUDE_DIRS "."
+                       EMBED_FILES image.jpg
+                       PRIV_REQUIRES esp_lcd driver)

--- a/esp_jpeg/examples/get_started/main/Kconfig.projbuild
+++ b/esp_jpeg/examples/get_started/main/Kconfig.projbuild
@@ -1,4 +1,5 @@
 menu "Example Configuration"
+
     config EXAMPLE_LCD_FLUSH_PARALLEL_LINES
         int "LCD flush parallel lines"
         default 12 if IDF_TARGET_ESP32C2

--- a/esp_jpeg/examples/get_started/main/decode_image.c
+++ b/esp_jpeg/examples/get_started/main/decode_image.c
@@ -35,7 +35,7 @@ esp_err_t decode_image(uint16_t **pixels)
     *pixels = NULL;
     esp_err_t ret = ESP_OK;
 
-    //Alocate pixel memory. Each line is an array of IMAGE_W 16-bit pixels; the `*pixels` array itself contains pointers to these lines.
+    //Allocate pixel memory. Each line is an array of IMAGE_W 16-bit pixels; the `*pixels` array itself contains pointers to these lines.
     *pixels = calloc(IMAGE_H * IMAGE_W, sizeof(uint16_t));
     ESP_GOTO_ON_FALSE((*pixels), ESP_ERR_NO_MEM, err, TAG, "Error allocating memory for lines");
 

--- a/esp_jpeg/examples/get_started/main/decode_image.h
+++ b/esp_jpeg/examples/get_started/main/decode_image.h
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+
 #include <stdint.h>
 #include "esp_err.h"
 
@@ -22,7 +23,7 @@ extern "C" {
  *        Effectively, you can get the pixel data by doing ``decode_image(&myPixels); pixelval=myPixels[ypos][xpos];``
  * @return - ESP_ERR_NOT_SUPPORTED if image is malformed or a progressive jpeg file
  *         - ESP_ERR_NO_MEM if out of memory
- *         - ESP_OK on succesful decode
+ *         - ESP_OK on successful decode
  */
 esp_err_t decode_image(uint16_t **pixels);
 

--- a/esp_jpeg/examples/get_started/main/idf_component.yml
+++ b/esp_jpeg/examples/get_started/main/idf_component.yml
@@ -1,17 +1,5 @@
 dependencies:
   idf: ">=5.0"
   esp_jpeg:
-    version: ">=1.0.2"
+    version: "*"
     override_path: "../../../"
-  esp-box:
-    version: "^2.4"
-    rules:
-      - if: "target == esp32s3"
-  esp32_s2_kaluga_kit:
-    version: "^3.0"
-    rules:
-      - if: "target == esp32s2"
-  esp_wrover_kit:
-    version: "^1.5"
-    rules:
-      - if: "target == esp32"

--- a/esp_jpeg/examples/get_started/main/lcd_tjpgd_example_main.c
+++ b/esp_jpeg/examples/get_started/main/lcd_tjpgd_example_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
@@ -8,11 +8,13 @@
 #include "sdkconfig.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_heap_caps.h"
+#include "driver/spi_master.h"
+#include "driver/gpio.h"
 #include "pretty_effect.h"
-#include "bsp/esp-bsp.h"
-#include "bsp/display.h"
 
 // Using SPI2 in the example, as it also supports octal modes on some targets
 #define LCD_HOST       SPI2_HOST
@@ -20,18 +22,26 @@
 // More means more memory use, but less overhead for setting up / finishing transfers. Make sure 240
 // is dividable by this.
 #define PARALLEL_LINES CONFIG_EXAMPLE_LCD_FLUSH_PARALLEL_LINES
-// The number of frames to show before rotate the graph
-#define ROTATE_FRAME   30
 
-#if BSP_LCD_H_RES > BSP_LCD_V_RES
-#define EXAMPLE_LCD_SWAP    0
-#define EXAMPLE_LCD_H_RES   BSP_LCD_H_RES
-#define EXAMPLE_LCD_V_RES   BSP_LCD_V_RES
-#else
-#define EXAMPLE_LCD_SWAP    1
-#define EXAMPLE_LCD_H_RES   BSP_LCD_V_RES
-#define EXAMPLE_LCD_V_RES   BSP_LCD_H_RES
-#endif
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////// Please update the following configuration according to your LCD spec //////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#define EXAMPLE_LCD_PIXEL_CLOCK_HZ (20 * 1000 * 1000)
+#define EXAMPLE_LCD_BK_LIGHT_ON_LEVEL  0
+#define EXAMPLE_LCD_BK_LIGHT_OFF_LEVEL !EXAMPLE_LCD_BK_LIGHT_ON_LEVEL
+#define EXAMPLE_PIN_NUM_DATA0          23  /*!< for 1-line SPI, this also refereed as MOSI */
+#define EXAMPLE_PIN_NUM_PCLK           19
+#define EXAMPLE_PIN_NUM_CS             22
+#define EXAMPLE_PIN_NUM_DC             21
+#define EXAMPLE_PIN_NUM_RST            18
+#define EXAMPLE_PIN_NUM_BK_LIGHT       5
+
+// The pixel number in horizontal and vertical
+#define EXAMPLE_LCD_H_RES              320
+#define EXAMPLE_LCD_V_RES              240
+// Bit number used to represent command and parameter
+#define EXAMPLE_LCD_CMD_BITS           8
+#define EXAMPLE_LCD_PARAM_BITS         8
 
 // Simple routine to generate some patterns and send them to the LCD. Because the
 // SPI driver handles transactions in the background, we can calculate the next line
@@ -44,8 +54,7 @@ static void display_pretty_colors(esp_lcd_panel_handle_t panel_handle)
     int sending_line = 0;
     int calc_line = 0;
 
-    // After ROTATE_FRAME frames, the image will be rotated
-    while (frame <= ROTATE_FRAME) {
+    while (1) {
         frame++;
         for (int y = 0; y < EXAMPLE_LCD_V_RES; y += PARALLEL_LINES) {
             // Calculate a line
@@ -60,22 +69,64 @@ static void display_pretty_colors(esp_lcd_panel_handle_t panel_handle)
 
 void app_main(void)
 {
-    esp_lcd_panel_io_handle_t io_handle = NULL;
-    esp_lcd_panel_handle_t panel_handle = NULL;
-
-    bsp_display_config_t disp_cfg = {
-        .max_transfer_sz = EXAMPLE_LCD_H_RES * PARALLEL_LINES * sizeof(uint16_t),
+    gpio_config_t bk_gpio_config = {
+        .mode = GPIO_MODE_OUTPUT,
+        .pin_bit_mask = 1ULL << EXAMPLE_PIN_NUM_BK_LIGHT
     };
-    // Display initialize from BSP
-    bsp_display_new(&disp_cfg, &panel_handle, &io_handle);
-    esp_lcd_panel_disp_on_off(panel_handle, true);
-    bsp_display_backlight_on();
+    // Initialize the GPIO of backlight
+    ESP_ERROR_CHECK(gpio_config(&bk_gpio_config));
+
+    spi_bus_config_t buscfg = {
+        .sclk_io_num = EXAMPLE_PIN_NUM_PCLK,
+        .mosi_io_num = EXAMPLE_PIN_NUM_DATA0,
+        .miso_io_num = -1,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        .max_transfer_sz = PARALLEL_LINES * EXAMPLE_LCD_H_RES * 2 + 8
+    };
+    // Initialize the SPI bus
+    ESP_ERROR_CHECK(spi_bus_initialize(LCD_HOST, &buscfg, SPI_DMA_CH_AUTO));
+
+    esp_lcd_panel_io_handle_t io_handle = NULL;
+    esp_lcd_panel_io_spi_config_t io_config = {
+        .dc_gpio_num = EXAMPLE_PIN_NUM_DC,
+        .cs_gpio_num = EXAMPLE_PIN_NUM_CS,
+        .pclk_hz = EXAMPLE_LCD_PIXEL_CLOCK_HZ,
+        .lcd_cmd_bits = EXAMPLE_LCD_CMD_BITS,
+        .lcd_param_bits = EXAMPLE_LCD_PARAM_BITS,
+        .spi_mode = 0,
+        .trans_queue_depth = 10,
+    };
+    // Attach the LCD to the SPI bus
+    ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)LCD_HOST, &io_config, &io_handle));
+
+    esp_lcd_panel_handle_t panel_handle = NULL;
+    esp_lcd_panel_dev_config_t panel_config = {
+        .reset_gpio_num = EXAMPLE_PIN_NUM_RST,
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_BGR,
+        .bits_per_pixel = 16,
+    };
+    // Initialize the LCD configuration
+    ESP_ERROR_CHECK(esp_lcd_new_panel_st7789(io_handle, &panel_config, &panel_handle));
+
+    // Turn off backlight to avoid unpredictable display on the LCD screen while initializing
+    // the LCD panel driver. (Different LCD screens may need different levels)
+    ESP_ERROR_CHECK(gpio_set_level(EXAMPLE_PIN_NUM_BK_LIGHT, EXAMPLE_LCD_BK_LIGHT_OFF_LEVEL));
+
+    // Reset the display
+    ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));
+    // Initialize LCD panel
+    ESP_ERROR_CHECK(esp_lcd_panel_init(panel_handle));
+    // Swap x and y axis (Different LCD screens may need different options)
+    ESP_ERROR_CHECK(esp_lcd_panel_swap_xy(panel_handle, true));
+    // Turn on the screen
+    ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
+
+    // Turn on backlight (Different LCD screens may need different levels)
+    ESP_ERROR_CHECK(gpio_set_level(EXAMPLE_PIN_NUM_BK_LIGHT, EXAMPLE_LCD_BK_LIGHT_ON_LEVEL));
 
     // Initialize the effect displayed
     ESP_ERROR_CHECK(pretty_effect_init());
-
-    // "Rotate or not" flag
-    bool is_rotated = false;
 
     // Allocate memory for the pixel buffers
     for (int i = 0; i < 2; i++) {
@@ -83,16 +134,6 @@ void app_main(void)
         assert(s_lines[i] != NULL);
     }
 
-#if EXAMPLE_LCD_SWAP
-    esp_lcd_panel_swap_xy(panel_handle, true);
-#endif
-
-    // Start and rotate
-    while (1) {
-        // Set driver configuration to rotate 180 degrees each time
-        ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel_handle, is_rotated, is_rotated));
-        // Display
-        display_pretty_colors(panel_handle);
-        is_rotated = !is_rotated;
-    }
+    //Go do nice stuff.
+    display_pretty_colors(panel_handle);
 }

--- a/esp_jpeg/examples/get_started/main/pretty_effect.c
+++ b/esp_jpeg/examples/get_started/main/pretty_effect.c
@@ -54,7 +54,6 @@ void pretty_effect_calc_lines(uint16_t *dest, int line, int frame, int linect)
     }
 }
 
-
 esp_err_t pretty_effect_init(void)
 {
     return decode_image(&pixels);

--- a/esp_jpeg/examples/get_started/sdkconfig.defaults
+++ b/esp_jpeg/examples/get_started/sdkconfig.defaults
@@ -1,4 +1,0 @@
-# This file was generated using idf.py save-defconfig. It can be edited manually.
-# Espressif IoT Development Framework (ESP-IDF) 5.5.0 Project Minimal Configuration
-#
-CONFIG_TOUCH_SUPPRESS_DEPRECATE_WARN=y


### PR DESCRIPTION
This PR is to fix a build issue we encounter in https://github.com/espressif/idf-extra-components/actions/runs/17204187200/job/48801105823

By decoupling the example from the BSP packages.
