### PR TITLE
change(esp_gcov): adapt new apptrace api changes

### DIFF
--- a/esp_gcov/CMakeLists.txt
+++ b/esp_gcov/CMakeLists.txt
@@ -59,7 +59,7 @@ if(CONFIG_ESP_GCOV_ENABLE)
 
     # Register component with app_trace dependency
     idf_component_register(SRCS "gcov_rtio.c"
-                          REQUIRES "app_trace"
+                          REQUIRES "esp_trace"
                           INCLUDE_DIRS ".")
 
     # Configure gcov-specific flags
@@ -74,6 +74,6 @@ if(CONFIG_ESP_GCOV_ENABLE)
 
 else()
     # Register empty component when GCOV is disabled
-    idf_component_register(REQUIRES "app_trace")
+    idf_component_register(REQUIRES "esp_trace")
     message(STATUS "GCOV: Component registered but GCOV support is disabled")
 endif()

--- a/esp_gcov/Kconfig
+++ b/esp_gcov/Kconfig
@@ -2,10 +2,10 @@ menu "GNU Code Coverage"
 
     config ESP_GCOV_ENABLE
         bool "GCOV to Host Enable"
-        depends on APPTRACE_ENABLE && !APPTRACE_SV_ENABLE
+        depends on ESP_TRACE_TRANSPORT_APPTRACE && ESP_TRACE_LIB_NONE
         select ESP_DEBUG_STUBS_ENABLE
         select ESP_IPC_ENABLE
-        default y
+        default n
         help
             Enables support for GCOV data transfer to host.
 

--- a/esp_gcov/gcov_rtio.c
+++ b/esp_gcov/gcov_rtio.c
@@ -39,7 +39,7 @@ void gcov_dump_task(void *pvParameter)
         goto gcov_exit;
     }
     ESP_EARLY_LOGV(TAG, "Config apptrace down buf");
