### PR TITLE
fix(network_provisioning/wifi_prov: Typo Fix in esp_prov.py

### DIFF
--- a/network_provisioning/tool/esp_prov/prov/network_prov.py
+++ b/network_provisioning/tool/esp_prov/prov/network_prov.py
@@ -45,9 +45,9 @@ def config_get_status_response(security_ctx, response_data):
             return 'connected'
         elif cmd_resp1.resp_get_wifi_status.wifi_sta_state == 1:
             print('++++ WiFi state: Connecting... ++++')
-            if cmd_resp1.resp_get_status.HasField('attempt_failed'):
-                if cmd_resp1.resp_get_status.attempt_failed.attempts_remaining:
-                    print(cmd_resp1.resp_get_status)
+            if cmd_resp1.resp_get_wifi_status.HasField('attempt_failed'):
+                if cmd_resp1.resp_get_wifi_status.attempt_failed.attempts_remaining:
+                    print(cmd_resp1.resp_get_wifi_status)
                 else:
                     print('attempt_failed {\n  attempts_remaining: 0\n}')
             return 'connecting'


### PR DESCRIPTION
# Description
Typo fix in esp_prov.py. Instead resp_get_wifi_status, resp_get_status was used

# Regression
https://github.com/espressif/idf-extra-components/pull/571