### PR TITLE
feat: add esp_schedule v1.3.2 from esp-rainmaker (IEC-402)

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -34,6 +34,11 @@ esp_jpeg/examples/get_started:
     - if: IDF_VERSION_MAJOR > 4 and IDF_TARGET in ["esp32", "esp32s2", "esp32s3"]
       reason: Example depends on BSP, which is supported only for IDF >= 5.0 and limited targets
 
+esp_schedule/examples/get_started:
+  enable:
+    - if: ((IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR >= 1) or (IDF_VERSION_MAJOR > 5)) and SOC_WIFI_SUPPORTED == 1
+      reason: Network provisioning component has dependencies IDF >= 5.1; example only supports Wi-Fi enabled targets
+
 catch2/examples/catch2-test:
   enable:
     - if: INCLUDE_DEFAULT == 1 or IDF_TARGET == "linux"

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -38,6 +38,7 @@ body:
         - esp_isotp
         - esp_jpeg
         - esp_lcd_qemu_rgb
+        - esp_schedule
         - esp_serial_slave_link
         - expat
         - fmt

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -42,6 +42,7 @@ jobs:
             esp_lcd_qemu_rgb
             esp_linenoise
             esp_jpeg
+            esp_schedule
             esp_serial_slave_link
             expat
             fmt

