### PR TITLE
fix(coap): add CVE-2025-50518 to exclude list

### DIFF
--- a/coap/sbom_libcoap.yml
+++ b/coap/sbom_libcoap.yml
@@ -12,3 +12,5 @@ cve-exclude-list:
     reason: Resolved in version 4.3.5-rc1
   - cve: CVE-2024-46304
     reason: Resolved in version 4.3.5-rc3
+  - cve: CVE-2025-50518
+    reason: Not applicable as per comment https://github.com/obgm/libcoap/issues/1724#issuecomment-3296780541


### PR DESCRIPTION
Not applicable as per discussion in https://github.com/obgm/libcoap/issues/1724

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
