### PR TITLE
fix(cbor): Handle spaces in file paths to resolve compilation errors (IEC-385)

### DIFF
--- a/cbor/CMakeLists.txt
+++ b/cbor/CMakeLists.txt
@@ -20,4 +20,4 @@ set_source_files_properties(tinycbor/src/open_memstream.c PROPERTIES
 # Fix unreachable macro redefinition issue between ESP-IDF toolchain and tinycbor
 # by force-including a header that resolves the conflict
 target_compile_options(${COMPONENT_LIB} PRIVATE
-                       "SHELL:-include ${CMAKE_CURRENT_SOURCE_DIR}/port/include/unreachable_fix.h")
+                       "SHELL:-include \"${CMAKE_CURRENT_SOURCE_DIR}/port/include/unreachable_fix.h\"")

--- a/cbor/idf_component.yml
+++ b/cbor/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.6.1~2"
+version: "0.6.1~3"
 description: "CBOR: Concise Binary Object Representation Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/cbor
 dependencies:


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

This fix addresses compilation failures caused by spaces in file paths when building the cbor component.
The issue occurred because path names with spaces were not properly quoted in compiler flags, leading to errors like:
`riscv32-esp-elf-gcc.exe: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files`
The fix ensures that all file paths are properly escaped/quoted in the build configuration, allowing the component to compile successfully even when located in directories with spaces in their names. This specifically resolves the problem with the -include flag referencing paths containing spaces.

e.g. Error message:
```
FAILED: esp-idf/espressif__cbor/CMakeFiles/__idf_espressif__cbor.dir/tinycbor/src/cborencoder_close_container_checked.c.obj
C:\Espressif\tools\riscv32-esp-elf\esp-14.2.0_20241119\riscv32-esp-elf\bin\riscv32-esp-elf-gcc.exe -DESP_PLATFORM -DIDF_VER=\"v5.5.1\" -DSOC_MMU_PAGE_SIZE=CONFIG_MMU_PAGE_SIZE -DSOC_XTAL_FREQ_MHZ=CONFIG_XTAL_FREQ -D_GLIBCXX_HAVE_POSIX_SEMAPHORE -D_GLIBCXX_USE_POSIX_SEMAPHORE -D_GNU_SOURCE -D_POSIX_READER_WRITER_LOCKS -IC:/Code/esp32c6/esp-rainmaker/examples/switch/build/config -I"C:/OneDrive - MSFT/Code/esp32c6/esp-rainmaker/examples/switch/managed_components/espressif__cbor/port/include" -I"C:/OneDrive - MSFT/Code/esp32c6/esp-rainmaker/examples/switch/managed_components/espressif__cbor/tinycbor/src" -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/newlib/platform_include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/freertos/config/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/freertos/config/include/freertos -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/freertos/config/riscv/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/freertos/FreeRTOS-Kernel/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/freertos/FreeRTOS-Kernel/portable/riscv/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/freertos/FreeRTOS-Kernel/portable/riscv/include/freertos -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/freertos/esp_additions/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/include/soc -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/include/soc/esp32c6 -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/dma/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/ldo/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/debug_probe/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/mspi_timing_tuning/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/mspi_timing_tuning/tuning_scheme_impl/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/power_supply/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/port/esp32c6/. -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/port/esp32c6/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_hw_support/port/esp32c6/private_include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/heap/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/heap/tlsf -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/log/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/soc/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/soc/esp32c6 -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/soc/esp32c6/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/soc/esp32c6/register -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/hal/platform_port/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/hal/esp32c6/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/hal/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_rom/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_rom/esp32c6/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_rom/esp32c6/include/esp32c6 -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_rom/esp32c6 -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_common/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_system/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_system/port/soc -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_system/port/include/riscv -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/esp_system/port/include/private -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/riscv/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/include/apps -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/include/apps/sntp -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/lwip/src/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/port/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/port/freertos/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/port/esp32xx/include -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/port/esp32xx/include/arch -IC:/Users/m2002/esp/v5.5.1/esp-idf/components/lwip/port/esp32xx/include/sys -march=rv32imac_zicsr_zifencei  -fdiagnostics-color=always -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=deprecated-declarations -Wextra -Wno-error=extra -Wno-unused-parameter -Wno-sign-compare -Wno-enum-conversion -gdwarf-4 -ggdb -nostartfiles -Og -fno-shrink-wrap -fmacro-prefix-map=C:/Code/esp32c6/esp-rainmaker/examples/switch=. -fmacro-prefix-map=C:/Users/m2002/esp/v5.5.1/esp-idf=/IDF -fstrict-volatile-bitfields -fno-jump-tables -fno-tree-switch-conversion -std=gnu17 -Wno-old-style-declaration -include C:/OneDrive - MSFT/Code/esp32c6/esp-rainmaker/examples/switch/managed_components/espressif__cbor/port/include/unreachable_fix.h -MD -MT esp-idf/espressif__cbor/CMakeFiles/__idf_espressif__cbor.dir/tinycbor/src/cborencoder_close_container_checked.c.obj -MF esp-idf\espressif__cbor\CMakeFiles\__idf_espressif__cbor.dir\tinycbor\src\cborencoder_close_container_checked.c.obj.d -o esp-idf/espressif__cbor/CMakeFiles/__idf_espressif__cbor.dir/tinycbor/src/cborencoder_close_container_checked.c.obj -c "C:/OneDrive - MSFT/Code/esp32c6/esp-rainmaker/examples/switch/managed_components/espressif__cbor/tinycbor/src/cborencoder_close_container_checked.c"
riscv32-esp-elf-gcc.exe: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
compilation terminated.
```