--- a/.idf_build_apps.toml
+++ b/.idf_build_apps.toml
@@ -13,6 +13,7 @@ manifest_file = [
     "esp_gcov/.build-test-rules.yml",
     "esp_jpeg/.build-test-rules.yml",
     "esp_linenoise/.build-test-rules.yml",
+    "esp_schedule/.build-test-rules.yml",
     "esp_serial_slave_link/.build-test-rules.yml",
     "expat/.build-test-rules.yml",
     "iqmath/.build-test-rules.yml",

--- a/esp_schedule/.build-test-rules.yml
+++ b/esp_schedule/.build-test-rules.yml
@@ -1,0 +1,2 @@
+# ESP Schedule build test rules
+# This file can be empty - the component will be built with default rules

--- a/esp_schedule/CMakeLists.txt
+++ b/esp_schedule/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(component_srcs "src/esp_schedule.c"
+                   "src/esp_schedule_nvs.c")
+
+idf_component_register(SRCS "${component_srcs}"
+                       INCLUDE_DIRS "include"
+                       PRIV_INCLUDE_DIRS "src"
+                       PRIV_REQUIRES nvs_flash esp_netif)

--- a/esp_schedule/Kconfig
+++ b/esp_schedule/Kconfig
@@ -1,0 +1,20 @@
+menu "ESP Schedule Configuration"
+
+    config ESP_SCHEDULE_ENABLE_DAYLIGHT
+        bool "Enable Daylight (Sunrise/Sunset) Schedules"
+        default y
+        help
+            Enable support for sunrise and sunset based schedules.
+
+            This feature allows scheduling based on astronomical calculations
+            for sunrise and sunset times at specific geographical locations.
+
+            Disabling this option will:
+            - Remove sunrise/sunset schedule types from the API
+            - Save memory by excluding solar calculation code
+            - Reduce binary size (by about 11500 bytes)
+
+            If disabled, ESP_SCHEDULE_TYPE_SUNRISE and ESP_SCHEDULE_TYPE_SUNSET
+            will not be available.
+
+endmenu

--- a/esp_schedule/LICENSE
+++ b/esp_schedule/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/esp_schedule/README.md
+++ b/esp_schedule/README.md
@@ -1,0 +1,28 @@
+# ESP Scheduling
+
+[![Component Registry](https://components.espressif.com/components/espressif/esp_schedule/badge.svg)](https://components.espressif.com/components/espressif/esp_schedule)
+
+This component is used to implement scheduling for:
+
+- **One-shot events** with a relative time difference (e.g., 30 seconds into the future)
+- **Periodic events** based on a certain time[^1] on days of the week (e.g., every Monday or Wednesday)
+- **Periodic/one-shot events** on a certain time[^1] based on the date:
+  - e.g., *(periodic)* every 23rd of January to April
+  - e.g., *(one-shot)* 9th of August, 2026
+- **Periodic events** at an offset from sunrise/sunset
+
+[^1]: By default, the time is w.r.t. UTC. If the timezone has been set, then the time is w.r.t. the specified timezone.
+
+## Example Usage
+
+See the comprehensive example in [`examples/get_started/`](examples/get_started/) for a complete demonstration of all ESP Schedule features, including:
+
+- **Days of Week Scheduling** - Recurring events on specific weekdays
+- **Date-based Scheduling** - Monthly and yearly recurring events
+- **Relative Scheduling** - One-time delayed events
+- **Solar Scheduling** - Sunrise/sunset based events with location coordinates and day-of-week filtering
+- **Schedule Persistence** - NVS storage and recovery
+- **Callback Handling** - Trigger and timestamp callbacks
+- **Schedule Management** - Create, edit, enable, and disable schedules
+
+The example includes detailed documentation, build instructions, and demonstrates all schedule types with practical use cases.

--- a/esp_schedule/examples/get_started/CMakeLists.txt
+++ b/esp_schedule/examples/get_started/CMakeLists.txt
@@ -1,0 +1,7 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+set(COMPONENTS main)
+project(esp_schedule_example)

--- a/esp_schedule/examples/get_started/README.md
+++ b/esp_schedule/examples/get_started/README.md
@@ -1,0 +1,214 @@
+# ESP Schedule Example
+
+## Overview
+
+This example demonstrates how to use the ESP Schedule component to create different types of schedules for ESP32 applications. The example shows four main schedule types:
+
+1. **Days of Week Schedule** - Triggers on specific days of the week at specified times
+2. **Date Schedule** - Triggers on specific dates (day and month combinations)
+3. **Relative Schedule** - Triggers after a specified number of seconds from creation
+4. **Solar Schedule** - Triggers at sunrise or sunset with optional offset
+
+## Schedule Types Demonstrated
+
+### 1. Days of Week Schedule (`ESP_SCHEDULE_TYPE_DAYS_OF_WEEK`)
+- Triggers every Monday, Wednesday, and Friday at 14:30 (2:30 PM)
+- Useful for recurring weekly events like meetings, reminders, or automated tasks
+
+### 2. Date Schedule (`ESP_SCHEDULE_TYPE_DATE`)
+- Triggers every month on the 15th at 09:00 (9:00 AM)
+- Useful for monthly recurring events like bill payments, reports, or maintenance tasks
+- Can be configured to repeat every year for annual events
+
+### 3. Relative Schedule (`ESP_SCHEDULE_TYPE_RELATIVE`)
+- Triggers 60 seconds after creation (one minute timer)
+- Useful for one-time delayed actions like turning off a device after a timeout
+- Has a validity period (2 minutes in this example)
+
+### 4. Solar Schedule (`ESP_SCHEDULE_TYPE_SUNRISE` / `ESP_SCHEDULE_TYPE_SUNSET`)
+- **Sunrise Schedule**: Triggers exactly at sunrise for a specific location (weekdays only)
+- **Sunset Schedule**: Triggers 30 minutes before sunset for a specific location (weekdays only)
+- Uses latitude/longitude coordinates to calculate solar times with day-of-week filtering
+- Perfect for automatic lighting control, irrigation systems, or other location-based automation
+- Supports both day-of-week patterns and specific date patterns for solar events
+- Requires `CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT=y` to be enabled
+
+## Features Demonstrated
+
+- **Schedule Creation**: How to create schedules with different trigger types
+- **Schedule Persistence**: Schedules are stored in NVS and persist across reboots
+- **Network Provisioning**: Automatic WiFi provisioning via BLE or SoftAP for network connectivity with QR code display
+- **Time Synchronization**: Robust SNTP time sync with threshold validation for accurate real-world scheduling
+- **Callback Functions**: Both trigger callbacks (when schedule fires) and timestamp callbacks (when next trigger time updates)
+- **Schedule Management**: Enable, disable, edit, and delete schedules
+- **Schedule Recovery**: Automatically recovers and re-enables schedules after reboot
+
+## How to Use Example
+
+### Hardware Required
+
+* An ESP development board (ESP32, ESP32-S2, ESP32-S3, etc.)
+* USB cable for power supply and programming
+* WiFi network access for time synchronization and network provisioning
+
+### Supported Targets
+
+This example requires Wi-Fi connectivity for network provisioning and time synchronization.
+
+**Supported Targets:** ESP32, ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-S2, ESP32-S3
+
+### Network Provisioning
+
+The example uses configurable network provisioning to connect to WiFi:
+
+1. **Flash and run** the example on your ESP device
+2. **A QR code will be displayed** in the serial output with provisioning data
+3. **Use a BLE/SoftAP provisioning app** (like "ESP SoftAP Prov" on Android/iOS) to scan the QR code (or manually enter the QR code details)
+4. **The device will automatically** connect to WiFi and synchronize time via NTP
+5. **Schedules will then** operate with accurate real-world timing
+
+#### Configuration
+
+- `CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SCHEME` - provisioning transport type
+- `CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION` - provisioning security version:
+   - **Version 0**: plaintext communication
+   - **Version 1**: Proof of Possession (PoP) used, "12345678"
+   - **Version 2**: Username: "wifiprov", Password: "abcd1234"
+
+### Project Configuration
+
+To select the provisioning scheme:
+
+1. Run `idf.py menuconfig` (or `idf.py set-target <chip> && idf.py menuconfig`)
+2. Navigate to `Example Configuration` → `ESP Schedule Example Configuration`
+3. Select your preferred `Network Provisioning Scheme`:
+   - `BLE Provisioning` (default) - Uses Bluetooth LE
+   - `SoftAP Provisioning` - Uses WiFi Access Point
+4. Save and exit
+
+### Build and Flash
+
+1. Run `idf.py set-target <chip_name>` to set the target chip (e.g., `esp32`, `esp32s3`)
+2. Run `idf.py build` to build the project
+3. Run `idf.py -p PORT flash monitor` to build, flash and monitor the project
+
+**Note**: The example includes network provisioning (BLE or SoftAP) and SNTP time synchronization which requires network connectivity. The example will automatically provision and connect to WiFi, then synchronize time from NTP servers. Ensure your device can connect to WiFi networks for proper operation.
+
+**Security Note**: The example uses a fixed Proof of Possession (PoP) value of "12345678" for secure provisioning. In production applications, use a unique, randomly generated PoP for enhanced security.
+
+**QR Code Note**: For BLE provisioning, a QR code is displayed in the serial output that can be scanned with the ESP RainMaker app. If the QR code is not visible, copy the provided URL and paste it in a browser to view the QR code.
+
+### Expected Output
+
+The example will show logs like:
+
+```text
+ESP Schedule example started. Schedules will trigger based on their configurations.
+I (Current time: Fri Oct 24 14:30:00 2025
+)
+I (Days of week schedule triggered! Data: Monday/Wednesday/Friday schedule
+)
+```
+
+The schedules will trigger at their configured times:
+- **Days of week schedule**: Every Monday, Wednesday, Friday at 14:30
+- **Date schedule**: Every 15th of the month at 09:00
+- **Relative schedule**: 60 seconds after the program starts
+- **Solar schedules**: At sunrise (exactly) and sunset (30 minutes early) for San Francisco, CA (weekdays only)
+
+## Code Structure
+
+### Main Components
+
+- **`esp_schedule_example_main.c`**: Main application file demonstrating schedule creation and usage
+- **Callback Functions**: Separate callbacks for each schedule type showing how to handle triggers
+- **Schedule Configuration**: Examples of how to configure different schedule types
+
+### Key Functions
+
+- `create_example_schedules()`: Creates the three example schedules
+- `edit_example_schedules()`: Demonstrates how to edit existing schedules
+- `days_of_week_callback()`, `date_callback()`, `relative_callback()`: Handle schedule triggers
+- `timestamp_callback()`: Handles schedule timestamp updates
+
+## Customization
+
+### Changing Schedule Times
+
+To modify the schedule times, edit the `esp_schedule_config_t` structures in `create_example_schedules()`:
+
+```c
+// Days of week schedule - change time to 10:00 AM
+.trigger.hours = 10,
+.trigger.minutes = 0,
+
+// Date schedule - change to 20th of every month at 3:00 PM
+.trigger.date.day = 20,
+.trigger.hours = 15,
+.trigger.minutes = 0,
+
+// Relative schedule - change to 30 seconds from now
+.trigger.relative_seconds = 30,
+
+// Solar schedule - change location to New York, adjust timing, and change days
+.trigger.day.repeat_days = ESP_SCHEDULE_DAY_SATURDAY | ESP_SCHEDULE_DAY_SUNDAY,  // Weekends only
+.trigger.solar.latitude = 40.7128,    // New York latitude
+.trigger.solar.longitude = -74.0060,  // New York longitude
+.trigger.solar.offset_minutes = 15,   // 15 minutes after sunrise
+```
+
+### Adding More Schedule Types
+
+The example demonstrates all the main schedule types including sunrise/sunset schedules. You can also use:
+
+- **Sunrise/Sunset Schedules** (already included in the example - see solar_callback):
+  ```c
+  .trigger.type = ESP_SCHEDULE_TYPE_SUNRISE,
+  .trigger.solar.latitude = 37.7749,    // San Francisco latitude
+  .trigger.solar.longitude = -122.4194, // San Francisco longitude
+  .trigger.solar.offset_minutes = 30,   // 30 minutes after sunrise
+  ```
+
+### Schedule Persistence
+
+Schedules are automatically saved to NVS (Non-Volatile Storage) and will persist across:
+- Device reboots
+- Power cycles
+- Firmware updates
+
+### Schedule Management
+
+The example shows how to:
+- Create new schedules
+- Enable/disable schedules
+- Edit existing schedules
+- Handle schedule recovery after reboot
+
+## Troubleshooting
+
+### Schedule Not Triggering
+
+1. **Check system time**: Ensure the ESP32 system time is set correctly
+2. **Verify schedule configuration**: Double-check hours/minutes and trigger conditions
+3. **Check logs**: Look for schedule creation and trigger messages in the serial output
+4. **Solar schedules**: Ensure `CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT=y` is enabled and location coordinates are accurate
+5. **Daylight saving time**: Solar schedules automatically adjust for DST changes
+
+### NVS Issues
+
+If you encounter NVS-related errors:
+1. The example includes automatic NVS initialization and recovery
+2. Check if the NVS partition has enough space
+3. Consider erasing NVS if corruption occurs: `idf.py erase-flash`
+
+### Memory Issues
+
+If you run out of memory when creating many schedules:
+1. Each schedule consumes some memory
+2. Consider the validity periods to automatically clean up old schedules
+3. Monitor heap usage with `ESP_LOGI(TAG, "Free heap: %d", esp_get_free_heap_size())`
+
+## Further Reading
+
+- [ESP Schedule API Reference](../../include/esp_schedule.h)
+- [ESP Schedule README](../../README.md)

--- a/esp_schedule/examples/get_started/main/CMakeLists.txt
+++ b/esp_schedule/examples/get_started/main/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(supported_targets "esp32" "esp32s2" "esp32s3" "esp32c2" "esp32c3" "esp32c5" "esp32c6" "esp32c61")
+
+# Redirect to a stub if target is not supported
+if(CONFIG_IDF_TARGET IN_LIST supported_targets)
+    set(srcs "esp_schedule_example_main.c"
+            "network/app_network.c"
+        )
+    set(priv_include_dirs "network")
+else()
+    message(WARNING "Target ${CONFIG_IDF_TARGET} is not supported. Redirecting to stub example.")
+    set(srcs "esp_schedule_example_stub.c")
+    set(priv_include_dirs "")
+endif()
+
+idf_component_register(SRCS ${srcs}
+                       INCLUDE_DIRS "."
+                       PRIV_INCLUDE_DIRS ${priv_include_dirs}
+                       PRIV_REQUIRES esp_schedule nvs_flash esp_netif esp_event esp_wifi)

--- a/esp_schedule/examples/get_started/main/Kconfig.projbuild
+++ b/esp_schedule/examples/get_started/main/Kconfig.projbuild
@@ -1,0 +1,54 @@
+menu "esp_schedule Example Configuration"
+
+    choice ESP_SCHEDULE_EXAMPLE_PROV_SCHEME
+        prompt "Network Provisioning Scheme"
+        default ESP_SCHEDULE_EXAMPLE_PROV_SOFTAP
+        help
+            Select the network provisioning scheme for the ESP Schedule example.
+            For BLE provisioning, please enable BT_ENABLED and BT_NIMBLE_ENABLED.
+
+        config ESP_SCHEDULE_EXAMPLE_PROV_BLE
+            bool "BLE Provisioning"
+            depends on BT_ENABLED && BT_NIMBLE_ENABLED
+            help
+                Use Bluetooth Low Energy (BLE) for network provisioning.
+                Requires a BLE-capable device and provisioning app.
+
+        config ESP_SCHEDULE_EXAMPLE_PROV_SOFTAP
+            bool "SoftAP Provisioning"
+            help
+                Use WiFi Soft Access Point for network provisioning.
+                Creates a WiFi hotspot that users can connect to for provisioning.
+
+    endchoice
+
+    choice ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION
+        prompt "Provisioning security version"
+        default ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_1 if ESP_PROTOCOMM_SUPPORT_SECURITY_VERSION_1
+        default ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_2 if ESP_PROTOCOMM_SUPPORT_SECURITY_VERSION_2
+        help
+            Select the network provisioning security version.
+
+        config ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_0
+            bool "Security Version 0"
+            depends on ESP_PROTOCOMM_SUPPORT_SECURITY_VERSION_0
+            help
+                Security version 0. No authentication is needed; plaintext communication.
+
+        config ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_1
+            bool "Security Version 1"
+            depends on ESP_PROTOCOMM_SUPPORT_SECURITY_VERSION_1
+            help
+                Security version 1. The PoP is set to '12345678'.
+                In production, please use a randomly generated PoP in a factory partition.
+
+        config ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_2
+            bool "Security Version 2"
+            depends on ESP_PROTOCOMM_SUPPORT_SECURITY_VERSION_2
+            help
+                Security version 2. Username: 'wifiprov', Password: 'abcd1234'
+                In production, please use a randomly generated username and password in a factory partition.
+
+    endchoice
+
+endmenu

--- a/esp_schedule/examples/get_started/main/esp_schedule_example_main.c
+++ b/esp_schedule/examples/get_started/main/esp_schedule_example_main.c
@@ -1,0 +1,305 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include "esp_log.h"
+#include "esp_schedule.h"
+#include "nvs_flash.h"
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_netif.h"
+#include "esp_event.h"
+#include "esp_sntp.h"
+#include "lwip/ip_addr.h"
+#include "network_provisioning/manager.h"
+#include "freertos/event_groups.h"
+#include "app_network.h"
+
+static const char *TAG = "esp_schedule_example";
+
+/* Event group for network provisioning synchronization */
+static EventGroupHandle_t s_network_event_group;
+
+// Callback functions for different schedule types
+static void days_of_week_callback(esp_schedule_handle_t handle, void *priv_data)
+{
+    ESP_LOGI(TAG, "Days of week schedule triggered! Data: %s", (char *)priv_data);
+
+    // Example: Toggle an LED, send a notification, etc.
+    // Your application logic here
+}
+
+static void date_callback(esp_schedule_handle_t handle, void *priv_data)
+{
+    ESP_LOGI(TAG, "Date schedule triggered! Data: %s", (char *)priv_data);
+
+    // Example: Birthday reminder, anniversary notification, etc.
+    // Your application logic here
+}
+
+static void relative_callback(esp_schedule_handle_t handle, void *priv_data)
+{
+    ESP_LOGI(TAG, "Relative schedule triggered! Data: %s", (char *)priv_data);
+
+    // Example: Timer expired, delayed action completed, etc.
+    // Your application logic here
+}
+
+#ifdef CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+static void solar_callback(esp_schedule_handle_t handle, void *priv_data)
+{
+    ESP_LOGI(TAG, "Solar schedule triggered! Data: %s", (char *)priv_data);
+
+    // Example: Turn on lights at sunset, turn off lights at sunrise, etc.
+    // Your application logic here
+}
+#endif // CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+
+static void timestamp_callback(esp_schedule_handle_t handle, uint32_t next_timestamp, void *priv_data)
+{
+    time_t timestamp = (time_t)next_timestamp;
+    char *time_str = ctime(&timestamp);
+    if (time_str) {
+        ESP_LOGI(TAG, "Next schedule timestamp updated for %s: %s", (char *)priv_data, time_str);
+    } else {
+        ESP_LOGI(TAG, "Next schedule timestamp updated for %s: <invalid time>", (char *)priv_data);
+    }
+}
+
+// Private data for different schedules
+static char *days_of_week_data = "Monday/Wednesday/Friday schedule";
+static char *date_data = "Monthly schedule";
+static char *relative_data = "Timer schedule";
+#ifdef CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+static char *solar_data = "Sunrise/Sunset schedule";
+#endif // CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+
+/**
+ * @brief Create example schedules
+ *
+ * This function creates the example schedules using the esp_schedule_create() API.
+ * @note If NVS is enabled, then the names of the schedules are used as NVS keys, so they must be shorter than the NVS key length limit of 16 characters.
+ */
+static void create_example_schedules(void)
+{
+    ESP_LOGI(TAG, "Creating example schedules...");
+
+    // Example 1: Days of week schedule
+    // Triggers every Monday, Wednesday, and Friday at 14:30
+    esp_schedule_config_t days_schedule = {
+        .name = "work_days",
+        .trigger.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK,
+        .trigger.hours = 14,
+        .trigger.minutes = 30,
+        .trigger.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY | ESP_SCHEDULE_DAY_WEDNESDAY | ESP_SCHEDULE_DAY_FRIDAY,
+        .trigger_cb = days_of_week_callback,
+        .timestamp_cb = timestamp_callback,
+        .priv_data = days_of_week_data,
+        .validity = {
+            .start_time = 0,  // Start immediately
+            .end_time = 0     // No end time (run indefinitely)
+        }
+    };
+
+    esp_schedule_handle_t days_handle = esp_schedule_create(&days_schedule);
+    if (days_handle) {
+        ESP_LOGI(TAG, "Created days of week schedule successfully");
+        esp_schedule_enable(days_handle);
+    }
+
+    // Example 2: Date schedule
+    // Triggers every month on the 15th at 09:00
+    esp_schedule_config_t date_schedule = {
+        .name = "monthly_15",
+        .trigger.type = ESP_SCHEDULE_TYPE_DATE,
+        .trigger.hours = 9,
+        .trigger.minutes = 0,
+        .trigger.date.day = 15,
+        .trigger.date.repeat_months = ESP_SCHEDULE_MONTH_ALL,  // Every month
+        .trigger.date.repeat_every_year = true,
+        .trigger_cb = date_callback,
+        .timestamp_cb = timestamp_callback,
+        .priv_data = date_data,
+        .validity = {
+            .start_time = 0,  // Start immediately
+            .end_time = 0     // No end time
+        }
+    };
+
+    esp_schedule_handle_t date_handle = esp_schedule_create(&date_schedule);
+    if (date_handle) {
+        ESP_LOGI(TAG, "Created date schedule successfully");
+        esp_schedule_enable(date_handle);
+    }
+
+    // Example 3: Relative schedule
+    // Triggers after 10 seconds from creation
+    time_t current_time = time(NULL);
+    esp_schedule_config_t relative_schedule = {
+        .name = "10_sec",
+        .trigger.type = ESP_SCHEDULE_TYPE_RELATIVE,
+        .trigger.relative_seconds = 10,  // 10 seconds from now
+        .trigger_cb = relative_callback,
+        .timestamp_cb = timestamp_callback,
+        .priv_data = relative_data,
+        .validity = {
+            .start_time = current_time,
+            .end_time = current_time + 120  // Valid for 2 minutes
+        }
+    };
+
+    esp_schedule_handle_t relative_handle = esp_schedule_create(&relative_schedule);
+    if (relative_handle) {
+        ESP_LOGI(TAG, "Created relative schedule successfully");
+        esp_schedule_enable(relative_handle);
+    }
+
+    // Example 4: Solar schedule (Sunrise/Sunset) with day-of-week filtering
+    // Note: This requires CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT to be enabled
+    // Triggers at sunrise and sunset for a specific location, but only on weekdays
+#ifdef CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    esp_schedule_config_t sunrise_schedule = {
+        .name = "sunrise",
+        .trigger.type = ESP_SCHEDULE_TYPE_SUNRISE,
+        .trigger.hours = 0,  // Hours/minutes are ignored for solar schedules
+        .trigger.minutes = 0,
+        .trigger.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY | ESP_SCHEDULE_DAY_TUESDAY |
+        ESP_SCHEDULE_DAY_WEDNESDAY | ESP_SCHEDULE_DAY_THURSDAY | ESP_SCHEDULE_DAY_FRIDAY,
+        .trigger.solar.latitude = 37.7749,    // San Francisco latitude
+        .trigger.solar.longitude = -122.4194, // San Francisco longitude
+        .trigger.solar.offset_minutes = 0,    // Exactly at sunrise
+        .trigger_cb = solar_callback,
+        .timestamp_cb = timestamp_callback,
+        .priv_data = solar_data,
+        .validity = {
+            .start_time = 0,  // Start immediately
+            .end_time = 0     // No end time
+        }
+    };
+
+    esp_schedule_handle_t sunrise_handle = esp_schedule_create(&sunrise_schedule);
+    if (sunrise_handle) {
+        ESP_LOGI(TAG, "Created sunrise schedule successfully");
+        esp_schedule_enable(sunrise_handle);
+    }
+
+    esp_schedule_config_t sunset_schedule = {
+        .name = "sunset",
+        .trigger.type = ESP_SCHEDULE_TYPE_SUNSET,
+        .trigger.hours = 0,  // Hours/minutes are ignored for solar schedules
+        .trigger.minutes = 0,
+        .trigger.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY | ESP_SCHEDULE_DAY_TUESDAY |
+        ESP_SCHEDULE_DAY_WEDNESDAY | ESP_SCHEDULE_DAY_THURSDAY | ESP_SCHEDULE_DAY_FRIDAY,
+        .trigger.solar.latitude = 37.7749,    // San Francisco latitude
+        .trigger.solar.longitude = -122.4194, // San Francisco longitude
+        .trigger.solar.offset_minutes = -30,  // 30 minutes before sunset
+        .trigger_cb = solar_callback,
+        .timestamp_cb = timestamp_callback,
+        .priv_data = solar_data,
+        .validity = {
+            .start_time = 0,  // Start immediately
+            .end_time = 0     // No end time
+        }
+    };
+
+    esp_schedule_handle_t sunset_handle = esp_schedule_create(&sunset_schedule);
+    if (sunset_handle) {
+        ESP_LOGI(TAG, "Created sunset schedule successfully");
+        esp_schedule_enable(sunset_handle);
+    }
+#endif // CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+}
+
+void app_main(void)
+{
+    // Initialize NVS (Non-Volatile Storage)
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+
+    // Initialize Event Loop (Network Interface is initialized in app_network)
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+    // Create event group for network provisioning synchronization
+    s_network_event_group = xEventGroupCreate();
+    if (s_network_event_group == NULL) {
+        ESP_LOGE(TAG, "Failed to create event group");
+        return;
+    }
+
+    // Initialize network provisioning (includes WiFi and network interfaces)
+    ESP_ERROR_CHECK(app_network_init(s_network_event_group));
+
+    // Start network provisioning and wait for connection
+    esp_err_t network_result = app_network_start(s_network_event_group, 300000); // 5 minutes timeout
+    if (network_result != ESP_OK) {
+        ESP_LOGE(TAG, "Network connection failed or timed out");
+        return;
+    }
+
+    // Start time synchronization
+    app_network_start_time_sync(s_network_event_group);
+
+    // Wait for time synchronization to complete
+    esp_err_t time_result = app_network_wait_for_time_sync(s_network_event_group, 60000); // 1 minute timeout
+    if (time_result != ESP_OK) {
+        ESP_LOGW(TAG, "Time synchronization failed or timed out, continuing anyway");
+    }
+
+    // Initialize ESP Schedule
+    ESP_LOGI(TAG, "Initializing ESP Schedule...");
+    uint8_t schedule_count;
+    esp_schedule_handle_t *schedule_list = esp_schedule_init(true, NULL, &schedule_count);
+    if (schedule_list != NULL) {
+        // If there are existing schedules in NVS, their handles will be available in this list. We don't use them in this example, so we free the array.
+        free(schedule_list);
+    }
+
+    // Make all the schedules used
+    create_example_schedules();
+
+    ESP_LOGI(TAG, "ESP Schedule example started. Schedules will trigger based on their configurations.");
+
+    // The schedules will now trigger automatically based on their configurations
+    // Monitor network status and handle disconnections
+    while (1) {
+        // Main application loop
+        vTaskDelay(pdMS_TO_TICKS(1000));  // Delay 1 second
+
+        // Print current time every 10 seconds for reference
+        static int counter = 0;
+        if (++counter >= 10) {
+            time_t now = time(NULL);
+            char *time_str = ctime(&now);
+            if (time_str) {
+                ESP_LOGI(TAG, "Current time: %s", time_str);
+            } else {
+                ESP_LOGI(TAG, "Current time: <invalid>");
+            }
+            counter = 0;
+        }
+
+        // Check for network disconnection and handle it
+        EventBits_t network_bits = xEventGroupGetBits(s_network_event_group);
+        if (network_bits & NETWORK_DISCONNECTED_BIT) {
+            ESP_LOGW(TAG, "Network disconnected, attempting to reconnect...");
+            // For now, just log the issue - in a real application you might
+            // want to restart provisioning or handle reconnection
+            vTaskDelay(pdMS_TO_TICKS(5000)); // Wait 5 seconds before checking again
+        }
+    }
+
+    // Cleanup (this won't be reached in the current infinite loop, but good practice)
+    if (s_network_event_group) {
+        vEventGroupDelete(s_network_event_group);
+    }
+}

--- a/esp_schedule/examples/get_started/main/esp_schedule_example_stub.c
+++ b/esp_schedule/examples/get_started/main/esp_schedule_example_stub.c
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_log.h"
+
+static const char *supported_targets[] = {
+    "esp32",
+    "esp32s2",
+    "esp32s3",
+    "esp32c2",
+    "esp32c3",
+    "esp32c5",
+    "esp32c6",
+    "esp32c61",
+};
+
+void app_main(void)
+{
+    // This is compiled only if CONFIG_IDF_TARGET is not in the list of supported targets.
+    char supported_targets_str[256] = "";
+    for (int i = 0; i < sizeof(supported_targets) / sizeof(supported_targets[0]); i++) {
+        char target_str[32];
+        snprintf(target_str, sizeof(target_str), "\n\t%s", supported_targets[i]);
+        strcat(supported_targets_str, target_str);
+    }
+    ESP_LOGE("esp_schedule_example", "Target '%s' is not supported. Please try one of these supported targets:%s", CONFIG_IDF_TARGET, supported_targets_str);
+    return;
+}

--- a/esp_schedule/examples/get_started/main/idf_component.yml
+++ b/esp_schedule/examples/get_started/main/idf_component.yml
@@ -1,0 +1,11 @@
+## IDF Component Manager Manifest File
+dependencies:
+  idf:
+    version: ">=5.1"
+  espressif/esp_schedule:
+    version: "~1.3.1"
+    override_path: "../../../."
+  espressif/network_provisioning:
+    version: "~1.2.0"
+  espressif/qrcode:
+    version: "~0.1.0"

--- a/esp_schedule/examples/get_started/main/network/app_network.c
+++ b/esp_schedule/examples/get_started/main/network/app_network.c
@@ -1,0 +1,468 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "app_network.h"
+#include "esp_log.h"
+#include "esp_event.h"
+#include "esp_sntp.h"
+#include "esp_netif.h"
+#include "esp_wifi.h"
+#include "esp_mac.h"
+#include "qrcode.h"
+#include "lwip/ip_addr.h"
+#include "network_provisioning/manager.h"
+#if defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_BLE)
+#include "network_provisioning/scheme_ble.h"
+#elif defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SOFTAP)
+#include "network_provisioning/scheme_softap.h"
+#endif
+#include "esp_wifi_types.h"
+
+static const char *TAG = "app_network";
+
+/* Static variables for event group and provisioning scheme */
+static EventGroupHandle_t s_event_group = NULL;
+static esp_netif_t *s_sta_netif = NULL;
+static uint8_t s_mac_addr[6];
+
+#if defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_1)
+/* Proof of Possession for secure provisioning */
+#define ESP_SCHEDULE_EXAMPLE_PROV_SEC1_POP "12345678"
+#elif defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_2)
+/* Username and password for protocomm security 2 */
+#define ESP_SCHEDULE_EXAMPLE_PROV_SEC2_USERNAME          "wifiprov"
+#define ESP_SCHEDULE_EXAMPLE_PROV_SEC2_PWD               "abcd1234"
+
+/* This salt,verifier has been generated for username = "wifiprov" and password = "abcd1234"
+ * IMPORTANT NOTE: For production cases, this must be unique to every device
+ * and should come from device manufacturing partition.*/
+static const char sec2_salt[] = {
+    0x03, 0x6e, 0xe0, 0xc7, 0xbc, 0xb9, 0xed, 0xa8, 0x4c, 0x9e, 0xac, 0x97, 0xd9, 0x3d, 0xec, 0xf4
+};
+
+static const char sec2_verifier[] = {
+    0x7c, 0x7c, 0x85, 0x47, 0x65, 0x08, 0x94, 0x6d, 0xd6, 0x36, 0xaf, 0x37, 0xd7, 0xe8, 0x91, 0x43,
+    0x78, 0xcf, 0xfd, 0x61, 0x6c, 0x59, 0xd2, 0xf8, 0x39, 0x08, 0x12, 0x72, 0x38, 0xde, 0x9e, 0x24,
+    0xa4, 0x70, 0x26, 0x1c, 0xdf, 0xa9, 0x03, 0xc2, 0xb2, 0x70, 0xe7, 0xb1, 0x32, 0x24, 0xda, 0x11,
+    0x1d, 0x97, 0x18, 0xdc, 0x60, 0x72, 0x08, 0xcc, 0x9a, 0xc9, 0x0c, 0x48, 0x27, 0xe2, 0xae, 0x89,
+    0xaa, 0x16, 0x25, 0xb8, 0x04, 0xd2, 0x1a, 0x9b, 0x3a, 0x8f, 0x37, 0xf6, 0xe4, 0x3a, 0x71, 0x2e,
+    0xe1, 0x27, 0x86, 0x6e, 0xad, 0xce, 0x28, 0xff, 0x54, 0x46, 0x60, 0x1f, 0xb9, 0x96, 0x87, 0xdc,
+    0x57, 0x40, 0xa7, 0xd4, 0x6c, 0xc9, 0x77, 0x54, 0xdc, 0x16, 0x82, 0xf0, 0xed, 0x35, 0x6a, 0xc4,
+    0x70, 0xad, 0x3d, 0x90, 0xb5, 0x81, 0x94, 0x70, 0xd7, 0xbc, 0x65, 0xb2, 0xd5, 0x18, 0xe0, 0x2e,
+    0xc3, 0xa5, 0xf9, 0x68, 0xdd, 0x64, 0x7b, 0xb8, 0xb7, 0x3c, 0x9c, 0xfc, 0x00, 0xd8, 0x71, 0x7e,
+    0xb7, 0x9a, 0x7c, 0xb1, 0xb7, 0xc2, 0xc3, 0x18, 0x34, 0x29, 0x32, 0x43, 0x3e, 0x00, 0x99, 0xe9,
+    0x82, 0x94, 0xe3, 0xd8, 0x2a, 0xb0, 0x96, 0x29, 0xb7, 0xdf, 0x0e, 0x5f, 0x08, 0x33, 0x40, 0x76,
+    0x52, 0x91, 0x32, 0x00, 0x9f, 0x97, 0x2c, 0x89, 0x6c, 0x39, 0x1e, 0xc8, 0x28, 0x05, 0x44, 0x17,
+    0x3f, 0x68, 0x02, 0x8a, 0x9f, 0x44, 0x61, 0xd1, 0xf5, 0xa1, 0x7e, 0x5a, 0x70, 0xd2, 0xc7, 0x23,
+    0x81, 0xcb, 0x38, 0x68, 0xe4, 0x2c, 0x20, 0xbc, 0x40, 0x57, 0x76, 0x17, 0xbd, 0x08, 0xb8, 0x96,
+    0xbc, 0x26, 0xeb, 0x32, 0x46, 0x69, 0x35, 0x05, 0x8c, 0x15, 0x70, 0xd9, 0x1b, 0xe9, 0xbe, 0xcc,
+    0xa9, 0x38, 0xa6, 0x67, 0xf0, 0xad, 0x50, 0x13, 0x19, 0x72, 0x64, 0xbf, 0x52, 0xc2, 0x34, 0xe2,
+    0x1b, 0x11, 0x79, 0x74, 0x72, 0xbd, 0x34, 0x5b, 0xb1, 0xe2, 0xfd, 0x66, 0x73, 0xfe, 0x71, 0x64,
+    0x74, 0xd0, 0x4e, 0xbc, 0x51, 0x24, 0x19, 0x40, 0x87, 0x0e, 0x92, 0x40, 0xe6, 0x21, 0xe7, 0x2d,
+    0x4e, 0x37, 0x76, 0x2f, 0x2e, 0xe2, 0x68, 0xc7, 0x89, 0xe8, 0x32, 0x13, 0x42, 0x06, 0x84, 0x84,
+    0x53, 0x4a, 0xb3, 0x0c, 0x1b, 0x4c, 0x8d, 0x1c, 0x51, 0x97, 0x19, 0xab, 0xae, 0x77, 0xff, 0xdb,
+    0xec, 0xf0, 0x10, 0x95, 0x34, 0x33, 0x6b, 0xcb, 0x3e, 0x84, 0x0f, 0xb9, 0xd8, 0x5f, 0xb8, 0xa0,
+    0xb8, 0x55, 0x53, 0x3e, 0x70, 0xf7, 0x18, 0xf5, 0xce, 0x7b, 0x4e, 0xbf, 0x27, 0xce, 0xce, 0xa8,
+    0xb3, 0xbe, 0x40, 0xc5, 0xc5, 0x32, 0x29, 0x3e, 0x71, 0x64, 0x9e, 0xde, 0x8c, 0xf6, 0x75, 0xa1,
+    0xe6, 0xf6, 0x53, 0xc8, 0x31, 0xa8, 0x78, 0xde, 0x50, 0x40, 0xf7, 0x62, 0xde, 0x36, 0xb2, 0xba
+};
+#endif
+
+/* Event handler for network provisioning events */
+static void network_prov_event_handler(void *ctx, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    if (event_base == NETWORK_PROV_EVENT) {
+        switch (event_id) {
+        case NETWORK_PROV_START:
+            ESP_LOGI(TAG, "Network provisioning started");
+            break;
+
+        case NETWORK_PROV_WIFI_CRED_RECV: {
+            ESP_LOGI(TAG, "WiFi credentials received");
+            wifi_config_t *wifi_config = (wifi_config_t *)event_data;
+            ESP_LOGI(TAG, "SSID: %s", wifi_config->sta.ssid);
+            break;
+        }
+
+        case NETWORK_PROV_WIFI_CRED_SUCCESS:
+            ESP_LOGI(TAG, "Network provisioning credentials accepted");
+            if (s_event_group) {
+                xEventGroupSetBits(s_event_group, PROVISIONING_SUCCESS_BIT);
+            }
+            break;
+
+        case NETWORK_PROV_WIFI_CRED_FAIL:
+            ESP_LOGE(TAG, "Network provisioning credentials failed");
+            if (s_event_group) {
+                xEventGroupSetBits(s_event_group, PROVISIONING_FAILED_BIT);
+            }
+            break;
+
+        case NETWORK_PROV_END:
+            ESP_LOGI(TAG, "Network provisioning ended");
+            break;
+
+        default:
+            ESP_LOGD(TAG, "Unhandled network provisioning event: %ld", event_id);
+            break;
+        }
+    }
+}
+
+/* Event handler for WiFi events */
+static void wifi_event_handler(void *ctx, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    if (event_base == WIFI_EVENT) {
+        switch (event_id) {
+        case WIFI_EVENT_STA_START:
+            ESP_LOGI(TAG, "WiFi station started");
+            esp_wifi_connect();
+            break;
+
+        case WIFI_EVENT_STA_CONNECTED:
+            ESP_LOGI(TAG, "WiFi station connected");
+            break;
+
+        case WIFI_EVENT_STA_DISCONNECTED: {
+            ESP_LOGW(TAG, "WiFi station disconnected");
+            wifi_event_sta_disconnected_t *event = (wifi_event_sta_disconnected_t *)event_data;
+            ESP_LOGW(TAG, "Disconnect reason: %d", event->reason);
+
+            if (s_event_group) {
+                xEventGroupSetBits(s_event_group, NETWORK_DISCONNECTED_BIT);
+            }
+            esp_wifi_connect();
+            break;
+        }
+
+        default:
+            ESP_LOGD(TAG, "Unhandled WiFi event: %ld", event_id);
+            break;
+        }
+    }
+}
+
+/* Event handler for IP events */
+static void ip_event_handler(void *ctx, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    if (event_base == IP_EVENT) {
+        switch (event_id) {
+        case IP_EVENT_STA_GOT_IP: {
+            ESP_LOGI(TAG, "WiFi connected, got IP address");
+            ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
+            ESP_LOGI(TAG, "IP Address: " IPSTR, IP2STR(&event->ip_info.ip));
+
+            if (s_event_group) {
+                xEventGroupSetBits(s_event_group, NETWORK_CONNECTED_BIT);
+            }
+            break;
+        }
+
+        case IP_EVENT_STA_LOST_IP:
+            ESP_LOGW(TAG, "WiFi disconnected, lost IP address");
+            if (s_event_group) {
+                xEventGroupSetBits(s_event_group, NETWORK_DISCONNECTED_BIT);
+            }
+            break;
+
+        default:
+            ESP_LOGD(TAG, "Unhandled IP event: %ld", event_id);
+            break;
+        }
+    }
+}
+
+/* Initialize WiFi interfaces */
+static esp_err_t wifi_init(void)
+{
+    esp_err_t ret;
+
+    /* Get MAC address for service name generation */
+    ret = esp_read_mac(s_mac_addr, ESP_MAC_BASE);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read MAC address: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    /* Initialize TCP/IP */
+    ret = esp_netif_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize TCP/IP: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    /* Create default WiFi station interface */
+    s_sta_netif = esp_netif_create_default_wifi_sta();
+    if (s_sta_netif == NULL) {
+        ESP_LOGE(TAG, "Failed to create WiFi station interface");
+        return ESP_FAIL;
+    }
+
+    /* Initialize WiFi with default configuration */
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ret = esp_wifi_init(&cfg);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize WiFi: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    /* Set WiFi storage to RAM (credentials will be managed by provisioning) */
+    ret = esp_wifi_set_storage(WIFI_STORAGE_RAM);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set WiFi storage: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    /* Register event handlers */
+    ret = esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register WiFi event handler: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, &ip_event_handler, NULL);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register IP event handler: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    ESP_LOGI(TAG, "WiFi interfaces initialized");
+    return ESP_OK;
+}
+
+/* Start WiFi station */
+static esp_err_t wifi_start_sta(void)
+{
+    esp_err_t ret;
+    ret = esp_wifi_set_mode(WIFI_MODE_STA);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set WiFi mode to STA: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = esp_wifi_start();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to start WiFi station: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    return ESP_OK;
+}
+
+/* Generate QR code for provisioning data */
+static void display_qr_code(const char *service_name)
+{
+    if (!service_name) {
+        ESP_LOGW(TAG, "Cannot generate QR code payload. Data missing.");
+        return;
+    }
+
+#if defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_BLE)
+    const char *transport = "ble";
+#elif defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SOFTAP)
+    const char *transport = "softap";
+#else
+    ESP_LOGE(TAG, "Unknown transport; cannot generate QR code.");
+    return;
+#endif
+
+    static const char *version = "v1";
+    char payload[150];
+
+#if defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_1)
+    snprintf(payload, sizeof(payload), "{\"ver\":\"%s\",\"name\":\"%s\",\"pop\":\"%s\",\"transport\":\"%s\"}",
+             version, service_name, ESP_SCHEDULE_EXAMPLE_PROV_SEC1_POP, transport);
+#elif defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_2)
+    snprintf(payload, sizeof(payload), "{\"ver\":\"%s\",\"name\":\"%s\",\"username\":\"%s\",\"pop\":\"%s\",\"transport\":\"%s\"}",
+             version, service_name, ESP_SCHEDULE_EXAMPLE_PROV_SEC2_USERNAME, ESP_SCHEDULE_EXAMPLE_PROV_SEC2_PWD, transport);
+#else
+    snprintf(payload, sizeof(payload), "{\"ver\":\"%s\",\"name\":\"%s\",\"transport\":\"%s\"}",
+             version, service_name, transport);
+#endif
+
+    ESP_LOGI(TAG, "Scan this QR code from the ESP RainMaker phone app for Provisioning.");
+    esp_qrcode_config_t cfg = ESP_QRCODE_CONFIG_DEFAULT();
+    esp_qrcode_generate(&cfg, payload);
+
+    ESP_LOGI(TAG, "If QR code is not visible, copy paste the below URL in a browser.\nhttps://espressif.github.io/esp-jumpstart/qrcode.html?data=%s", payload);
+}
+
+/* Initialize network provisioning with event group handling */
+esp_err_t app_network_init(EventGroupHandle_t event_group)
+{
+    esp_err_t ret;
+
+    s_event_group = event_group;
+
+    /* Initialize WiFi interfaces first */
+    ret = wifi_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize WiFi");
+        return ret;
+    }
+
+    /* Initialize network provisioning manager */
+    network_prov_mgr_config_t config = {
+#if defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_BLE)
+        .scheme = network_prov_scheme_ble,
+        .scheme_event_handler = NETWORK_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BLE,
+#elif defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SOFTAP)
+        .scheme = network_prov_scheme_softap,
+        .scheme_event_handler = NETWORK_PROV_EVENT_HANDLER_NONE,
+#endif
+    };
+
+    ret = network_prov_mgr_init(config);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize network provisioning manager: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    /* Register event handlers */
+    ret = esp_event_handler_register(NETWORK_PROV_EVENT, ESP_EVENT_ANY_ID, &network_prov_event_handler, NULL);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register network provisioning event handler: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, &ip_event_handler, NULL);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register IP event handler: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    ESP_LOGI(TAG, "Network provisioning initialized successfully");
+    return ESP_OK;
+}
+
+/* Start network provisioning and wait for connection */
+esp_err_t app_network_start(EventGroupHandle_t event_group, uint32_t timeout_ms)
+{
+    esp_err_t ret;
+    bool provisioned = false;
+
+    /* Check if device is already provisioned */
+    ret = network_prov_mgr_is_wifi_provisioned(&provisioned);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to check provisioning status: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    if (!provisioned) {
+        ESP_LOGI(TAG, "Device not provisioned, starting provisioning...");
+
+        /* Generate service name */
+        char service_name[32];
+        snprintf(service_name, sizeof(service_name), "ESP-Schedule-%02x%02x%02x",
+                 s_mac_addr[3], s_mac_addr[4], s_mac_addr[5]);
+
+        /* Display QR code for provisioning */
+        display_qr_code(service_name);
+#if defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SOFTAP)
+        /* For SoftAP, create WiFi AP interface */
+        esp_netif_create_default_wifi_ap();
+#endif
+
+#if defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_0)
+        ret = network_prov_mgr_start_provisioning(NETWORK_PROV_SECURITY_0, NULL, service_name, NULL);
+#endif
+#if defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_1)
+        ret = network_prov_mgr_start_provisioning(NETWORK_PROV_SECURITY_1, ESP_SCHEDULE_EXAMPLE_PROV_SEC1_POP, service_name, NULL);
+#elif defined(CONFIG_ESP_SCHEDULE_EXAMPLE_PROV_SECURITY_VERSION_2)
+        const network_prov_security2_params_t sec2_params = {
+            .salt = sec2_salt,
+            .salt_len = sizeof(sec2_salt),
+            .verifier = sec2_verifier,
+            .verifier_len = sizeof(sec2_verifier),
+        };
+        ret = network_prov_mgr_start_provisioning(NETWORK_PROV_SECURITY_2, &sec2_params, service_name, NULL);
+#endif
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to start network provisioning: %s", esp_err_to_name(ret));
+            return ret;
+        }
+    } else {
+        ESP_LOGI(TAG, "Device already provisioned, starting Wi-Fi STA");
+
+        /* Start WiFi station directly */
+        ret = wifi_start_sta();
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to start WiFi station: %s", esp_err_to_name(ret));
+            return ret;
+        }
+
+        /* Post provisioning end event since we're already provisioned */
+        esp_event_post(NETWORK_PROV_EVENT, NETWORK_PROV_END, NULL, 0, portMAX_DELAY);
+    }
+
+    /* Wait for network connection */
+    EventBits_t bits = xEventGroupWaitBits(event_group,
+                                           NETWORK_CONNECTED_BIT,
+                                           pdTRUE,  // Clear bits on exit
+                                           pdFALSE, // Wait for connection only
+                                           pdMS_TO_TICKS(timeout_ms));
+
+    if (bits & NETWORK_CONNECTED_BIT) {
+        ESP_LOGI(TAG, "Network connected successfully");
+        return ESP_OK;
+    } else {
+        ESP_LOGE(TAG, "Network connection timed out");
+        return ESP_ERR_TIMEOUT;
+    }
+}
+
+/* Start time synchronization */
+void app_network_start_time_sync(EventGroupHandle_t event_group)
+{
+    ESP_LOGI(TAG, "Starting SNTP time synchronization...");
+
+    /* Configure SNTP */
+    esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
+    esp_sntp_setservername(0, "pool.ntp.org");
+    esp_sntp_setservername(1, "time.google.com");
+    esp_sntp_setservername(2, "time.cloudflare.com");
+
+    /* Start SNTP */
+    esp_sntp_init();
+
+    /* Set a flag to indicate time sync has started */
+    if (event_group) {
+        xEventGroupSetBits(event_group, TIME_SYNC_SUCCESS_BIT);
+    }
+}
+
+/* Wait for time synchronization to complete */
+esp_err_t app_network_wait_for_time_sync(EventGroupHandle_t event_group, uint32_t timeout_ms)
+{
+    time_t now = 0;
+    int retry = 0;
+    const int retry_count = timeout_ms / 2000;  // Check every 2 seconds
+    const time_t time_threshold = 1609459200;  // January 1, 2021 - reasonable baseline
+
+    ESP_LOGI(TAG, "Waiting for time synchronization...");
+
+    while (retry < retry_count) {
+        time(&now);
+
+        if (now >= time_threshold && sntp_get_sync_status() != SNTP_SYNC_STATUS_RESET) {
+            ESP_LOGI(TAG, "Time synchronized successfully! Current time: %s", ctime(&now));
+            if (event_group) {
+                xEventGroupSetBits(event_group, TIME_SYNC_SUCCESS_BIT);
+            }
+            return ESP_OK;
+        }
+
+        ESP_LOGD(TAG, "Time sync attempt %d/%d, time: %ld, status: %d",
+                 retry + 1, retry_count, (long)now, sntp_get_sync_status());
+
+        vTaskDelay(2000 / portTICK_PERIOD_MS);
+        retry++;
+    }
+
+    ESP_LOGW(TAG, "Time synchronization may have failed or time is before threshold");
+    if (event_group) {
+        xEventGroupSetBits(event_group, TIME_SYNC_FAILED_BIT);
+    }
+    return ESP_ERR_TIMEOUT;
+}