-    esp_err_t res = esp_apptrace_down_buffer_config(ESP_APPTRACE_DEST_JTAG, down_buf, ESP_GCOV_DOWN_BUF_SIZE);
+    esp_err_t res = esp_apptrace_down_buffer_config(down_buf, ESP_GCOV_DOWN_BUF_SIZE);
     if (res != ESP_OK) {
         ESP_EARLY_LOGE(TAG, "Failed to config apptrace down buf (%d)!", res);
         dump_result = res;
@@ -51,7 +51,7 @@ void gcov_dump_task(void *pvParameter)
     __gcov_reset();
     free(down_buf);
     ESP_EARLY_LOGV(TAG, "Finish file transfer session");
-    dump_result = esp_apptrace_fstop(ESP_APPTRACE_DEST_JTAG);
+    dump_result = esp_apptrace_fstop();
     if (dump_result != ESP_OK) {
         ESP_EARLY_LOGE(TAG, "Failed to send files transfer stop cmd (%d)!", dump_result);
     }
@@ -117,7 +117,7 @@ void esp_gcov_dump(void)
 {
     ESP_EARLY_LOGV(TAG, "%s", __FUNCTION__);
 
-    while (!esp_apptrace_host_is_connected(ESP_APPTRACE_DEST_JTAG)) {
+    while (!esp_apptrace_host_is_connected()) {
         vTaskDelay(pdMS_TO_TICKS(10));
     }
 
@@ -132,7 +132,7 @@ void esp_gcov_dump(void)
 void *gcov_rtio_fopen(const char *path, const char *mode)
 {
     ESP_EARLY_LOGV(TAG, "%s '%s' '%s'", __FUNCTION__, path, mode);
-    void *f = esp_apptrace_fopen(ESP_APPTRACE_DEST_JTAG, path, mode);
+    void *f = esp_apptrace_fopen(path, mode);
     ESP_EARLY_LOGV(TAG, "%s ret %p", __FUNCTION__, f);
     return f;
 }
@@ -140,13 +140,13 @@ void *gcov_rtio_fopen(const char *path, const char *mode)
 int gcov_rtio_fclose(void *stream)
 {
     ESP_EARLY_LOGV(TAG, "%s", __FUNCTION__);
-    return esp_apptrace_fclose(ESP_APPTRACE_DEST_JTAG, stream);
+    return esp_apptrace_fclose(stream);
 }
 
 size_t gcov_rtio_fread(void *ptr, size_t size, size_t nmemb, void *stream)
 {
     ESP_EARLY_LOGV(TAG, "%s read %u", __FUNCTION__, size * nmemb);
-    size_t sz = esp_apptrace_fread(ESP_APPTRACE_DEST_JTAG, ptr, size, nmemb, stream);
+    size_t sz = esp_apptrace_fread(ptr, size, nmemb, stream);
     ESP_EARLY_LOGV(TAG, "%s actually read %u", __FUNCTION__, sz);
     return sz;
 }
@@ -154,26 +154,26 @@ size_t gcov_rtio_fread(void *ptr, size_t size, size_t nmemb, void *stream)
 size_t gcov_rtio_fwrite(const void *ptr, size_t size, size_t nmemb, void *stream)
 {
     ESP_EARLY_LOGV(TAG, "%s", __FUNCTION__);
-    return esp_apptrace_fwrite(ESP_APPTRACE_DEST_JTAG, ptr, size, nmemb, stream);
+    return esp_apptrace_fwrite(ptr, size, nmemb, stream);
 }
 
 int gcov_rtio_fseek(void *stream, long offset, int whence)
 {
-    int ret = esp_apptrace_fseek(ESP_APPTRACE_DEST_JTAG, stream, offset, whence);
+    int ret = esp_apptrace_fseek(stream, offset, whence);
     ESP_EARLY_LOGV(TAG, "%s(%p %ld %d) = %d", __FUNCTION__, stream, offset, whence, ret);
     return ret;
 }
 
 long gcov_rtio_ftell(void *stream)
 {
-    long ret = esp_apptrace_ftell(ESP_APPTRACE_DEST_JTAG, stream);
+    long ret = esp_apptrace_ftell(stream);
     ESP_EARLY_LOGV(TAG, "%s(%p) = %ld", __FUNCTION__, stream, ret);
     return ret;
 }
 
 int gcov_rtio_feof(void *stream)
 {
-    int ret = esp_apptrace_feof(ESP_APPTRACE_DEST_JTAG, stream);
+    int ret = esp_apptrace_feof(stream);
     ESP_EARLY_LOGV(TAG, "%s(%p) = %d", __FUNCTION__, stream, ret);
     return ret;
 }

--- a/esp_gcov/idf_component.yml
+++ b/esp_gcov/idf_component.yml
@@ -1,7 +1,7 @@
-version: 1.0.2
+version: 1.0.3
 description: Gcov (Source Code Coverage) component for ESP-IDF
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_gcov
 issues: https://github.com/espressif/idf-extra-components/issues
 repository: https://github.com/espressif/idf-extra-components.git
 dependencies:
-  idf: ">=6.0"
+  idf: ">=6.1"

--- a/esp_gcov/sdkconfig.rename
+++ b/esp_gcov/sdkconfig.rename
@@ -1,0 +1,5 @@
+# sdkconfig replacement configurations for deprecated options formatted as
+# CONFIG_DEPRECATED_OPTION CONFIG_NEW_OPTION
+
+CONFIG_ESP32_GCOV_ENABLE                                CONFIG_ESP_GCOV_ENABLE
+CONFIG_APPTRACE_GCOV_DUMP_TASK_STACK_SIZE               CONFIG_ESP_GCOV_DUMP_TASK_STACK_SIZE


### PR DESCRIPTION
This PR updates the `esp_gcov` component to align with recent breaking changes in the `app_trace` component and to integrate with the new `esp_trace` component.

## Changes

- Updated component dependency from `app_trace` to `esp_trace`
- Remove `ESP_APPTRACE_DEST_JTAG` parameter from all `esp_apptrace_*` functions
- Updated Kconfig dependencies to use esp_trace configuration options
- Added `sdkconfig.rename` for backward compatibility with deprecated config options
- Bumped version from 1.0.2 to 1.0.3
