### PR TITLE
feat(network_provisioning): use managed cJSON for IDF 6.0 and above

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 07-October-2025
+
+- Use managed cJSON component for IDF v6.0 and above
+
 # 01-April-2025
 
 - Extend provisioning check for `ESP_WIFI_REMOTE_ENABLED` as well along with existing `ESP_WIFI_ENABLED`

--- a/network_provisioning/CMakeLists.txt
+++ b/network_provisioning/CMakeLists.txt
@@ -26,8 +26,15 @@ if(CONFIG_BT_ENABLED)
     endif()
 endif()
 
+set(priv_requires protobuf-c bt esp_timer esp_wifi openthread)
+
+# For IDF < 6.0, use IDF's built-in json component; for IDF >= 6.0 use managed cJSON component
+if("${IDF_VERSION_MAJOR}" VERSION_LESS "6")
+    list(APPEND priv_requires json)
+endif()
+
 idf_component_register(SRCS "${srcs}"
                     INCLUDE_DIRS include
                     PRIV_INCLUDE_DIRS src proto-c
                     REQUIRES lwip protocomm
-                    PRIV_REQUIRES protobuf-c bt esp_timer esp_wifi openthread)
+                    PRIV_REQUIRES ${priv_requires})

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.2.0"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:
@@ -6,3 +6,5 @@ dependencies:
     espressif/cjson:
       version: "^1.7.19"
       override_path: "../cjson"
+      rules:
+        - if: "idf_version >= 6.0"


### PR DESCRIPTION
If a project is already using the JSON component from IDF 5.x, it’s better to use the same component in network_provisioning as well.

For IDF 6.0 and later, we must use the cJSON component from the registry since it has been removed from the IDF.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