--- a/esp_schedule/examples/get_started/main/network/app_network.h
+++ b/esp_schedule/examples/get_started/main/network/app_network.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "network_provisioning/manager.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Event group bits for network provisioning states */
+#define NETWORK_CONNECTED_BIT      BIT0
+#define NETWORK_DISCONNECTED_BIT   BIT1
+#define PROVISIONING_SUCCESS_BIT   BIT2
+#define PROVISIONING_FAILED_BIT    BIT3
+#define TIME_SYNC_SUCCESS_BIT      BIT4
+#define TIME_SYNC_FAILED_BIT       BIT5
+
+/**
+ * @brief Initialize network provisioning with event group handling
+ *
+ * This function initializes the network provisioning system and sets up event handlers
+ * for network provisioning and IP events. It uses either BLE or SoftAP provisioning
+ * based on the Kconfig selection.
+ *
+ * @param event_group Pointer to the event group that will be used for synchronization
+ * @return esp_err_t ESP_OK on success, or error code on failure
+ */
+esp_err_t app_network_init(EventGroupHandle_t event_group);
+
+/**
+ * @brief Start network provisioning and wait for connection
+ *
+ * This function checks if the device is already provisioned. If provisioned,
+ * it starts WiFi station and waits for network connection. If not provisioned,
+ * it starts the provisioning sequence and waits for network connection.
+ *
+ * @param event_group The event group to wait on
+ * @param timeout_ms Timeout in milliseconds
+ * @return esp_err_t ESP_OK if network connected, ESP_FAIL if failed or timed out
+ */
+esp_err_t app_network_start(EventGroupHandle_t event_group, uint32_t timeout_ms);
+
+/**
+ * @brief Start time synchronization
+ *
+ * This function starts SNTP time synchronization and waits for it to complete.
+ *
+ * @param event_group The event group to signal completion on
+ */
+void app_network_start_time_sync(EventGroupHandle_t event_group);
+
+/**
+ * @brief Wait for time synchronization to complete
+ *
+ * This function waits for time synchronization to complete successfully.
+ *
+ * @param event_group The event group to wait on
+ * @param timeout_ms Timeout in milliseconds
+ * @return esp_err_t ESP_OK if time sync succeeded, ESP_FAIL if failed or timed out
+ */
+esp_err_t app_network_wait_for_time_sync(EventGroupHandle_t event_group, uint32_t timeout_ms);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp_schedule/examples/get_started/sdkconfig.defaults
+++ b/esp_schedule/examples/get_started/sdkconfig.defaults
@@ -1,0 +1,7 @@
+# Example project configuration for ESP Schedule
+
+# Enable daylight (sunrise/sunset) schedules for the example
+CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT=y
+
+# Example can become pretty big, so enable larger partition
+CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y

