### PR TITLE
fix(jpeg): Fix a typo in kconfig

### DIFF
--- a/esp_jpeg/Kconfig
+++ b/esp_jpeg/Kconfig
@@ -7,7 +7,7 @@ menu "JPEG Decoder"
         help
             By default, Espressif SoCs use TJpg decoder implemented in ROM code.
             If this feature is disabled, new configuration of TJpg decoder can be used.
-            Refer to REAME.md for more details.
+            Refer to README.md for more details.
 
     config JD_SZBUF
         int "Size of stream input buffer"


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
REAME -> README
