### PR TITLE
fix(esp_linenoise): close eventfd associated with an instance when de…

### DIFF
--- a/esp_linenoise/Kconfig
+++ b/esp_linenoise/Kconfig
@@ -1,0 +1,15 @@
+menu "esp_linenoise configuration"
+    config ESP_LINENOISE_MAX_INSTANCE_NB
+        int "Maximum number of esp_linenoise instances that can be created simultaneously"
+        range 1 32
+        default 5
+        help
+            Specifies the maximum number of esp_linenoise instances that can be created simultaneously.
+            This limitation applies only when esp_linenoise_abort is used, and the following note is
+            relevant in that context.
+
+            A dynamic memory allocation is performed when the first esp_linenoise instance is created and is
+            freed once the last instance is deleted. The allocated memory size is proportional to the value
+            set in this configuration. Therefore, it is recommended to keep this value as low as possible
+            to reduce memory consumption while ensuring the application’s functional requirements are met.
+endmenu

--- a/esp_linenoise/idf_component.yml
+++ b/esp_linenoise/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: "ESP Linenoise - Line editing C library"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_linenoise
 license: Apache-2.0


### PR DESCRIPTION

# Change description
When deleting a linenoise instance, the linked list of in_fd / evenfd pair item is removed from the list but the evenfd is not closed.
When creating and deleting a lot of esp_linenoise instances, this causes the eventfd to eventually reach the MAX number of FD it can create.
Closing the eventfd associated with the esp_linenoise instance when deleting the instance prevents this.