--- a/esp_schedule/examples/get_started/sdkconfig.defaults.esp32c2
+++ b/esp_schedule/examples/get_started/sdkconfig.defaults.esp32c2
@@ -1,0 +1,4 @@
+# ESP32C2 specific
+
+CONFIG_IDF_TARGET="esp32c2"
+CONFIG_XTAL_FREQ_26=y

--- a/esp_schedule/idf_component.yml
+++ b/esp_schedule/idf_component.yml
@@ -1,0 +1,11 @@
+## IDF Component Manager Manifest File
+version: "1.3.2"
+description: Task scheduling based on periodic and one-time events
+url: https://github.com/espressif/idf-extra-components/tree/master/components/esp_schedule
+repository: https://github.com/espressif/idf-extra-components.git
+issues: https://github.com/espressif/esp-rainmaker/issues
+dependencies:
+  idf: ">=5.1"
+  espressif/esp_daylight:
+    version: "~1.0.1"
+    override_path: "../esp_daylight"

--- a/esp_schedule/include/esp_schedule.h
+++ b/esp_schedule/include/esp_schedule.h
@@ -1,0 +1,257 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <time.h>
+#include "esp_err.h"
+#include "sdkconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Schedule Handle */
+typedef void *esp_schedule_handle_t;
+
+/** Maximum length of the schedule name allowed. This value cannot be more than 16 as it is used for NVS key. */
+#define MAX_SCHEDULE_NAME_LEN 16
+
+/** Callback for schedule trigger
+ *
+ * This callback is called when the schedule is triggered.
+ *
+ * @param[in] handle Schedule handle.
+ * @param[in] priv_data Pointer to the private data passed while creating/editing the schedule.
+ */
+typedef void (*esp_schedule_trigger_cb_t)(esp_schedule_handle_t handle, void *priv_data);
+
+/** Callback for schedule timestamp
+ *
+ * This callback is called when the next trigger timestamp of the schedule is changed. This might be useful to check if
+ * one time schedules have already passed while the device was powered off.
+ *
+ * @param[in] handle Schedule handle.
+ * @param[in] next_timestamp timestamp at which the schedule will trigger next.
+ * @param[in] priv_data Pointer to the user data passed while creating/editing the schedule.
+ */
+typedef void (*esp_schedule_timestamp_cb_t)(esp_schedule_handle_t handle, uint32_t next_timestamp, void *priv_data);
+
+/** Schedule type */
+typedef enum esp_schedule_type {
+    ESP_SCHEDULE_TYPE_INVALID = 0,
+    ESP_SCHEDULE_TYPE_DAYS_OF_WEEK,
+    ESP_SCHEDULE_TYPE_DATE,
+    ESP_SCHEDULE_TYPE_RELATIVE,
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    ESP_SCHEDULE_TYPE_SUNRISE,
+    ESP_SCHEDULE_TYPE_SUNSET,
+#endif
+} esp_schedule_type_t;
+
+/** Schedule days. Used for ESP_SCHEDULE_TYPE_DAYS_OF_WEEK. */
+typedef enum esp_schedule_days {
+    ESP_SCHEDULE_DAY_ONCE      = 0,
+    ESP_SCHEDULE_DAY_EVERYDAY  = 0b1111111,
+    ESP_SCHEDULE_DAY_MONDAY    = 1 << 0,
+    ESP_SCHEDULE_DAY_TUESDAY   = 1 << 1,
+    ESP_SCHEDULE_DAY_WEDNESDAY = 1 << 2,
+    ESP_SCHEDULE_DAY_THURSDAY  = 1 << 3,
+    ESP_SCHEDULE_DAY_FRIDAY    = 1 << 4,
+    ESP_SCHEDULE_DAY_SATURDAY  = 1 << 5,
+    ESP_SCHEDULE_DAY_SUNDAY    = 1 << 6,
+} esp_schedule_days_t;
+
+/** Schedule months. Used for ESP_SCHEDULE_TYPE_DATE. */
+typedef enum esp_schedule_months {
+    ESP_SCHEDULE_MONTH_ONCE         = 0,
+    ESP_SCHEDULE_MONTH_ALL          = 0b111111111111,
+    ESP_SCHEDULE_MONTH_JANUARY      = 1 << 0,
+    ESP_SCHEDULE_MONTH_FEBRUARY     = 1 << 1,
+    ESP_SCHEDULE_MONTH_MARCH        = 1 << 2,
+    ESP_SCHEDULE_MONTH_APRIL        = 1 << 3,
+    ESP_SCHEDULE_MONTH_MAY          = 1 << 4,
+    ESP_SCHEDULE_MONTH_JUNE         = 1 << 5,
+    ESP_SCHEDULE_MONTH_JULY         = 1 << 6,
+    ESP_SCHEDULE_MONTH_AUGUST       = 1 << 7,
+    ESP_SCHEDULE_MONTH_SEPTEMBER    = 1 << 8,
+    ESP_SCHEDULE_MONTH_OCTOBER      = 1 << 9,
+    ESP_SCHEDULE_MONTH_NOVEMBER     = 1 << 10,
+    ESP_SCHEDULE_MONTH_DECEMBER     = 1 << 11,
+} esp_schedule_months_t;
+
+/** Trigger details of the schedule */
+typedef struct esp_schedule_trigger {
+    /** Type of schedule */
+    esp_schedule_type_t type;
+    /** Hours in 24 hour format. Accepted values: 0-23 */
+    uint8_t hours;
+    /** Minutes in the given hour. Accepted values: 0-59. */
+    uint8_t minutes;
+    /** For type ESP_SCHEDULE_TYPE_DAYS_OF_WEEK and solar schedules with day-of-week patterns */
+    struct {
+        /** 'OR' list of esp_schedule_days_t */
+        uint8_t repeat_days;
+    } day;
+    /** For type ESP_SCHEDULE_TYPE_DATE and solar schedules with specific date patterns */
+    struct {
+        /** Day of the month. Accepted values: 1-31. */
+        uint8_t day;
+        /* 'OR' list of esp_schedule_months_t */
+        uint16_t repeat_months;
+        /** Year */
+        uint16_t year;
+        /** If the schedule is to be repeated every year. */
+        bool repeat_every_year;
+    } date;
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    /** For type ESP_SCHEDULE_TYPE_SUNRISE and ESP_SCHEDULE_TYPE_SUNSET
+     * Uses day.repeat_days for day-of-week patterns (if date.day == 0)
+     * Uses date.* fields for specific date patterns (if date.day != 0)
+     * If both are 0, treated as single-time schedule */
+    struct {
+        /** Latitude in decimal degrees (-90 to +90, positive North) */
+        double latitude;
+        /** Longitude in decimal degrees (-180 to +180, positive East) */
+        double longitude;
+        /** Offset in minutes from sunrise/sunset (positive = after, negative = before) */
+        int offset_minutes;
+    } solar;
+#endif
+    /** For type ESP_SCHEDULE_TYPE_SECONDS */
+    int relative_seconds;
+    /** Used for passing the next schedule timestamp for
+     * ESP_SCHEDULE_TYPE_RELATIVE */
+    time_t next_scheduled_time_utc;
+} esp_schedule_trigger_t;
+
+/** Schedule Validity
+ * Start and end time within which the schedule will be applicable.
+ */
+typedef struct esp_schedule_validity {
+    /* Start time as UTC timestamp */
+    time_t start_time;
+    /* End time as UTC timestamp */
+    time_t end_time;
+} esp_schedule_validity_t;
+
+/** Schedule config */
+typedef struct esp_schedule_config {
+    /** Name of the schedule. This is like a primary key for the schedule. This is required. +1 for NULL termination. */
+    char name[MAX_SCHEDULE_NAME_LEN + 1];
+    /** Trigger details */
+    esp_schedule_trigger_t trigger;
+    /** Trigger callback */
+    esp_schedule_trigger_cb_t trigger_cb;
+    /** Timestamp callback */
+    esp_schedule_timestamp_cb_t timestamp_cb;
+    /** Private data associated with the schedule. This will be passed to callbacks. */
+    void *priv_data;
+    /** Validity of schedules. */
+    esp_schedule_validity_t validity;
+} esp_schedule_config_t;
+
+/** Initialize ESP Schedule
+ *
+ * This initializes ESP Schedule. This must be called first before calling any of the other APIs.
+ * This API also gets all the schedules from NVS (if it has been enabled).
+ *
+ * Note: After calling this API, the pointers to the callbacks should be updated for all the schedules by calling
+ * esp_schedule_get() followed by esp_schedule_edit() with the correct callbacks.
+ *
+ * @param[in] enable_nvs If NVS is to be enabled or not.
+ * @param[in] nvs_partition (Optional) The NVS partition to be used. If NULL is passed, the default partition is used.
+ * @param[out] schedule_count Number of active schedules found in NVS.
+ *
+ * @return Array of schedule handles if any schedules have been found.
+ * @return NULL if no schedule is found in NVS (or if NVS is not enabled).
+ */
+esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, uint8_t *schedule_count);
+
+/** Create Schedule
+ *
+ * This API can be used to create a new schedule. The schedule still needs to be enabled using
+ * esp_schedule_enable().
+ *
+ * @param[in] schedule_config Configuration of the schedule to be created.
+ *
+ * @return Schedule handle if successfully created.
+ * @return NULL in case of error.
+ */
+esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config);
+
+/** Remove Schedule
+ *
+ * This API can be used to remove an existing schedule.
+ *
+ * @param[in] handle Schedule handle for the schedule to be removed.
+ *
+ * @return ESP_OK on success.
+ * @return error in case of failure.
+ */
+esp_err_t esp_schedule_delete(esp_schedule_handle_t handle);
+
+/** Edit Schedule
+ *
+ * This API can be used to edit an existing schedule.
+ * The schedule name should be same as when the schedule was created. The complete config must be provided
+ * or the previously stored config might be over-written.
+ *
+ * Note: If a schedule is edited when it is on-going, the new changes will not be reflected.
+ * You will need to disable the schedule, edit it, and then enable it again.
+ *
+ * @param[in] handle Schedule handle for the schedule to be edited.
+ * @param[in] schedule_config Configuration of the schedule to be edited.
+ *
+ * @return ESP_OK on success.
+ * @return error in case of failure.
+ */
+esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config);
+
+/** Enable Schedule
+ *
+ * This API can be used to enable an existing schedule.
+ * It can be used to enable a schedule after it has been created using esp_schedule_create()
+ * or if the schedule has been disabled using esp_schedule_disable().
+ *
+ * @param[in] handle Schedule handle for the schedule to be enabled.
+ *
+ * @return ESP_OK on success.
+ * @return error in case of failure.
+ */
+esp_err_t esp_schedule_enable(esp_schedule_handle_t handle);
+
+/** Disable Schedule
+ *
+ * This API can be used to disable an on-going schedule.
+ * It does not remove the schedule, just stops it. The schedule can be enabled again using
+ * esp_schedule_enable().
+ *
+ * @param[in] handle Schedule handle for the schedule to be disabled.
+ *
+ * @return ESP_OK on success.
+ * @return error in case of failure.
+ */
+esp_err_t esp_schedule_disable(esp_schedule_handle_t handle);
+
+/** Get Schedule
+ *
+ * This API can be used to get details of an existing schedule.
+ * The schedule_config is populated with the schedule details.
+ *
+ * @param[in] handle Schedule handle.
+ * @param[out] schedule_config Details of the schedule whose handle is passed.
+ *
+ * @return ESP_OK on success.
+ * @return error in case of failure.
+ */
+esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp_schedule/src/esp_schedule.c
+++ b/esp_schedule/src/esp_schedule.c
@@ -1,0 +1,851 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <string.h>
+#include <inttypes.h>
+#include "esp_log.h"
+#include "esp_sntp.h"
+#include "esp_daylight.h"
+#include "esp_schedule_internal.h"
+
+static const char *TAG = "esp_schedule";
+
+#define SECONDS_TILL_2020 ((2020 - 1970) * 365 * 24 * 3600)
+#define SECONDS_IN_DAY (60 * 60 * 24)
+
+static bool init_done = false;
+
+static int esp_schedule_get_no_of_days(esp_schedule_trigger_t *trigger, struct tm *current_time, struct tm *schedule_time)
+{
+    /* for day, monday = 0, sunday = 6. */
+    int next_day = 0;
+    /* struct tm has tm_wday with sunday as 0. Whereas we have monday as 0. Converting struct tm to our format */
+    int today = ((current_time->tm_wday + 7 - 1) % 7);
+
+    esp_schedule_days_t today_bit = 1 << today;
+    uint8_t repeat_days = trigger->day.repeat_days;
+    int current_seconds = (current_time->tm_hour * 60 + current_time->tm_min) * 60 + current_time->tm_sec;
+    int schedule_seconds = (schedule_time->tm_hour * 60 + schedule_time->tm_min) * 60;
+
+    /* Handling for one time schedule */
+    if (repeat_days == ESP_SCHEDULE_DAY_ONCE) {
+        if (schedule_seconds > current_seconds) {
+            /* The schedule is today and is yet to go off */
+            return 0;
+        } else {
+            /* The schedule is tomorrow */
+            return 1;
+        }
+    }
+
+    /* Handling for repeating schedules */
+    /* Check if it is today */
+    if ((repeat_days & today_bit)) {
+        if (schedule_seconds > current_seconds) {
+            /* The schedule is today and is yet to go off. */
+            return 0;
+        }
+    }
+    /* Check if it is this week or next week */
+    if ((repeat_days & (today_bit ^ 0xFF)) > today_bit) {
+        /* Next schedule is yet to come in this week */
+        next_day = ffs(repeat_days & (0xFF << (today + 1))) - 1;
+        return (next_day - today);
+    } else {
+        /* First scheduled day of the next week */
+        next_day = ffs(repeat_days) - 1;
+        if (next_day == today) {
+            /* Same day, next week */
+            return 7;
+        }
+        return (7 - today + next_day);
+    }
+
+    ESP_LOGE(TAG, "No of days could not be found. This should not happen.");
+    return 0;
+}
+
+static uint8_t esp_schedule_get_next_month(esp_schedule_trigger_t *trigger, struct tm *current_time, struct tm *schedule_time)
+{
+    int current_seconds = (current_time->tm_hour * 60 + current_time->tm_min) * 60 + current_time->tm_sec;
+    int schedule_seconds = (schedule_time->tm_hour * 60 + schedule_time->tm_min) * 60;
+    /* +1 is because struct tm has months starting from 0, whereas we have them starting from 1 */
+    uint8_t current_month = current_time->tm_mon + 1;
+    /* -1 because month_bit starts from 0b1. So for January, it should be 1 << 0. And current_month starts from 1. */
+    uint16_t current_month_bit = 1 << (current_month - 1);
+    uint8_t next_schedule_month = 0;
+    uint16_t repeat_months = trigger->date.repeat_months;
+
+    /* Check if month is not specified */
+    if (repeat_months == ESP_SCHEDULE_MONTH_ONCE) {
+        if (trigger->date.day == current_time->tm_mday) {
+            /* The schedule day is same. Check if time has already passed */
+            if (schedule_seconds > current_seconds) {
+                /* The schedule is today and is yet to go off */
+                return current_month;
+            } else {
+                /* Today's time has passed */
+                return (current_month + 1);
+            }
+        } else if (trigger->date.day > current_time->tm_mday) {
+            /* The day is yet to come in this month */
+            return current_month;
+        } else {
+            /* The day has passed in the current month */
+            return (current_month + 1);
+        }
+    }
+
+    /* Check if schedule is not this year itself, it is in future. */
+    if (trigger->date.year > (current_time->tm_year + 1900)) {
+        /* Find first schedule month of next year */
+        next_schedule_month = ffs(repeat_months);
+        /* Year will be handled by the caller. So no need to add any additional months */
+        return next_schedule_month;
+    }
+
+    /* Check if schedule is this month and is yet to come */
+    if (current_month_bit & repeat_months) {
+        if (trigger->date.day == current_time->tm_mday) {
+            /* The schedule day is same. Check if time has already passed */
+            if (schedule_seconds > current_seconds) {
+                /* The schedule is today and is yet to go off */
+                return current_month;
+            }
+        }
+        if (trigger->date.day > current_time->tm_mday) {
+            /* The day is yet to come in this month */
+            return current_month;
+        }
+    }
+
+    /* Check if schedule is this year */
+    if ((repeat_months & (current_month_bit ^ 0xFFFF)) > current_month_bit) {
+        /* Next schedule month is yet to come in this year */
+        next_schedule_month = ffs(repeat_months & (0xFFFF << (current_month)));
+        return next_schedule_month;
+    }
+
+    /* Check if schedule is for this year and does not repeat */
+    if (!trigger->date.repeat_every_year) {
+        /* For yearly repeating schedules with year=0, treat as repeating */
+        if (trigger->date.year != 0 && trigger->date.year <= (current_time->tm_year + 1900)) {
+            ESP_LOGE(TAG, "Schedule does not repeat next year, but get_next_month has been called.");
+            return 0;
+        }
+    }
+
+    /* Schedule is not this year */
+    /* Find first schedule month of next year */
+    next_schedule_month = ffs(repeat_months);
+    /* +12 because the schedule is next year */
+    return (next_schedule_month + 12);
+}
+
+static uint16_t esp_schedule_get_next_year(esp_schedule_trigger_t *trigger, struct tm *current_time, struct tm *schedule_time)
+{
+    uint16_t current_year = current_time->tm_year + 1900;
+    uint16_t schedule_year = trigger->date.year;
+    if (schedule_year > current_year) {
+        return schedule_year;
+    }
+    /* If the schedule is set to repeat_every_year, we return the current year */
+    /* If the schedule has already passed in this year, we still return current year, as the additional months will be handled in get_next_month */
+    return current_year;
+}
+
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+/* Helper function to calculate solar time for a specific date */
+static time_t esp_schedule_calc_solar_time_for_date(const esp_schedule_trigger_t *trigger,
+        int year, int month, int day,
+        const char *schedule_name)
+{
+    time_t sunrise_utc, sunset_utc;
+
+    bool calc_ok = esp_daylight_calc_sunrise_sunset_utc(
+                       year, month, day,
+                       trigger->solar.latitude,
+                       trigger->solar.longitude,
+                       &sunrise_utc, &sunset_utc);
+
+    if (!calc_ok) {
+        ESP_LOGW(TAG, "Failed to calculate sunrise/sunset for date %04d-%02d-%02d for %s (likely polar night/day condition)",
+                 year, month, day, schedule_name);
+        return 0;
+    }
+
+    time_t solar_time = (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE) ? sunrise_utc : sunset_utc;
+    return esp_daylight_apply_offset(solar_time, trigger->solar.offset_minutes);
+}
+
+/* Helper function to handle logging and timer calculation for solar schedules */
+static int32_t esp_schedule_finalize_solar_time(time_t solar_time, time_t now,
+        const esp_schedule_trigger_t *trigger,
+        const char *schedule_name)
+{
+    char time_str[64];
+    struct tm schedule_time;
+
+    /* Convert solar time to local time for display and DST handling */
+    localtime_r(&solar_time, &schedule_time);
+
+    /* Print schedule time */
+    memset(time_str, 0, sizeof(time_str));
+    strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
+    ESP_LOGI(TAG, "Schedule %s (%s%+d min) will be active on: %s. DST: %s",
+             schedule_name,
+             (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE) ? "sunrise" : "sunset",
+             trigger->solar.offset_minutes,
+             time_str, schedule_time.tm_isdst ? "Yes" : "No");
+
+    /* Simple epoch-based timer calculation */
+    int32_t timer_seconds = (int32_t)difftime(solar_time, now);
+
+    /* With proactive logic, this should not happen, but log if it does */
+    if (timer_seconds < 0) {
+        ESP_LOGW(TAG, "Unexpected: Solar schedule time has passed (%" PRId32 " seconds ago). This should have been handled proactively.", -timer_seconds);
+        /* Return the negative value to help debug - caller will handle this as error */
+    }
+
+    return timer_seconds;
+}
+#endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
+
+static uint32_t esp_schedule_get_next_schedule_time_diff(const char *schedule_name, esp_schedule_trigger_t *trigger)
+{
+    struct tm current_time, schedule_time;
+    time_t now;
+    char time_str[64];
+    int32_t time_diff;
+
+    /* Get current time */
+    time(&now);
+    /* Handling ESP_SCHEDULE_TYPE_RELATIVE first since it doesn't require any
+     * computation based on days, hours, minutes, etc.
+     */
+    if (trigger->type == ESP_SCHEDULE_TYPE_RELATIVE) {
+        /* If next scheduled time is already set, just compute the difference
+         * between current time and next scheduled time and return that diff.
+         */
+        time_t target;
+        if (trigger->next_scheduled_time_utc > 0) {
+            target = (time_t)trigger->next_scheduled_time_utc;
+            time_diff = difftime(target, now);
+        } else {
+            target = now + (time_t)trigger->relative_seconds;
+            time_diff = trigger->relative_seconds;
+        }
+        localtime_r(&target, &schedule_time);
+        trigger->next_scheduled_time_utc = mktime(&schedule_time);
+        /* Print schedule time */
+        memset(time_str, 0, sizeof(time_str));
+        strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
+        ESP_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule_name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
+        return time_diff;
+    }
+
+    /* Handle solar-based schedules (sunrise/sunset) */
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    if (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE || trigger->type == ESP_SCHEDULE_TYPE_SUNSET) {
+        time_t solar_time = 0;
+
+        /* Start with current local time for day calculations */
+        localtime_r(&now, &current_time);
+
+        /* Determine schedule pattern using unified approach */
+        if (trigger->date.day != 0) {
+            /* Date-based solar schedule - check if today's solar time + offset has passed */
+            struct tm schedule_time = current_time;
+            schedule_time.tm_mday = trigger->date.day;
+
+            /* For same day, check if solar time + offset has passed before deciding year */
+            if (trigger->date.day == current_time.tm_mday) {
+                uint8_t current_month = current_time.tm_mon + 1;
+                uint16_t repeat_months = trigger->date.repeat_months;
+                uint16_t current_month_bit = 1 << (current_month - 1);
+
+                /* Check if this month is in the repeat pattern */
+                if (current_month_bit & repeat_months) {
+                    /* Calculate today's solar time + offset */
+                    time_t today_solar = esp_schedule_calc_solar_time_for_date(trigger,
+                                         current_time.tm_year + 1900,
+                                         current_time.tm_mon + 1,
+                                         current_time.tm_mday,
+                                         schedule_name);
+
+                    /* If today's solar time + offset hasn't passed, use today */
+                    if (today_solar > 0 && today_solar > now) {
+                        schedule_time.tm_mon = current_time.tm_mon;
+                        schedule_time.tm_year = current_time.tm_year;
+                    } else {
+                        /* Solar time has passed, use next occurrence */
+                        schedule_time.tm_mon = esp_schedule_get_next_month(trigger, &current_time, &schedule_time) - 1;
+                        schedule_time.tm_year = esp_schedule_get_next_year(trigger, &current_time, &schedule_time) - 1900;
+                    }
+                } else {
+                    /* Not this month, use normal logic */
+                    schedule_time.tm_mon = esp_schedule_get_next_month(trigger, &current_time, &schedule_time) - 1;
+                    schedule_time.tm_year = esp_schedule_get_next_year(trigger, &current_time, &schedule_time) - 1900;
+                }
+            } else {
+                /* Different day, use normal logic */
+                schedule_time.tm_mon = esp_schedule_get_next_month(trigger, &current_time, &schedule_time) - 1;
+                schedule_time.tm_year = esp_schedule_get_next_year(trigger, &current_time, &schedule_time) - 1900;
+            }
+
+            if (schedule_time.tm_mon < 0) {
+                ESP_LOGE(TAG, "Invalid month found for solar schedule: %s", schedule_name);
+                return 0;
+            }
+            if (schedule_time.tm_mon >= 12) {
+                schedule_time.tm_year += schedule_time.tm_mon / 12;
+                schedule_time.tm_mon = schedule_time.tm_mon % 12;
+            }
+            mktime(&schedule_time);
+
+            /* Calculate solar time for the determined date */
+            solar_time = esp_schedule_calc_solar_time_for_date(trigger,
+                         schedule_time.tm_year + 1900,
+                         schedule_time.tm_mon + 1,
+                         schedule_time.tm_mday,
+                         schedule_name);
+
+        } else if (trigger->day.repeat_days != 0) {
+            /* Day-of-week solar schedule - check if today's solar time + offset has passed */
+            struct tm schedule_time = current_time;
+
+            /* Check if today is one of the scheduled days */
+            int today = current_time.tm_wday == 0 ? 7 : current_time.tm_wday; /* Convert Sunday from 0 to 7 */
+            uint8_t today_bit = 1 << (today - 1); /* Monday=bit0, Tuesday=bit1, etc. */
+
+            if (trigger->day.repeat_days & today_bit) {
+                /* Today is a scheduled day, check if solar time + offset has passed */
+                time_t today_solar = esp_schedule_calc_solar_time_for_date(trigger,
+                                     current_time.tm_year + 1900,
+                                     current_time.tm_mon + 1,
+                                     current_time.tm_mday,
+                                     schedule_name);
+
+                /* If today's solar time + offset hasn't passed, use today */
+                if (today_solar > 0 && today_solar > now) {
+                    /* Use today */
+                    solar_time = today_solar;
+                } else {
+                    /* Solar time has passed, find next scheduled day */
+                    int no_of_days = esp_schedule_get_no_of_days(trigger, &current_time, &schedule_time);
+                    schedule_time.tm_mday += no_of_days;
+                    mktime(&schedule_time);
+
+                    solar_time = esp_schedule_calc_solar_time_for_date(trigger,
+                                 schedule_time.tm_year + 1900,
+                                 schedule_time.tm_mon + 1,
+                                 schedule_time.tm_mday,
+                                 schedule_name);
+                }
+            } else {
+                /* Today is not a scheduled day, use normal logic */
+                int no_of_days = esp_schedule_get_no_of_days(trigger, &current_time, &schedule_time);
+                schedule_time.tm_mday += no_of_days;
+                mktime(&schedule_time);
+
+                solar_time = esp_schedule_calc_solar_time_for_date(trigger,
+                             schedule_time.tm_year + 1900,
+                             schedule_time.tm_mon + 1,
+                             schedule_time.tm_mday,
+                             schedule_name);
+            }
+
+        } else {
+            /* Single-time solar schedule - use logic similar to regular schedules */
+            solar_time = esp_schedule_calc_solar_time_for_date(trigger,
+                         current_time.tm_year + 1900,
+                         current_time.tm_mon + 1,
+                         current_time.tm_mday,
+                         schedule_name);
+
+            /* If time has passed today, calculate for tomorrow (like regular schedules) */
+            if (solar_time > 0 && solar_time <= now) {
+                struct tm tomorrow_time;
+                localtime_r(&now, &tomorrow_time);  // Use fresh local time
+                tomorrow_time.tm_mday += 1;
+                mktime(&tomorrow_time);
+
+                solar_time = esp_schedule_calc_solar_time_for_date(trigger,
+                             tomorrow_time.tm_year + 1900,
+                             tomorrow_time.tm_mon + 1,
+                             tomorrow_time.tm_mday,
+                             schedule_name);
+
+                /* If tomorrow's time is still in the past (due to large negative offset), try day after tomorrow */
+                if (solar_time > 0 && solar_time <= now) {
+                    tomorrow_time.tm_mday += 1;
+                    mktime(&tomorrow_time);
+
+                    solar_time = esp_schedule_calc_solar_time_for_date(trigger,
+                                 tomorrow_time.tm_year + 1900,
+                                 tomorrow_time.tm_mon + 1,
+                                 tomorrow_time.tm_mday,
+                                 schedule_name);
+                }
+            }
+        }
+
+        /* Return error if solar calculation failed */
+        if (solar_time == 0) {
+            ESP_LOGW(TAG, "Solar schedule %s cannot be calculated (no sunrise/sunset at this location/date)", schedule_name);
+            return 0;
+        }
+
+        /* Calculate timer - should always be positive since we proactively handle past times */
+        time_diff = esp_schedule_finalize_solar_time(solar_time, now, trigger, schedule_name);
+        if (time_diff < 0) {
+            /* This should not happen with proactive logic, but handle gracefully */
+            ESP_LOGE(TAG, "Solar schedule time calculation error for %s (got %" PRId32 " seconds)", schedule_name, time_diff);
+            return 0;
+        }
+
+        /* Store the final scheduled time - use raw UTC solar time for ts field (phone apps need UTC) */
+        trigger->next_scheduled_time_utc = solar_time;
+
+        return time_diff;
+    }
+#endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
+
+    localtime_r(&now, &current_time);
+
+    /* Get schedule time */
+    localtime_r(&now, &schedule_time);
+    schedule_time.tm_sec = 0;
+    schedule_time.tm_min = trigger->minutes;
+    schedule_time.tm_hour = trigger->hours;
+    mktime(&schedule_time);
+
+    /* Adjust schedule day */
+    if (trigger->type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
+        int no_of_days = 0;
+        no_of_days = esp_schedule_get_no_of_days(trigger, &current_time, &schedule_time);
+        schedule_time.tm_sec += no_of_days * SECONDS_IN_DAY;
+    }
+    if (trigger->type == ESP_SCHEDULE_TYPE_DATE) {
+        schedule_time.tm_mday = trigger->date.day;
+        schedule_time.tm_mon = esp_schedule_get_next_month(trigger, &current_time, &schedule_time) - 1;
+        schedule_time.tm_year = esp_schedule_get_next_year(trigger, &current_time, &schedule_time) - 1900;
+        if (schedule_time.tm_mon < 0) {
+            ESP_LOGE(TAG, "Invalid month found: %d. Setting it to next month.", schedule_time.tm_mon);
+            schedule_time.tm_mon = current_time.tm_mon + 1;
+        }
+        if (schedule_time.tm_mon >= 12) {
+            schedule_time.tm_year += schedule_time.tm_mon / 12;
+            schedule_time.tm_mon = schedule_time.tm_mon % 12;
+        }
+    }
+    mktime(&schedule_time);
+
+    /* Adjust time according to DST */
+    time_t dst_adjust = 0;
+    if (!current_time.tm_isdst && schedule_time.tm_isdst) {
+        dst_adjust = -3600;
+    } else if (current_time.tm_isdst && !schedule_time.tm_isdst) {
+        dst_adjust = 3600;
+    }
+    ESP_LOGD(TAG, "DST adjust seconds: %lld", (long long) dst_adjust);
+    schedule_time.tm_sec += dst_adjust;
+    mktime(&schedule_time);
+
+    /* Print schedule time */
+    memset(time_str, 0, sizeof(time_str));
+    strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
+    ESP_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule_name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
+
+    /* Calculate difference */
+    time_diff = difftime((mktime(&schedule_time)), mktime(&current_time));
+
+    /* For one time schedules to check for expiry after a reboot. If NVS is enabled, this should be stored in NVS. */
+    trigger->next_scheduled_time_utc = mktime(&schedule_time);
+
+    return time_diff;
+}
+
+static bool esp_schedule_is_expired(esp_schedule_trigger_t *trigger)
+{
+    time_t current_timestamp = 0;
+    struct tm current_time = {0};
+    time(&current_timestamp);
+    localtime_r(&current_timestamp, &current_time);
+
+    if (trigger->type == ESP_SCHEDULE_TYPE_RELATIVE) {
+        if (trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= current_timestamp) {
+            /* Relative seconds based schedule has expired */
+            return true;
+        } else if (trigger->next_scheduled_time_utc == 0) {
+            /* Schedule has been disabled, so it is as good as expired. */
+            return true;
+        }
+    } else if (trigger->type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
+        if (trigger->day.repeat_days == ESP_SCHEDULE_DAY_ONCE) {
+            if (trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= current_timestamp) {
+                /* One time schedule has expired */
+                return true;
+            } else if (trigger->next_scheduled_time_utc == 0) {
+                /* Schedule has been disabled, so it is as good as expired. */
+                return true;
+            }
+        }
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    } else if (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE || trigger->type == ESP_SCHEDULE_TYPE_SUNSET) {
+        /* Check if this is a single-time solar schedule */
+        if (trigger->date.day == 0 && trigger->day.repeat_days == 0) {
+            if (trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= current_timestamp) {
+                /* One time solar schedule has expired */
+                return true;
+            } else if (trigger->next_scheduled_time_utc == 0) {
+                /* Schedule has been disabled, so it is as good as expired. */
+                return true;
+            }
+        }
+        /* Repeating solar schedules (day-of-week or date-based) never expire - they recalculate */
+#endif
+    } else if (trigger->type == ESP_SCHEDULE_TYPE_DATE) {
+        if (trigger->date.repeat_months == 0) {
+            if (trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= current_timestamp) {
+                /* One time schedule has expired */
+                return true;
+            } else {
+                return false;
+            }
+        }
+        if (trigger->date.repeat_every_year == true) {
+            return false;
+        }
+
+        struct tm schedule_time = {0};
+        localtime_r(&current_timestamp, &schedule_time);
+        schedule_time.tm_sec = 0;
+        schedule_time.tm_min = trigger->minutes;
+        schedule_time.tm_hour = trigger->hours;
+        schedule_time.tm_mday = trigger->date.day;
+        /* For expiry, just check the last month of the repeat_months. */
+        /* '-1' because struct tm has months starting from 0 and we have months starting from 1. */
+        schedule_time.tm_mon = fls(trigger->date.repeat_months) - 1;
+        /* '-1900' because struct tm has number of years after 1900 */
+        schedule_time.tm_year = trigger->date.year - 1900;
+        time_t schedule_timestamp = mktime(&schedule_time);
+
+        if (schedule_timestamp < current_timestamp) {
+            return true;
+        }
+    } else {
+        /* Invalid type. Mark as expired */
+        return true;
+    }
+    return false;
+}
+
+static void esp_schedule_stop_timer(esp_schedule_t *schedule)
+{
+    xTimerStop(schedule->timer, portMAX_DELAY);
+}
+
+static void esp_schedule_start_timer(esp_schedule_t *schedule)
+{
+    time_t current_time = 0;
+    time(&current_time);
+    if (current_time < SECONDS_TILL_2020) {
+        ESP_LOGE(TAG, "Time is not updated");
+        return;
+    }
+
+    schedule->next_scheduled_time_diff = esp_schedule_get_next_schedule_time_diff(schedule->name, &schedule->trigger);
+
+    /* Check if schedule calculation failed (returns 0) */
+    if (schedule->next_scheduled_time_diff == 0) {
+        ESP_LOGW(TAG, "Schedule %s calculation failed or returned invalid time. Skipping timer creation.", schedule->name);
+        /* Reset timestamp to indicate schedule is not active */
+        schedule->trigger.next_scheduled_time_utc = 0;
+        return;
+    }
+
+    ESP_LOGI(TAG, "Starting a timer for %"PRIu32" seconds for schedule %s", schedule->next_scheduled_time_diff, schedule->name);
+
+    if (schedule->timestamp_cb) {
+        schedule->timestamp_cb((esp_schedule_handle_t)schedule, schedule->trigger.next_scheduled_time_utc, schedule->priv_data);
+    }
+
+    xTimerStop(schedule->timer, portMAX_DELAY);
+    xTimerChangePeriod(schedule->timer, (schedule->next_scheduled_time_diff * 1000) / portTICK_PERIOD_MS, portMAX_DELAY);
+}
+
+static void esp_schedule_common_timer_cb(TimerHandle_t timer)
+{
+    void *priv_data = pvTimerGetTimerID(timer);
+    if (priv_data == NULL) {
+        return;
+    }
+    esp_schedule_t *schedule = (esp_schedule_t *)priv_data;
+    time_t now;
+    time(&now);
+    struct tm validity_time;
+    char time_str[64] = {0};
+    if (schedule->validity.start_time != 0) {
+        if (now < schedule->validity.start_time) {
+            memset(time_str, 0, sizeof(time_str));
+            localtime_r(&schedule->validity.start_time, &validity_time);
+            strftime(time_str, sizeof(time_str), "%c %z[%Z]", &validity_time);
+            ESP_LOGW(TAG, "Schedule %s skipped. It will be active only after: %s. DST: %s.", schedule->name, time_str, validity_time.tm_isdst ? "Yes" : "No");
+            /* TODO: Start the timer such that the next time it triggers, it will be within the valid window.
+             * Currently, it will just keep triggering and then get skipped if not in valid range.
+             */
+            goto restart_schedule;
+        }
+    }
+    if (schedule->validity.end_time != 0) {
+        if (now > schedule->validity.end_time) {
+            localtime_r(&schedule->validity.end_time, &validity_time);
+            strftime(time_str, sizeof(time_str), "%c %z[%Z]", &validity_time);
+            ESP_LOGW(TAG, "Schedule %s skipped. It can't be active after: %s. DST: %s.", schedule->name, time_str, validity_time.tm_isdst ? "Yes" : "No");
+            /* Return from here will ensure that the timer does not start again for this schedule */
+            return;
+        }
+    }
+    ESP_LOGI(TAG, "Schedule %s triggered", schedule->name);
+    if (schedule->trigger_cb) {
+        schedule->trigger_cb((esp_schedule_handle_t)schedule, schedule->priv_data);
+    }
+
+restart_schedule:
+
+    if (esp_schedule_is_expired(&schedule->trigger)) {
+        /* Not deleting the schedule here. Just not starting it again. */
+        return;
+    }
+    esp_schedule_start_timer(schedule);
+}
+
+static void esp_schedule_delete_timer(esp_schedule_t *schedule)
+{
+    xTimerDelete(schedule->timer, portMAX_DELAY);
+}
+
+static void esp_schedule_create_timer(esp_schedule_t *schedule)
+{
+    if (esp_schedule_nvs_is_enabled()) {
+        /* This is just used for calculating next_scheduled_time_utc for ESP_SCHEDULE_DAY_ONCE (in case of ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) or for ESP_SCHEDULE_MONTH_ONCE (in case of ESP_SCHEDULE_TYPE_DATE), and only used when NVS is enabled. And if NVS is enabled, time will already be synced and the time will be correctly calculated. */
+        schedule->next_scheduled_time_diff = esp_schedule_get_next_schedule_time_diff(schedule->name, &schedule->trigger);
+    }
+
+    /* Temporarily setting the timer for 1 (anything greater than 0) tick. This will get changed when xTimerChangePeriod() is called. */
+    schedule->timer = xTimerCreate("schedule", 1, pdFALSE, (void *)schedule, esp_schedule_common_timer_cb);
+}
+
+esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config)
+{
+    if (schedule_config == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    esp_schedule_t *schedule = (esp_schedule_t *)handle;
+
+    strlcpy(schedule_config->name, schedule->name, sizeof(schedule_config->name));
+    schedule_config->trigger.type = schedule->trigger.type;
+    schedule_config->trigger.hours = schedule->trigger.hours;
+    schedule_config->trigger.minutes = schedule->trigger.minutes;
+    if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
+        schedule_config->trigger.day.repeat_days = schedule->trigger.day.repeat_days;
+    } else if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DATE) {
+        schedule_config->trigger.date.day = schedule->trigger.date.day;
+        schedule_config->trigger.date.repeat_months = schedule->trigger.date.repeat_months;
+        schedule_config->trigger.date.year = schedule->trigger.date.year;
+        schedule_config->trigger.date.repeat_every_year = schedule->trigger.date.repeat_every_year;
+    }
+
+    schedule_config->trigger_cb = schedule->trigger_cb;
+    schedule_config->timestamp_cb = schedule->timestamp_cb;
+    schedule_config->priv_data = schedule->priv_data;
+    schedule_config->validity = schedule->validity;
+    return ESP_OK;
+}
+
+esp_err_t esp_schedule_enable(esp_schedule_handle_t handle)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    esp_schedule_t *schedule = (esp_schedule_t *)handle;
+    esp_schedule_start_timer(schedule);
+    return ESP_OK;
+}
+
+esp_err_t esp_schedule_disable(esp_schedule_handle_t handle)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    esp_schedule_t *schedule = (esp_schedule_t *)handle;
+    esp_schedule_stop_timer(schedule);
+    /* Disabling a schedule should also reset the next_scheduled_time.
+     * It would be re-computed after enabling.
+     */
+    schedule->trigger.next_scheduled_time_utc = 0;
+    return ESP_OK;
+}
+
+static esp_err_t esp_schedule_set(esp_schedule_t *schedule, esp_schedule_config_t *schedule_config)
+{
+    /* Setting everything apart from name. */
+    schedule->trigger.type = schedule_config->trigger.type;
+    if (schedule->trigger.type == ESP_SCHEDULE_TYPE_RELATIVE) {
+        schedule->trigger.relative_seconds = schedule_config->trigger.relative_seconds;
+        schedule->trigger.next_scheduled_time_utc = schedule_config->trigger.next_scheduled_time_utc;
+    } else {
+        schedule->trigger.hours = schedule_config->trigger.hours;
+        schedule->trigger.minutes = schedule_config->trigger.minutes;
+
+        if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
+            schedule->trigger.day.repeat_days = schedule_config->trigger.day.repeat_days;
+        } else if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DATE) {
+            schedule->trigger.date.day = schedule_config->trigger.date.day;
+            schedule->trigger.date.repeat_months = schedule_config->trigger.date.repeat_months;
+            schedule->trigger.date.year = schedule_config->trigger.date.year;
+            schedule->trigger.date.repeat_every_year = schedule_config->trigger.date.repeat_every_year;
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+        } else if (schedule->trigger.type == ESP_SCHEDULE_TYPE_SUNRISE || schedule->trigger.type == ESP_SCHEDULE_TYPE_SUNSET) {
+            schedule->trigger.solar.latitude = schedule_config->trigger.solar.latitude;
+            schedule->trigger.solar.longitude = schedule_config->trigger.solar.longitude;
+            schedule->trigger.solar.offset_minutes = schedule_config->trigger.solar.offset_minutes;
+            /* Copy day and date fields for unified solar schedule approach */
+            schedule->trigger.day.repeat_days = schedule_config->trigger.day.repeat_days;
+            schedule->trigger.date.day = schedule_config->trigger.date.day;
+            schedule->trigger.date.repeat_months = schedule_config->trigger.date.repeat_months;
+            schedule->trigger.date.year = schedule_config->trigger.date.year;
+            schedule->trigger.date.repeat_every_year = schedule_config->trigger.date.repeat_every_year;
+#endif
+        }
+    }
+
+    schedule->trigger_cb = schedule_config->trigger_cb;
+    schedule->timestamp_cb = schedule_config->timestamp_cb;
+    schedule->priv_data = schedule_config->priv_data;
+    schedule->validity = schedule_config->validity;
+    esp_schedule_nvs_add(schedule);
+    return ESP_OK;
+}
+
+esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config)
+{
+    if (handle == NULL || schedule_config == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    esp_schedule_t *schedule = (esp_schedule_t *)handle;
+    if (strncmp(schedule->name, schedule_config->name, sizeof(schedule->name)) != 0) {
+        ESP_LOGE(TAG, "Schedule name mismatch. Expected: %s, Passed: %s", schedule->name, schedule_config->name);
+        return ESP_FAIL;
+    }
+
+    /* Editing a schedule with relative time should also reset it. */
+    if (schedule->trigger.type == ESP_SCHEDULE_TYPE_RELATIVE) {
+        schedule->trigger.next_scheduled_time_utc = 0;
+    }
+    esp_schedule_set(schedule, schedule_config);
+    ESP_LOGD(TAG, "Schedule %s edited", schedule->name);
+    return ESP_OK;
+}
+
+esp_err_t esp_schedule_delete(esp_schedule_handle_t handle)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    esp_schedule_t *schedule = (esp_schedule_t *)handle;
+    ESP_LOGI(TAG, "Deleting schedule %s", schedule->name);
+    if (schedule->timer) {
+        esp_schedule_stop_timer(schedule);
+        esp_schedule_delete_timer(schedule);
+    }
+    esp_schedule_nvs_remove(schedule);
+    free(schedule);
+    return ESP_OK;
+}
+
+esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config)
+{
+    if (schedule_config == NULL) {
+        return NULL;
+    }
+    if (strlen(schedule_config->name) <= 0) {
+        ESP_LOGE(TAG, "Set schedule failed. Please enter a unique valid name for the schedule.");
+        return NULL;
+    }
+
+    if (schedule_config->trigger.type == ESP_SCHEDULE_TYPE_INVALID) {
+        ESP_LOGE(TAG, "Schedule type is invalid.");
+        return NULL;
+    }
+
+    esp_schedule_t *schedule = (esp_schedule_t *)MEM_CALLOC_EXTRAM(1, sizeof(esp_schedule_t));
+    if (schedule == NULL) {
+        ESP_LOGE(TAG, "Could not allocate handle");
+        return NULL;
+    }
+    strlcpy(schedule->name, schedule_config->name, sizeof(schedule->name));
+
+    esp_schedule_set(schedule, schedule_config);
+
+    esp_schedule_create_timer(schedule);
+    ESP_LOGD(TAG, "Schedule %s created", schedule->name);
+    return (esp_schedule_handle_t)schedule;
+}
+
+esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, uint8_t *schedule_count)
+{
+    if (!esp_sntp_enabled()) {
+        ESP_LOGI(TAG, "Initializing SNTP");
+        esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
+        esp_sntp_setservername(0, "pool.ntp.org");
+        esp_sntp_init();
+    }
+
+    if (!enable_nvs) {
+        return NULL;
+    }
+
+    /* Wait for time to be updated here */
+
+    /* Below this is initialising schedules from NVS */
+    esp_schedule_nvs_init(nvs_partition);
+
+    /* Get handle list from NVS */
+    esp_schedule_handle_t *handle_list = NULL;
+    *schedule_count = 0;
+    handle_list = esp_schedule_nvs_get_all(schedule_count);
+    if (handle_list == NULL) {
+        ESP_LOGI(TAG, "No schedules found in NVS");
+        return NULL;
+    }
+    ESP_LOGI(TAG, "Schedules found in NVS: %"PRIu8, *schedule_count);
+    /* Start/Delete the schedules */
+    esp_schedule_t *schedule = NULL;
+    for (size_t handle_count = 0; handle_count < *schedule_count; handle_count++) {
+        schedule = (esp_schedule_t *)handle_list[handle_count];
+        schedule->trigger_cb = NULL;
+        schedule->timer = NULL;
+        /* Check for ONCE and expired schedules and delete them. */
+        if (esp_schedule_is_expired(&schedule->trigger)) {
+            /* This schedule has already expired. */
+            ESP_LOGI(TAG, "Schedule %s does not repeat and has already expired. Deleting it.", schedule->name);
+            esp_schedule_delete((esp_schedule_handle_t)schedule);
+            /* Removing the schedule from the list */
+            handle_list[handle_count] = handle_list[*schedule_count - 1];
+            (*schedule_count)--;
+            handle_count--;
+            continue;
+        }
+        esp_schedule_create_timer(schedule);
+        esp_schedule_start_timer(schedule);
+    }
+    init_done = true;
+    return handle_list;
+}

