### PR TITLE
feat(sh2lib): TCP keepalive configuration (IEC-367)

### DIFF
--- a/sh2lib/sh2lib.c
+++ b/sh2lib/sh2lib.c
@@ -243,6 +243,7 @@ int sh2lib_connect(struct sh2lib_config_t *cfg, struct sh2lib_handle *hd)
         .alpn_protos = proto,
         .cacert_buf = cfg->cacert_buf,
         .cacert_bytes = cfg->cacert_bytes,
+        .keep_alive_cfg = cfg->keep_alive_cfg,
         .crt_bundle_attach = cfg->crt_bundle_attach,
         .non_block = true,
         .timeout_ms = 10 * 1000,

--- a/sh2lib/sh2lib.h
+++ b/sh2lib/sh2lib.h
@@ -44,6 +44,7 @@ struct sh2lib_config_t {
     esp_err_t (*crt_bundle_attach)(void *conf);
     /*!< Function pointer to esp_crt_bundle_attach. Enables the use of certification
          bundle for server verification, must be enabled in menuconfig */
+    tls_keep_alive_cfg_t *keep_alive_cfg;/*!< Enable TCP keep-alive timeout for SSL connection */
 };
 
 /** Flag indicating receive stream is reset */


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Enable configuring ESP-TLS TCP KeepAlive config pointer
