### PR TITLE
fix(touch_element): fixed incorrect intr mask (IEC-423)

### DIFF
--- a/touch_element/CHANGELOG.md
+++ b/touch_element/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Fixed the incorrect interrupt mask
+
 ## 1.1.0
 
 - Refactor to remove the dependency on the hal and soc caps in IDF

--- a/touch_element/idf_component.yml
+++ b/touch_element/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.1"
 description: Touch Element Library
 url: https://github.com/espressif/idf-extra-components/tree/master/touch_element
 repository: https://github.com/espressif/idf-extra-components.git

--- a/touch_element/include/esp_private/touch_sensor_legacy_ll.h
+++ b/touch_element/include/esp_private/touch_sensor_legacy_ll.h
@@ -708,10 +708,10 @@ static inline void touch_ll_intr_enable(touch_pad_intr_mask_t int_mask)
     if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
         RTCCNTL.int_ena_w1ts.rtc_touch_done_w1ts = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_ACTIVE) {
         RTCCNTL.int_ena_w1ts.rtc_touch_active_w1ts = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_INACTIVE) {
         RTCCNTL.int_ena_w1ts.rtc_touch_inactive_w1ts = 1;
     }
     if (int_mask & TOUCH_LL_INTR_MASK_SCAN_DONE) {
@@ -735,10 +735,10 @@ static inline void touch_ll_intr_disable(touch_pad_intr_mask_t int_mask)
     if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
         RTCCNTL.int_ena_w1tc.rtc_touch_done_w1tc = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_ACTIVE) {
         RTCCNTL.int_ena_w1tc.rtc_touch_active_w1tc = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_INACTIVE) {
         RTCCNTL.int_ena_w1tc.rtc_touch_inactive_w1tc = 1;
     }
     if (int_mask & TOUCH_LL_INTR_MASK_SCAN_DONE) {
@@ -762,10 +762,10 @@ static inline void touch_ll_intr_clear(touch_pad_intr_mask_t int_mask)
     if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
         RTCCNTL.int_clr.rtc_touch_done = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_ACTIVE) {
         RTCCNTL.int_clr.rtc_touch_active = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_INACTIVE) {
         RTCCNTL.int_clr.rtc_touch_inactive = 1;
     }
     if (int_mask & TOUCH_LL_INTR_MASK_SCAN_DONE) {
@@ -794,10 +794,10 @@ static inline uint32_t touch_ll_read_intr_status_mask(void)
         intr_msk |= TOUCH_LL_INTR_MASK_DONE;
     }
     if (intr_st.rtc_touch_active) {
-        intr_msk |= TOUCH_LL_INTR_MASK_DONE;
+        intr_msk |= TOUCH_LL_INTR_MASK_ACTIVE;
     }
     if (intr_st.rtc_touch_inactive) {
-        intr_msk |= TOUCH_LL_INTR_MASK_DONE;
+        intr_msk |= TOUCH_LL_INTR_MASK_INACTIVE;
     }
     if (intr_st.rtc_touch_scan_done) {
         intr_msk |= TOUCH_LL_INTR_MASK_SCAN_DONE;
@@ -823,10 +823,10 @@ static inline void touch_ll_intr_enable(touch_pad_intr_mask_t int_mask)
     if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
         RTCCNTL.int_ena.rtc_touch_done = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_ACTIVE) {
         RTCCNTL.int_ena.rtc_touch_active = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_INACTIVE) {
         RTCCNTL.int_ena.rtc_touch_inactive = 1;
     }
     if (int_mask & TOUCH_LL_INTR_MASK_SCAN_DONE) {
@@ -847,10 +847,10 @@ static inline void touch_ll_intr_disable(uint32_t int_mask)
     if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
         RTCCNTL.int_ena.rtc_touch_done = 0;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_ACTIVE) {
         RTCCNTL.int_ena.rtc_touch_active = 0;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_INACTIVE) {
         RTCCNTL.int_ena.rtc_touch_inactive = 0;
     }
     if (int_mask & TOUCH_LL_INTR_MASK_SCAN_DONE) {
@@ -871,10 +871,10 @@ static inline void touch_ll_intr_clear(touch_pad_intr_mask_t int_mask)
     if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
         RTCCNTL.int_clr.rtc_touch_done = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_ACTIVE) {
         RTCCNTL.int_clr.rtc_touch_active = 1;
     }