--- a/esp_schedule/src/esp_schedule_internal.h
+++ b/esp_schedule/src/esp_schedule_internal.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/timers.h"
+#include "esp_schedule.h"
+#include "esp_heap_caps.h"
+
+/** Memory allocation macros for external RAM */
+#if ((CONFIG_SPIRAM || CONFIG_SPIRAM_SUPPORT) && \
+        (CONFIG_SPIRAM_USE_CAPS_ALLOC || CONFIG_SPIRAM_USE_MALLOC))
+#define MEM_ALLOC_EXTRAM(size)         heap_caps_malloc_prefer(size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
+#define MEM_CALLOC_EXTRAM(num, size)   heap_caps_calloc_prefer(num, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
+#define MEM_REALLOC_EXTRAM(ptr, size)  heap_caps_realloc_prefer(ptr, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
+#else
+#define MEM_ALLOC_EXTRAM(size)         malloc(size)
+#define MEM_CALLOC_EXTRAM(num, size)   calloc(num, size)
+#define MEM_REALLOC_EXTRAM(ptr, size)  realloc(ptr, size)
+#endif
+
+typedef struct esp_schedule {
+    char name[MAX_SCHEDULE_NAME_LEN + 1];
+    esp_schedule_trigger_t trigger;
+    uint32_t next_scheduled_time_diff;
+    TimerHandle_t timer;
+    esp_schedule_trigger_cb_t trigger_cb;
+    esp_schedule_timestamp_cb_t timestamp_cb;
+    void *priv_data;
+    esp_schedule_validity_t validity;
+} esp_schedule_t;
+
+esp_err_t esp_schedule_nvs_add(esp_schedule_t *schedule);
+esp_err_t esp_schedule_nvs_remove(esp_schedule_t *schedule);
+esp_schedule_handle_t *esp_schedule_nvs_get_all(uint8_t *schedule_count);
+bool esp_schedule_nvs_is_enabled(void);
+esp_err_t esp_schedule_nvs_init(char *nvs_partition);

