### PR TITLE
fix(esp_delta_ota): Fixed the esp_delta_ota_patch_gen script

### DIFF
--- a/esp_delta_ota/CHANGELOG.md
+++ b/esp_delta_ota/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.3
+
+### Bugfixes:
+- Fixed `esp_delta_ota_patch_gen.py` patch generation, by ignoring the case in regex which is used to get validation hash of binary through esptool command, caused due to breaking change in esptool.
+
 ## 1.1.2
 
 ### Bugfixes:

--- a/esp_delta_ota/examples/https_delta_ota/tools/esp_delta_ota_patch_gen.py
+++ b/esp_delta_ota/examples/https_delta_ota/tools/esp_delta_ota_patch_gen.py
@@ -54,7 +54,7 @@ def create_patch(chip: str, base_binary: str, new_binary: str, patch_file_name: 
         sys.stdout.close()
         sys.stdout = output
 
-    x = re.search(r"Validation Hash: ([A-Za-z0-9]+) \(valid\)", content)
+    x = re.search(r"Validation Hash: ([A-Za-z0-9]+) \(valid\)", content, re.IGNORECASE)
     
     if x is None:
         print("Failed to find validation hash in base binary.")

--- a/esp_delta_ota/idf_component.yml
+++ b/esp_delta_ota/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.2"
+version: "1.1.3"
 description: "ESP Delta OTA Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_delta_ota
 dependencies:


### PR DESCRIPTION
# Descritpion

- Unable to get the validation hash due to breaking change in esptool. [Ref](https://github.com/espressif/esptool/commit/3f625c39ad1aa924ba361775e5f9233ec76ab04c#diff-be54f44154aa2e2c38dbdd985d29906dfde8971c34077e23901352edc8a39033)
- Ignored the case, to make it compatible with older and newer version of esptool.
- Not restricted the esptool version in the requirements.txt (will not help in such breaking changes).

- Closes https://github.com/espressif/idf-extra-components/issues/605