### PR TITLE
fix(serial_slave_link): Fix the driver dependency (IEC-378)

### DIFF
--- a/esp_serial_slave_link/CHANGELOG.md
+++ b/esp_serial_slave_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Clean up the component dependency, don't depend on the `driver` component directly
+
 ## 1.1.0
 
 - Supported communicating with ESP32C6 SDIO Slave

--- a/esp_serial_slave_link/CMakeLists.txt
+++ b/esp_serial_slave_link/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(public_requires "sdmmc")
 
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}" VERSION_GREATER_EQUAL "5.3")
-    list(APPEND public_requires "esp_driver_spi" "esp_driver_sdmmc")
+    list(APPEND public_requires "esp_driver_sdspi" "esp_driver_sdmmc")
 else()
     list(APPEND public_requires "driver")
 endif()

--- a/esp_serial_slave_link/idf_component.yml
+++ b/esp_serial_slave_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1"
+version: "1.1.1~1"
 description: Espressif Serial Slave Link Library
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_serial_slave_link
 repository: https://github.com/espressif/idf-extra-components.git


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Added the dependent driver