-    if (int_mask & TOUCH_LL_INTR_MASK_DONE) {
+    if (int_mask & TOUCH_LL_INTR_MASK_INACTIVE) {
         RTCCNTL.int_clr.rtc_touch_inactive = 1;
     }
     if (int_mask & TOUCH_LL_INTR_MASK_SCAN_DONE) {
@@ -900,10 +900,10 @@ static inline uint32_t touch_ll_read_intr_status_mask(void)
         intr_msk |= TOUCH_LL_INTR_MASK_DONE;
     }
     if (intr_st.rtc_touch_active) {
-        intr_msk |= TOUCH_LL_INTR_MASK_DONE;
+        intr_msk |= TOUCH_LL_INTR_MASK_ACTIVE;
     }
     if (intr_st.rtc_touch_inactive) {
-        intr_msk |= TOUCH_LL_INTR_MASK_DONE;
+        intr_msk |= TOUCH_LL_INTR_MASK_INACTIVE;
     }
     if (intr_st.rtc_touch_scan_done) {
         intr_msk |= TOUCH_LL_INTR_MASK_SCAN_DONE;

--- a/touch_element/touch_element.c
+++ b/touch_element/touch_element.c
@@ -248,7 +248,7 @@ void touch_element_uninstall(void)
     if (ret != ESP_OK) {
         abort();
     }
-    touch_ll_intr_disable((touch_pad_intr_mask_t)(TOUCH_LL_INTR_MASK_DONE | TOUCH_LL_INTR_MASK_DONE | TOUCH_LL_INTR_MASK_TIMEOUT));
+    touch_ll_intr_disable((touch_pad_intr_mask_t)(TOUCH_LL_INTR_MASK_ACTIVE | TOUCH_LL_INTR_MASK_INACTIVE | TOUCH_LL_INTR_MASK_TIMEOUT));
     ret = rtc_isr_deregister(te_intr_cb, NULL);
     if (ret != ESP_OK) {
         abort();
@@ -710,8 +710,8 @@ static esp_err_t te_hw_init(const touch_elem_hw_config_t *hardware_init)
                          RTC_CNTL_TOUCH_TIMEOUT_INT_ST_M | RTC_CNTL_TOUCH_SCAN_DONE_INT_ST_M;
     ret = rtc_isr_register(te_intr_cb, NULL, intr_mask, 0);
     TE_CHECK(ret == ESP_OK, ret);
-    touch_ll_intr_enable((touch_pad_intr_mask_t)(TOUCH_LL_INTR_MASK_DONE | TOUCH_LL_INTR_MASK_SCAN_DONE |
-                         TOUCH_LL_INTR_MASK_DONE | TOUCH_LL_INTR_MASK_TIMEOUT));
+    touch_ll_intr_enable((touch_pad_intr_mask_t)(TOUCH_LL_INTR_MASK_ACTIVE | TOUCH_LL_INTR_MASK_SCAN_DONE |
+                         TOUCH_LL_INTR_MASK_INACTIVE | TOUCH_LL_INTR_MASK_TIMEOUT));
     TE_CHECK(ret == ESP_OK, ret);
     /*< Internal de-noise configuration */
     touch_pad_denoise_t denoise_config;


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

The bug was introduced in the [last commit](https://github.com/espressif/idf-extra-components/commit/9060b4727418b9fe419db5f7a00fb572b2a40fc5) `TOUCH_LL_INTR_MASK_ACTIVE ` and `TOUCH_LL_INTR_MASK_INACTIVE` was wrongly modified to `TOUCH_LL_INTR_MASK_DONE`.
