### PR TITLE
fix(cbor): use SHELL prefix to keep option groups

### DIFF
--- a/cbor/CMakeLists.txt
+++ b/cbor/CMakeLists.txt
@@ -20,4 +20,4 @@ set_source_files_properties(tinycbor/src/open_memstream.c PROPERTIES
 # Fix unreachable macro redefinition issue between ESP-IDF toolchain and tinycbor
 # by force-including a header that resolves the conflict
 target_compile_options(${COMPONENT_LIB} PRIVATE
-                       "-include" "${CMAKE_CURRENT_SOURCE_DIR}/port/include/unreachable_fix.h")
+                       "SHELL:-include ${CMAKE_CURRENT_SOURCE_DIR}/port/include/unreachable_fix.h")

--- a/cbor/idf_component.yml
+++ b/cbor/idf_component.yml
@@ -1,5 +1,5 @@
-version: "0.6.1~1"
+version: "0.6.1~2"
 description: "CBOR: Concise Binary Object Representation Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/cbor
 dependencies:
-  idf: ">=4.3"
+  idf: ">=5.0"


### PR DESCRIPTION
Closes https://github.com/espressif/idf-extra-components/issues/554