### PR TITLE
ci: filter out clang-tidy warnings about C11 secure functions

### DIFF
--- a/.github/filter_sarif.py
+++ b/.github/filter_sarif.py
@@ -3,35 +3,7 @@
 import argparse
 import copy
 import json
-import typing
-
-
-def process(in_file: typing.TextIO, out_file: typing.TextIO, include_prefix_list: typing.List[str]) -> None:
-    in_json = json.load(in_file)
-    if len(in_json['runs']) != 1:
-        raise NotImplementedError('Only 1 run is supported')
-    in_results = in_json['runs'][0]['results']
-    out_results = []
-    for result in in_results:
-        locations = result['locations']
-        if len(locations) != 1:
-            raise NotImplementedError('Only 1 location is supported')
-        artifact_location = locations[0]['physicalLocation']['artifactLocation']
-        uri = artifact_location['uri']
-        new_uri = None
-        for include_prefix in include_prefix_list:
-            if uri.startswith(include_prefix):
-                new_uri = uri.replace(include_prefix, '')
-                break
-        if not new_uri:
-            continue
-        new_result = copy.deepcopy(result)
-        new_result['locations'][0]['physicalLocation']['artifactLocation']['uri'] = new_uri
-        out_results.append(new_result)
-
-    out_json = copy.deepcopy(in_json)
-    out_json['runs'][0]['results'] = out_results
-    json.dump(out_json, out_file, indent=True)
+import typing as t
 
 
 def main():
@@ -39,9 +11,86 @@ def main():
     parser.add_argument('-o', '--output', type=argparse.FileType('w'), help='Output filtered SARIF file')
     parser.add_argument('--include-prefix', required=True, action='append',
                         help='File prefix for source code to include in analysis')
+    parser.add_argument('--exclude-text-contains', action='append', default=[],
+                        help='Exclude results whose message.text contains this substring (may be repeated)')
     parser.add_argument('input_file', type=argparse.FileType('r'), help='Input SARIF file')
     args = parser.parse_args()
-    process(args.input_file, args.output, args.include_prefix)
+    process(args.input_file, args.output, args.include_prefix, args.exclude_text_contains)
+
+
+def process(in_file: t.TextIO, out_file: t.TextIO, include_prefix_list: t.List[str], exclude_text_contains_list: t.List[str]) -> None:
+    in_json = json.load(in_file)
+    if len(in_json['runs']) != 1:
+        raise NotImplementedError('Only 1 run is supported')
+    in_results = in_json['runs'][0]['results']
+    out_results = []
+    for result in in_results:
+        transformed = transform_result(result, include_prefix_list, exclude_text_contains_list)
+        if transformed is not None:
+            out_results.append(transformed)
+
+    out_json = copy.deepcopy(in_json)
+    out_json['runs'][0]['results'] = out_results
+    json.dump(out_json, out_file, indent=True)
+
+
+def normalize_uri_optional(uri: t.Optional[str], include_prefix_list: t.List[str], strict: bool) -> t.Optional[str]:
+    if uri is None:
+        return None
+    for include_prefix in include_prefix_list:
+        if uri.startswith(include_prefix):
+            return uri.replace(include_prefix, '')
+    return None if strict else uri
+
+
+def message_contains_any(text: str, substrings: t.List[str]) -> bool:
+    return any(substr in text for substr in substrings)
+
+
+def dedupe_related_locations(related_locations: t.Any, include_prefix_list: t.List[str]) -> t.List[t.Dict[str, t.Any]]:
+    if not isinstance(related_locations, list) or not related_locations:
+        return []
+    seen_keys: t.Set[t.Tuple[t.Any, ...]] = set()
+    deduped: t.List[t.Dict[str, t.Any]] = []
+    for rel in related_locations:
+        if not isinstance(rel, dict):
+            continue
+        rel_msg_text = rel['message']['text']
+        rel_uri = rel['physicalLocation']['artifactLocation']['uri']
+        rel_uri_norm = normalize_uri_optional(rel_uri, include_prefix_list, strict=False)
+        rel['physicalLocation']['artifactLocation']['uri'] = rel_uri_norm
+        key = (rel_msg_text,
+               rel_uri_norm,
+               rel['physicalLocation']['region']['startLine'],
+               rel['physicalLocation']['region']['startColumn'])
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        deduped.append(rel)
+    return deduped
+
+
+def transform_result(result: t.Dict[str, t.Any], include_prefix_list: t.List[str], exclude_text_contains_list: t.List[str]) -> t.Optional[t.Dict[str, t.Any]]:
+    locations = result['locations']
+    if len(locations) != 1:
+        raise NotImplementedError('Only 1 location is supported')
+    artifact_location = locations[0]['physicalLocation']['artifactLocation']
+    uri = artifact_location['uri']
+    normalized_uri = normalize_uri_optional(uri, include_prefix_list, strict=True)
+    if not normalized_uri:
+        return None
+    message_text = result['message']['text']
+    if message_contains_any(message_text, exclude_text_contains_list):
+        return None
+    new_result = copy.deepcopy(result)
+    new_result['locations'][0]['physicalLocation']['artifactLocation']['uri'] = normalized_uri
+    deduped_related = dedupe_related_locations(new_result.get('relatedLocations'), include_prefix_list)
+    if deduped_related:
+        new_result['relatedLocations'] = deduped_related
+    elif 'relatedLocations' in new_result:
+        # Ensure we have a list per schema even if empty
+        new_result['relatedLocations'] = []
+    return new_result
 
 
 if __name__ == '__main__':

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Run clang-tidy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: espressif/idf:latest
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
           ${IDF_PATH}/tools/idf_tools.py --non-interactive install esp-clang
       - name: Install clang-tidy-sarif
         run: |
