### PR TITLE
refactor: strip the touch element dependency on the hal in IDF (IEC-421)

### DIFF
--- a/touch_element/CHANGELOG.md
+++ b/touch_element/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+- Refactor to remove the dependency on the hal and soc caps in IDF
+- Moved the enums in `touch_pad_intr_mask_t` to ll header, but still keep `touch_pad_intr_mask_t` for backward compatibility
+
 ## 1.0.0
 
 - Added test app, examples and documentations for the touch element library

--- a/touch_element/idf_component.yml
+++ b/touch_element/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.1.0"
 description: Touch Element Library
 url: https://github.com/espressif/idf-extra-components/tree/master/touch_element
 repository: https://github.com/espressif/idf-extra-components.git

--- a/touch_element/include/touch_element/touch_sensor_legacy_types.h
+++ b/touch_element/include/touch_element/touch_sensor_legacy_types.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include "esp_attr.h"
 #include "esp_bit_defs.h"
-#include "soc/soc_caps.h"
 
 #if __has_include("hal/touch_sensor_legacy_types.h")
 #include "hal/touch_sensor_legacy_types.h"
@@ -166,7 +165,7 @@ typedef enum {
 
 
 /********************************/
-#define TOUCH_PAD_BIT_MASK_ALL              ((1<<SOC_TOUCH_SENSOR_NUM)-1)
+#define TOUCH_PAD_BIT_MASK_ALL              (0x7FFF)
 #define TOUCH_PAD_SLOPE_DEFAULT             (TOUCH_PAD_SLOPE_7)
 #define TOUCH_PAD_TIE_OPT_DEFAULT           (TOUCH_PAD_TIE_OPT_FLOAT)
 #define TOUCH_PAD_BIT_MASK_MAX              (TOUCH_PAD_BIT_MASK_ALL)
@@ -190,31 +189,7 @@ typedef enum {
                                                     Recommended typical value: Modify this value to make the measurement time around 1ms.
                                                     Range: 0 ~ 0xffff */
 
-// TODO: replace by ll macro
-typedef enum {
-    TOUCH_PAD_INTR_MASK_DONE = BIT(0),      /*!<Measurement done for one of the enabled channels. */
-    TOUCH_PAD_INTR_MASK_ACTIVE = BIT(1),    /*!<Active for one of the enabled channels. */
-    TOUCH_PAD_INTR_MASK_INACTIVE = BIT(2),  /*!<Inactive for one of the enabled channels. */
-    TOUCH_PAD_INTR_MASK_SCAN_DONE = BIT(3), /*!<Measurement done for all the enabled channels. */
-    TOUCH_PAD_INTR_MASK_TIMEOUT = BIT(4),   /*!<Timeout for one of the enabled channels. */
-#if SOC_TOUCH_PROXIMITY_MEAS_DONE_SUPPORTED
-    TOUCH_PAD_INTR_MASK_PROXI_MEAS_DONE = BIT(5),   /*!<For proximity sensor, when the number of measurements reaches the set count of measurements, an interrupt will be generated. */
-    TOUCH_PAD_INTR_MASK_MAX
-#define TOUCH_PAD_INTR_MASK_ALL (TOUCH_PAD_INTR_MASK_TIMEOUT    \
-                                | TOUCH_PAD_INTR_MASK_SCAN_DONE \
-                                | TOUCH_PAD_INTR_MASK_INACTIVE  \
-                                | TOUCH_PAD_INTR_MASK_ACTIVE    \
-                                | TOUCH_PAD_INTR_MASK_DONE      \
-                                | TOUCH_PAD_INTR_MASK_PROXI_MEAS_DONE) /*!<All touch interrupt type enable. */
-#else
-    TOUCH_PAD_INTR_MASK_MAX
-#define TOUCH_PAD_INTR_MASK_ALL (TOUCH_PAD_INTR_MASK_TIMEOUT    \
-                                | TOUCH_PAD_INTR_MASK_SCAN_DONE \
-                                | TOUCH_PAD_INTR_MASK_INACTIVE  \
-                                | TOUCH_PAD_INTR_MASK_ACTIVE    \
-                                | TOUCH_PAD_INTR_MASK_DONE) /*!<All touch interrupt type enable. */
-#endif
-} touch_pad_intr_mask_t;
+typedef uint32_t touch_pad_intr_mask_t;
 
 typedef enum {
     TOUCH_PAD_DENOISE_BIT12 = 0,    /*!<Denoise range is 12bit */

--- a/touch_element/touch_element.c
+++ b/touch_element/touch_element.c
@@ -16,7 +16,6 @@
 #include "driver/rtc_io.h"
 #include "esp_private/rtc_ctrl.h"
 #include "esp_private/gpio.h"
-#include "soc/touch_sensor_periph.h"
 #include "soc/rtc_cntl_reg.h"
 #include "esp_private/touch_sensor_legacy_hal.h"
 #include "esp_private/touch_element_private.h"
@@ -81,10 +80,10 @@
 #define TOUCH_GET_IO_NUM(channel) (touch_sensor_channel_io_map[channel])
 
 typedef enum {
-    TE_INTR_PRESS = 0,          //Touch sensor press interrupt(TOUCH_PAD_INTR_MASK_ACTIVE)
-    TE_INTR_RELEASE,            //Touch sensor release interrupt(TOUCH_PAD_INTR_MASK_INACTIVE)
-    TE_INTR_TIMEOUT,            //Touch sensor scan timeout interrupt(TOUCH_PAD_INTR_MASK_TIMEOUT)
-    TE_INTR_SCAN_DONE,          //Touch sensor scan done interrupt(TOUCH_PAD_INTR_MASK_SCAN_DONE), now just use for setting threshold
+    TE_INTR_PRESS = 0,          //Touch sensor press interrupt(TOUCH_LL_INTR_MASK_DONE)
+    TE_INTR_RELEASE,            //Touch sensor release interrupt(TOUCH_LL_INTR_MASK_DONE)
+    TE_INTR_TIMEOUT,            //Touch sensor scan timeout interrupt(TOUCH_LL_INTR_MASK_TIMEOUT)
+    TE_INTR_SCAN_DONE,          //Touch sensor scan done interrupt(TOUCH_LL_INTR_MASK_SCAN_DONE), now just use for setting threshold
     TE_INTR_MAX
 } te_intr_t;
 
@@ -109,6 +108,12 @@ typedef struct {
 
 static te_obj_t *s_te_obj = NULL;
 RTC_FAST_ATTR uint32_t threshold_shadow[TOUCH_PAD_MAX - 1] = {0};
+
+/* Store IO number corresponding to the Touch Sensor channel number. */
+/* Note: T0 is an internal channel that does not have a corresponding external GPIO. */
+const int touch_sensor_channel_io_map[TOUCH_LL_CHAN_NUM] = {
+    -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
+    };
 
 /**
  * Internal de-noise channel(Touch channel 0) equivalent capacitance table, depends on hardware design
@@ -200,7 +205,7 @@ esp_err_t touch_element_start(void)
         if (ret != ESP_OK) {
             break;
         }
-        touch_ll_intr_enable(TOUCH_PAD_INTR_MASK_SCAN_DONE); //Use scan done interrupt to set threshold
+        touch_ll_intr_enable((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_SCAN_DONE); //Use scan done interrupt to set threshold
         touch_ll_start_fsm();
         xQueueReset(s_te_obj->event_msg_queue);
         xQueueReset(s_te_obj->intr_msg_queue);
@@ -219,7 +224,7 @@ esp_err_t touch_element_stop(void)
     esp_err_t ret = ESP_OK;
     xSemaphoreTake(s_te_obj->mutex, portMAX_DELAY);
     touch_ll_stop_fsm();
-    touch_ll_intr_disable(TOUCH_PAD_INTR_MASK_SCAN_DONE);
+    touch_ll_intr_disable((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_SCAN_DONE);
     ret = esp_timer_stop(s_te_obj->proc_timer);
     if (ret != ESP_OK) {
         return ret;
@@ -243,7 +248,7 @@ void touch_element_uninstall(void)
     if (ret != ESP_OK) {
         abort();
     }
-    touch_ll_intr_disable(TOUCH_PAD_INTR_MASK_ACTIVE | TOUCH_PAD_INTR_MASK_INACTIVE | TOUCH_PAD_INTR_MASK_TIMEOUT);
+    touch_ll_intr_disable((touch_pad_intr_mask_t)(TOUCH_LL_INTR_MASK_DONE | TOUCH_LL_INTR_MASK_DONE | TOUCH_LL_INTR_MASK_TIMEOUT));
     ret = rtc_isr_deregister(te_intr_cb, NULL);
     if (ret != ESP_OK) {
         abort();
@@ -356,14 +361,14 @@ static void te_intr_cb(void *arg)
 #if CONFIG_IDF_TARGET_ESP32S2
     /*< Workaround: For ESP32S2, the scan done interrupt may occur earlier,
         so we need to ignore the fake scan done interrupt */
-    if (intr_mask & TOUCH_PAD_INTR_MASK_SCAN_DONE) {
+    if (intr_mask & TOUCH_LL_INTR_MASK_SCAN_DONE) {
         uint32_t curr_pad = touch_ll_get_current_meas_channel();
         uint16_t ch_mask = 0;
         touch_ll_get_channel_mask(&ch_mask);
         /* If the current channel is not the last channel, it means the scan done interrupt is fake */
         if (__builtin_clz((uint32_t)ch_mask) != __builtin_clz(BIT(curr_pad))) {
-            touch_ll_intr_clear(TOUCH_PAD_INTR_MASK_SCAN_DONE);
-            intr_mask &= ~TOUCH_PAD_INTR_MASK_SCAN_DONE;
+            touch_ll_intr_clear((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_SCAN_DONE);
+            intr_mask &= ~TOUCH_LL_INTR_MASK_SCAN_DONE;
         }
     }
 #endif
@@ -397,17 +402,17 @@ static void te_intr_cb(void *arg)
         touch_trig_diff >>= 1;
     }
 
-    if (intr_mask & TOUCH_PAD_INTR_MASK_TIMEOUT) {
+    if (intr_mask & TOUCH_LL_INTR_MASK_TIMEOUT) {
         te_intr_msg.channel_state = TE_STATE_IDLE;
         te_intr_msg.intr_type = TE_INTR_TIMEOUT;
-    } else if (intr_mask & TOUCH_PAD_INTR_MASK_SCAN_DONE) {
+    } else if (intr_mask & TOUCH_LL_INTR_MASK_SCAN_DONE) {
         te_intr_msg.channel_state = TE_STATE_IDLE;
         te_intr_msg.intr_type = TE_INTR_SCAN_DONE;
         need_send_queue = false;
         /*< Due to a hardware issue, all of the data read operation(read raw, read smooth, read benchmark) */
         /*< must be after the second times of measure_done interrupt. */
         if (++scan_done_cnt >= 5) {
-            touch_ll_intr_disable(TOUCH_PAD_INTR_MASK_SCAN_DONE);  //TODO: remove hal
+            touch_ll_intr_disable((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_SCAN_DONE);  //TODO: remove hal
             scan_done_cnt = 0;
             need_send_queue = true;
         }
@@ -705,15 +710,15 @@ static esp_err_t te_hw_init(const touch_elem_hw_config_t *hardware_init)
                          RTC_CNTL_TOUCH_TIMEOUT_INT_ST_M | RTC_CNTL_TOUCH_SCAN_DONE_INT_ST_M;
     ret = rtc_isr_register(te_intr_cb, NULL, intr_mask, 0);
     TE_CHECK(ret == ESP_OK, ret);
-    touch_ll_intr_enable(TOUCH_PAD_INTR_MASK_ACTIVE | TOUCH_PAD_INTR_MASK_SCAN_DONE |
-                         TOUCH_PAD_INTR_MASK_INACTIVE | TOUCH_PAD_INTR_MASK_TIMEOUT);
+    touch_ll_intr_enable((touch_pad_intr_mask_t)(TOUCH_LL_INTR_MASK_DONE | TOUCH_LL_INTR_MASK_SCAN_DONE |
+                         TOUCH_LL_INTR_MASK_DONE | TOUCH_LL_INTR_MASK_TIMEOUT));
     TE_CHECK(ret == ESP_OK, ret);
     /*< Internal de-noise configuration */
     touch_pad_denoise_t denoise_config;
     denoise_config.grade = hardware_init->denoise_level;
     denoise_config.cap_level = hardware_init->denoise_equivalent_cap;
-    touch_ll_set_slope(TOUCH_LL_DENOISE_CHANNEL, TOUCH_PAD_SLOPE_DEFAULT);
-    touch_ll_set_tie_option(TOUCH_LL_DENOISE_CHANNEL, TOUCH_PAD_TIE_OPT_DEFAULT);
+    touch_ll_set_slope((touch_pad_t)TOUCH_LL_DENOISE_CHANNEL, TOUCH_PAD_SLOPE_DEFAULT);
+    touch_ll_set_tie_option((touch_pad_t)TOUCH_LL_DENOISE_CHANNEL, TOUCH_PAD_TIE_OPT_DEFAULT);
     touch_hal_denoise_set_config(&denoise_config);
     touch_hal_denoise_enable();
 

--- a/touch_element/touch_sensor_legacy_hal.c
+++ b/touch_element/touch_sensor_legacy_hal.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "soc/soc_caps.h"
-#include "soc/touch_sensor_pins.h"
 #include "esp_private/touch_sensor_legacy_ll.h"
 #include "esp_private/touch_sensor_legacy_hal.h"
 #include "touch_element/touch_sensor_legacy_types.h"
@@ -16,8 +14,8 @@ static int s_meas_times = -1;
 void touch_hal_init(void)
 {
     touch_ll_stop_fsm();
-    touch_ll_intr_disable(TOUCH_PAD_INTR_MASK_ALL);
-    touch_ll_intr_clear(TOUCH_PAD_INTR_MASK_ALL);
+    touch_ll_intr_disable((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_ALL);
+    touch_ll_intr_clear((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_ALL);
     touch_ll_clear_channel_mask(TOUCH_PAD_BIT_MASK_ALL);
     touch_ll_clear_trigger_status_mask();
     touch_ll_set_meas_times(TOUCH_PAD_MEASURE_CYCLE_DEFAULT);
@@ -45,11 +43,11 @@ void touch_hal_deinit(void)
     touch_ll_clkgate(false);
     touch_ll_clear_channel_mask(TOUCH_PAD_BIT_MASK_ALL);
     touch_ll_clear_trigger_status_mask();
-    touch_ll_intr_disable(TOUCH_PAD_INTR_MASK_ALL);
+    touch_ll_intr_disable((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_ALL);
     touch_ll_timeout_disable();
     touch_ll_waterproof_enable(false);
     touch_ll_denoise_enable(false);
-    touch_pad_t prox_pad[SOC_TOUCH_PROXIMITY_CHANNEL_NUM] = {[0 ... (SOC_TOUCH_PROXIMITY_CHANNEL_NUM - 1)] = 0};
+    touch_pad_t prox_pad[TOUCH_LL_PROXIMITY_CHANNEL_NUM] = {[0 ... (TOUCH_LL_PROXIMITY_CHANNEL_NUM - 1)] = 0};
     touch_ll_proximity_set_channel_num((const touch_pad_t *)prox_pad);
     touch_ll_sleep_set_channel_num(0);
     touch_ll_sleep_enable_proximity_sensing(false);
@@ -121,7 +119,7 @@ void touch_hal_denoise_get_config(touch_pad_denoise_t *denoise)
 
 void touch_hal_denoise_enable(void)
 {
-    touch_ll_clear_channel_mask(1U << SOC_TOUCH_DENOISE_CHANNEL);
+    touch_ll_clear_channel_mask(1U << TOUCH_LL_DENOISE_CHANNEL);
     touch_ll_denoise_enable(true);
 }
 
@@ -139,27 +137,27 @@ void touch_hal_waterproof_get_config(touch_pad_waterproof_t *waterproof)
 
 void touch_hal_waterproof_enable(void)
 {
-    touch_ll_clear_channel_mask(1U << SOC_TOUCH_SHIELD_CHANNEL);
+    touch_ll_clear_channel_mask(1U << TOUCH_LL_SHIELD_CHANNEL);
     touch_ll_waterproof_enable(true);
 }
 
 bool touch_hal_enable_proximity(touch_pad_t touch_num, bool enabled)
 {
     int i = 0;
-    touch_pad_t ch_num[SOC_TOUCH_PROXIMITY_CHANNEL_NUM] = {0};
+    touch_pad_t ch_num[TOUCH_LL_PROXIMITY_CHANNEL_NUM] = {0};
     touch_ll_proximity_get_channel_num(ch_num);
     if (enabled) {
-        for (i = 0; i < SOC_TOUCH_PROXIMITY_CHANNEL_NUM; i++) {
+        for (i = 0; i < TOUCH_LL_PROXIMITY_CHANNEL_NUM; i++) {
             if (ch_num[i] == TOUCH_PAD_NUM0 || ch_num[i] >= TOUCH_PAD_MAX || ch_num[i] == touch_num) {
                 ch_num[i] = touch_num;
                 break;
             }
         }
-        if (i == SOC_TOUCH_PROXIMITY_CHANNEL_NUM) {
+        if (i == TOUCH_LL_PROXIMITY_CHANNEL_NUM) {
             return false;
         }
     } else {
-        for (i = 0; i < SOC_TOUCH_PROXIMITY_CHANNEL_NUM; i++) {
+        for (i = 0; i < TOUCH_LL_PROXIMITY_CHANNEL_NUM; i++) {
             if (ch_num[i] == touch_num) {
                 ch_num[i] = TOUCH_PAD_NUM0;
                 break;


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
Refactor to get rid of the dependency on the hal and some caps in IDF
