### PR TITLE
feat(esp_linenoise): Expose esp_linenoise_probe API

### DIFF
--- a/esp_linenoise/idf_component.yml
+++ b/esp_linenoise/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2"
+version: "1.0.3"
 description: "ESP Linenoise - Line editing C library"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_linenoise
 license: Apache-2.0

--- a/esp_linenoise/include/esp_linenoise.h
+++ b/esp_linenoise/include/esp_linenoise.h
@@ -127,6 +127,14 @@ typedef struct esp_linenoise_config {
 typedef struct esp_linenoise_instance *esp_linenoise_handle_t;
 
 /**
+ * @brief Probe the terminal to check weather it supports escape sequences
+ *
+ * @param handle The linenoise handle used to check
+ * @return int 0 if the terminal supports escape sequences
+ */
+int esp_linenoise_probe(esp_linenoise_handle_t handle);
+
+/**
  * @brief Returns the default parameters for creating a linenoise instance.
  *
  * @param[out] config esp_linenoise_config_t structure to populate with default values.
@@ -306,6 +314,24 @@ esp_err_t esp_linenoise_set_max_cmd_line_length(esp_linenoise_handle_t handle, s
  * @return ESP_OK on success, or error code on failure.
  */
 esp_err_t esp_linenoise_get_max_cmd_line_length(esp_linenoise_handle_t handle, size_t *max_cmd_line_length);
+
+/**
+ * @brief Sets the prompt used by the esp_linenoise instance.
+ *
+ * @param handle Handle to the linenoise instance.
+ * @param prompt Prompt to be set.
+ * @return ESP_OK on success, or error code on failure.
+ */
+esp_err_t esp_linenoise_set_prompt(esp_linenoise_handle_t handle, const char *prompt);
+
+/**
+ * @brief Gets the current esp_linenoise instance prompt.
+ *
+ * @param handle Handle to the linenoise instance.
+ * @param prompt esp_linenoise instance current prompt.
+ * @return ESP_OK on success, or error code on failure.
+ */
+esp_err_t esp_linenoise_get_prompt(esp_linenoise_handle_t handle, const char **prompt);
 
 /**
  * @brief Return the output file descriptor used by esp_linenoise

--- a/esp_linenoise/private_include/esp_linenoise_private.h
+++ b/esp_linenoise/private_include/esp_linenoise_private.h
@@ -90,14 +90,6 @@ esp_linenoise_instance_t *esp_linenoise_create_instance_static(void)
 }
 
 /**
- * @brief Probe the terminal to check weather it supports escape sequences
- *
- * @param instance The linenoise instance used to check
- * @return int 0 if the terminal supports escape sequences
- */
-int esp_linenoise_probe(esp_linenoise_instance_t *instance);
-
-/**
  * @brief This function is used by the callback function registered by the user
  * in order to add completion options given the input string when the
  * user typed <tab>. See the example.c source code for a very easy to

--- a/esp_linenoise/test_apps/main/test_esp_linenoise_get_set.c
+++ b/esp_linenoise/test_apps/main/test_esp_linenoise_get_set.c
@@ -72,6 +72,20 @@ TEST_CASE("set and get empty line flag", "[esp_linenoise]")
     TEST_ASSERT_EQUAL(ESP_OK, esp_linenoise_delete_instance(h));
 }
 
+TEST_CASE("set and get prompt", "[esp_linenoise]")
+{
+    esp_linenoise_handle_t h = get_linenoise_instance_default_config();
+
+    const char *test_prompt = "test";
+    const char *ret_prompt = NULL;
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_linenoise_set_prompt(h, test_prompt));
+    TEST_ASSERT_EQUAL(ESP_OK, esp_linenoise_get_prompt(h, &ret_prompt));
+    TEST_ASSERT_TRUE(strcmp(test_prompt, ret_prompt) == 0);
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_linenoise_delete_instance(h));
+}
+
 TEST_CASE("default max line length and max history length", "[esp_linenoise]")
 {
     esp_linenoise_config_t config;


### PR DESCRIPTION
# Checklist
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
This PR exposes the `esp_linenoise_probe` function and adds a getter and setter function for the `esp_linenoise_config_t` prompt field.

This makes the re-probing and update of prompt possible.