-          curl -sSL https://github.com/psastras/sarif-rs/releases/download/clang-tidy-sarif-v0.3.3/clang-tidy-sarif-x86_64-unknown-linux-gnu -o clang-tidy-sarif
+          curl -sSL https://github.com/psastras/sarif-rs/releases/download/clang-tidy-sarif-v0.8.0/clang-tidy-sarif-x86_64-unknown-linux-gnu -o clang-tidy-sarif
           chmod +x clang-tidy-sarif
       - name: Install pyclang
         shell: bash
@@ -42,8 +42,18 @@ jobs:
       - name: Convert clang-tidy results into SARIF output
         run: |
           export PATH=$PWD:$PATH
-          ./clang-tidy-sarif -o results.sarif.raw warnings.txt
-          python3 $GITHUB_WORKSPACE/.github/filter_sarif.py -o results.sarif --include-prefix ${GITHUB_WORKSPACE}/ results.sarif.raw
+          ./clang-tidy-sarif -o results.sarif.raw -i warnings.txt
+          # Remove warnings which recommend using functions not supported in newlib.
+          python3 $GITHUB_WORKSPACE/.github/filter_sarif.py -o results.sarif \
+            --include-prefix ${GITHUB_WORKSPACE}/ \
+            --exclude-text-contains memset_s \
+            --exclude-text-contains memmove_s \
+            --exclude-text-contains memcpy_s \
+            --exclude-text-contains fprintf_s \
+            --exclude-text-contains snprintf_s \
+            --exclude-text-contains strncpy_s \
+            --exclude-text-contains sscanf_s \
+            results.sarif.raw
       - uses: actions/upload-artifact@v4
         with:
           path: |


### PR DESCRIPTION
clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling lint warns about usages of functions such as memset, memcpy, memmove, recommending replacing them with safer equivalents: memset_s, memcpy_s, memmove_s. Newlib doesn't implement memset_s, memcpy_s, memmove_s.

This change filters out these warnings without disabling the DeprecatedOrUnsafeBufferHandling lint, as it is still useful for warning about other string functions, such as strcpy.

Also bumps the versions of clang-tidy-sarif and of the runner VM, and updates filter_sarif.py to be compatible with the new version of clang-tidy-sarif.