--- a/esp_schedule/src/esp_schedule_nvs.c
+++ b/esp_schedule/src/esp_schedule_nvs.c
@@ -1,0 +1,279 @@
+// Copyright 2025 Espressif Systems (Shanghai) CO LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+#include <time.h>
+#include "esp_log.h"
+#include "nvs.h"
+#include "esp_schedule_internal.h"
+
+static const char *TAG = "esp_schedule_nvs";
+
+#define ESP_SCHEDULE_NVS_NAMESPACE "schd"
+#define ESP_SCHEDULE_COUNT_KEY "schd_count"
+
+static char *esp_schedule_nvs_partition = NULL;
+static bool nvs_enabled = false;
+
+esp_err_t esp_schedule_nvs_add(esp_schedule_t *schedule)
+{
+    if (!nvs_enabled) {
+        ESP_LOGD(TAG, "NVS not enabled. Not adding to NVS.");
+        return ESP_ERR_INVALID_STATE;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+        return err;
+    }
+
+    /* Check if this is new schedule or editing an existing schedule */
+    size_t buf_size;
+    bool editing_schedule = true;
+    err = nvs_get_blob(nvs_handle, schedule->name, NULL, &buf_size);
+    if (err != ESP_OK) {
+        if (err == ESP_ERR_NVS_NOT_FOUND) {
+            editing_schedule = false;
+        } else {
+            ESP_LOGE(TAG, "NVS get failed with error %d", err);
+            nvs_close(nvs_handle);
+            return err;
+        }
+    } else {
+        ESP_LOGI(TAG, "Updating the existing schedule %s", schedule->name);
+    }
+
+    err = nvs_set_blob(nvs_handle, schedule->name, schedule, sizeof(esp_schedule_t));
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS set failed with error %d", err);
+        nvs_close(nvs_handle);
+        return err;
+    }
+    if (editing_schedule == false) {
+        uint8_t schedule_count;
+        err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
+        if (err != ESP_OK) {
+            if (err == ESP_ERR_NVS_NOT_FOUND) {
+                schedule_count = 0;
+            } else {
+                ESP_LOGE(TAG, "NVS get failed with error %d", err);
+                nvs_close(nvs_handle);
+                return err;
+            }
+        }
+        schedule_count++;
+        err = nvs_set_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, schedule_count);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "NVS set failed for schedule count with error %d", err);
+            nvs_close(nvs_handle);
+            return err;
+        }
+    }
+    nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+    ESP_LOGI(TAG, "Schedule %s added in NVS", schedule->name);
+    return ESP_OK;
+}
+
+esp_err_t esp_schedule_nvs_remove_all(void)
+{
+    if (!nvs_enabled) {
+        ESP_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
+        return ESP_ERR_INVALID_STATE;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+        return err;
+    }
+    err = nvs_erase_all(nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS erase all keys failed with error %d", err);
+        nvs_close(nvs_handle);
+        return err;
+    }
+    nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+    ESP_LOGI(TAG, "All schedules removed from NVS");
+    return ESP_OK;
+}
+
+esp_err_t esp_schedule_nvs_remove(esp_schedule_t *schedule)
+{
+    if (!nvs_enabled) {
+        ESP_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
+        return ESP_ERR_INVALID_STATE;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+        return err;
+    }
+    err = nvs_erase_key(nvs_handle, schedule->name);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS erase key failed with error %d", err);
+        nvs_close(nvs_handle);
+        return err;
+    }
+    uint8_t schedule_count;
+    err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS get failed for schedule count with error %d", err);
+        nvs_close(nvs_handle);
+        return err;
+    }
+    schedule_count--;
+    err = nvs_set_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, schedule_count);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS set failed for schedule count with error %d", err);
+        nvs_close(nvs_handle);
+        return err;
+    }
+    nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+    ESP_LOGI(TAG, "Schedule %s removed from NVS", schedule->name);
+    return ESP_OK;
+}
+
+static uint8_t esp_schedule_nvs_get_count(void)
+{
+    if (!nvs_enabled) {
+        ESP_LOGD(TAG, "NVS not enabled. Not getting count from NVS.");
+        return 0;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READONLY, &nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+        return 0;
+    }
+    uint8_t schedule_count;
+    err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS get failed for schedule count with error %d", err);
+        nvs_close(nvs_handle);
+        return 0;
+    }
+    nvs_close(nvs_handle);
+    ESP_LOGI(TAG, "Schedules in NVS: %d", schedule_count);
+    return schedule_count;
+}
+
+static esp_schedule_handle_t esp_schedule_nvs_get(char *nvs_key)
+{
+    if (!nvs_enabled) {
+        ESP_LOGD(TAG, "NVS not enabled. Not getting from NVS.");
+        return NULL;
+    }
+    size_t buf_size;
+    nvs_handle_t nvs_handle;
+    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READONLY, &nvs_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+        return NULL;
+    }
+    err = nvs_get_blob(nvs_handle, nvs_key, NULL, &buf_size);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS get failed with error %d", err);
+        nvs_close(nvs_handle);
+        return NULL;
+    }
+    esp_schedule_t *schedule = (esp_schedule_t *)malloc(buf_size);
+    if (schedule == NULL) {
+        ESP_LOGE(TAG, "Could not allocate handle");
+        nvs_close(nvs_handle);
+        return NULL;
+    }
+    err = nvs_get_blob(nvs_handle, nvs_key, schedule, &buf_size);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS get failed with error %d", err);
+        nvs_close(nvs_handle);
+        free(schedule);
+        return NULL;
+    }
+    nvs_close(nvs_handle);
+    ESP_LOGI(TAG, "Schedule %s found in NVS", schedule->name);
+    return (esp_schedule_handle_t) schedule;
+}
+
+esp_schedule_handle_t *esp_schedule_nvs_get_all(uint8_t *schedule_count)
+{
+    if (!nvs_enabled) {
+        ESP_LOGD(TAG, "NVS not enabled. Not Initialising NVS.");
+        return NULL;
+    }
+
+    *schedule_count = esp_schedule_nvs_get_count();
+    if (*schedule_count == 0) {
+        ESP_LOGI(TAG, "No Entries found in NVS");
+        return NULL;
+    }
+    esp_schedule_handle_t *handle_list = (esp_schedule_handle_t *)malloc(sizeof(esp_schedule_handle_t) * (*schedule_count));
+    if (handle_list == NULL) {
+        ESP_LOGE(TAG, "Could not allocate schedule list");
+        *schedule_count = 0;
+        return NULL;
+    }
+    int handle_count = 0;
+
+    nvs_entry_info_t nvs_entry;
+    nvs_iterator_t nvs_iterator = NULL;
+    esp_err_t err = nvs_entry_find(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_TYPE_BLOB, &nvs_iterator);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "No entry found in NVS");
+        free(handle_list);
+        return NULL;
+    }
+    while (err == ESP_OK) {
+        nvs_entry_info(nvs_iterator, &nvs_entry);
+        ESP_LOGI(TAG, "Found schedule in NVS with key: %s", nvs_entry.key);
+        handle_list[handle_count] = esp_schedule_nvs_get(nvs_entry.key);
+        if (handle_list[handle_count] != NULL) {
+            /* Increase count only if nvs_get was successful */
+            handle_count++;
+        }
+        err = nvs_entry_next(&nvs_iterator);
+    }
+    nvs_release_iterator(nvs_iterator);
+    *schedule_count = handle_count;
+    ESP_LOGI(TAG, "Found %d schedules in NVS", *schedule_count);
+    return handle_list;
+}
+
+bool esp_schedule_nvs_is_enabled(void)
+{
+    return nvs_enabled;
+}
+
+esp_err_t esp_schedule_nvs_init(char *nvs_partition)
+{
+    if (nvs_enabled) {
+        ESP_LOGI(TAG, "NVS already enabled");
+        return ESP_OK;
+    }
+    if (nvs_partition) {
+        esp_schedule_nvs_partition = strndup(nvs_partition, strlen(nvs_partition));
+    } else {
+        esp_schedule_nvs_partition = strndup("nvs", strlen("nvs"));
+    }
+    if (esp_schedule_nvs_partition == NULL) {
+        ESP_LOGE(TAG, "Could not allocate nvs_partition");
+        return ESP_ERR_NO_MEM;
+    }
+    nvs_enabled = true;
+    return ESP_OK;
+}


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [?] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8) (link is broken)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Migration of esp_schedule to here to have a common version usable by both ESP RainMaker and ESP RMNG.
