### PR TITLE
change(expat): exclude CVE-2025-59375

### DIFF
--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -12,3 +12,5 @@ cve-exclude-list:
     reason: Resolved in version 2.6.4, please see https://github.com/libexpat/libexpat/pull/915
   - cve: CVE-2024-8176
     reason: Resolved in version 2.7.0, please see https://github.com/libexpat/libexpat/pull/973
+  - cve: CVE-2025-59375
+    reason: Resolved in version 2.7.2, please see https://github.com/libexpat/libexpat/pull/1034


### PR DESCRIPTION
# Checklist
- [ ] CI passing

# Change description
The expat was updated to version 2.7.2 to fix [CVE-2025-59375](https://nvd.nist.gov/vuln/detail/CVE-2025-59375) with this [PR](https://github.com/espressif/idf-extra-components/pull/573)

However the Github vulnerability scan still reports this vulnerability: https://github.com/espressif/idf-extra-components/actions/runs/17814199758

This PR adds the CVE to the exclude list.