### PR TITLE
fix: Add heap dependency to led_strip and essl_sdio (IEC-416)

### DIFF
--- a/esp_serial_slave_link/essl_sdio.c
+++ b/esp_serial_slave_link/essl_sdio.c
@@ -11,6 +11,7 @@
 
 #include "essl_internal.h"
 #include "essl_sdio.h"
+#include "esp_heap_caps.h"
 
 static const char TAG[] = "essl_sdio";
 

--- a/esp_serial_slave_link/idf_component.yml
+++ b/esp_serial_slave_link/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1~1"
+version: "1.1.2"
 description: Espressif Serial Slave Link Library
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_serial_slave_link
 repository: https://github.com/espressif/idf-extra-components.git

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.1~1"
+version: "3.0.2"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 repository: https://github.com/espressif/idf-extra-components.git

--- a/led_strip/src/led_strip_spi_dev.c
+++ b/led_strip/src/led_strip_spi_dev.c
@@ -12,6 +12,7 @@
 #include "soc/spi_periph.h"
 #include "led_strip.h"
 #include "led_strip_interface.h"
+#include "esp_heap_caps.h"
 
 #define LED_STRIP_SPI_DEFAULT_RESOLUTION (2.5 * 1000 * 1000) // 2.5MHz resolution
 #define LED_STRIP_SPI_DEFAULT_TRANS_QUEUE_SIZE 4


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
