### PR TITLE
fix(esp_lienoise): Update esp_linenoise.c to fix clang-tidy findings

### DIFF
--- a/esp_linenoise/src/esp_linenoise.c
+++ b/esp_linenoise/src/esp_linenoise.c
@@ -1264,7 +1264,6 @@ esp_err_t esp_linenoise_get_line(esp_linenoise_handle_t handle, char *cmd_line_b
     esp_err_t ret_val = ESP_OK;
     if (count > 0) {
         esp_linenoise_sanitize(cmd_line_buffer);
-        count = strlen(cmd_line_buffer);
     } else if (count == 0 && config->allow_empty_line) {
         /* will return an empty (0-length) string */
     } else {
@@ -1395,6 +1394,8 @@ esp_err_t esp_linenoise_history_load(esp_linenoise_handle_t handle, const char *
         }
         const esp_err_t ret_val = esp_linenoise_history_add(handle, buf);
         if (ret_val != ESP_OK) {
+            free(buf);
+            fclose(fp);
             return ret_val;
         }
     }


### PR DESCRIPTION
- remove the update of `count` after the command line is sanitized in `esp_linenoise_get_line` since the variable is not used after the command line is sanitized.
- free the `buf` pointer and close the `fp` file before the early return in `esp_linenoise_history_load`

# Checklist
- [ ] CI passing

# Change description
Update `esp_linenoise_get_line` and `esp_linenoise_history_load` to fix the clang-tidy warnings listed in the [artifact](https://github.com/espressif/idf-extra-components/actions/runs/18552711513/artifacts/4285147535)
