### PR TITLE
Fix prompt length issue (IEC-405)

### DIFF
--- a/esp_linenoise/src/esp_linenoise.c
+++ b/esp_linenoise/src/esp_linenoise.c
@@ -974,7 +974,7 @@ static int esp_linenoise_dumb(esp_linenoise_instance_t *instance, char *buffer, 
 {
     esp_linenoise_config_t *config = &instance->config;
 
-    config->write_bytes_cb(instance->config.out_fd, config->prompt, sizeof(config->prompt));
+    config->write_bytes_cb(instance->config.out_fd, config->prompt, strlen(config->prompt));
 
     size_t count = 0;
     const int in_fd = instance->config.in_fd;


### PR DESCRIPTION


# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
When writing the prompt, the length was incorrectly always the size of a char* pointer. The change uses strlen to properly write the correct size of the provided prompt string.
