### PR TITLE
fix(cbor): fix public include directory path

### DIFF
--- a/cbor/CMakeLists.txt
+++ b/cbor/CMakeLists.txt
@@ -10,8 +10,7 @@ idf_component_register(SRCS "tinycbor/src/cborencoder_close_container_checked.c"
                             "tinycbor/src/cbortojson.c"
                             "tinycbor/src/cborvalidation.c"
                             "tinycbor/src/open_memstream.c"
-                    INCLUDE_DIRS "port/include"
-                    PRIV_INCLUDE_DIRS "tinycbor/src")
+                    INCLUDE_DIRS "tinycbor/src")
 
 # for open_memstream.c
 set_source_files_properties(tinycbor/src/open_memstream.c PROPERTIES

--- a/cbor/examples/cbor/main/cbor_example_main.c
+++ b/cbor/examples/cbor/main/cbor_example_main.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include "esp_log.h"
 #include "cbor.h"
+#include "cborjson.h"
 
 static const char *TAG = "example";
 

--- a/cbor/idf_component.yml
+++ b/cbor/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.6.1~3"
+version: "0.6.1~4"
 description: "CBOR: Concise Binary Object Representation Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/cbor
 dependencies:

--- a/cbor/port/include/cbor.h
+++ b/cbor/port/include/cbor.h
@@ -1,7 +1,0 @@
-/*
- * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
- *
- * SPDX-License-Identifier: Unlicense OR CC0-1.0
- */
-#include "../../tinycbor/src/cbor.h"
-#include "../../tinycbor/src/cborjson.h"


### PR DESCRIPTION
Closes https://github.com/espressif/idf-extra-components/issues/614

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
