### PR TITLE
fix(json_generator): int64 to string conversion without snprintf (IEC-425)

### DIFF
--- a/json_generator/idf_component.yml
+++ b/json_generator/idf_component.yml
@@ -1,3 +1,3 @@
-version: "1.2.0"
+version: "1.2.1"
 description: A simple JSON (JavasScript Object Notation) generator with flushing capability
 url: https://github.com/espressif/json_generator

--- a/json_generator/src/json_generator.c
+++ b/json_generator/src/json_generator.c
@@ -238,7 +238,7 @@ static int json_gen_set_int64(json_gen_str_t *jstr, int64_t val)
     bool negative = false;
 
     if (val < 0) {
-        abs_val = (uint64_t)(-val);
+        abs_val = val == INT64_MIN ? (uint64_t)(INT64_MAX) + 1 : (uint64_t)(-val);
         negative = true;
     } else {
         abs_val = (uint64_t)val;
@@ -249,7 +249,7 @@ static int json_gen_set_int64(json_gen_str_t *jstr, int64_t val)
 
     // Handle zero case
     if (abs_val == 0) {
-        *ptr = '0';
+        *(--ptr) = '0';
     } else {
         // Extract digits from right to left using modulo 10
         while (abs_val > 0) {

--- a/json_generator/test_apps/main/json_generator_test.c
+++ b/json_generator/test_apps/main/json_generator_test.c
@@ -1,6 +1,64 @@
-#include <stdio.h>
+#include "unity.h"
+#include "unity_test_runner.h"
+#include "json_generator.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <time.h>
+#include <limits.h>
+#include <inttypes.h>
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+static void json_generator_setup(json_gen_str_t *p_jstr, char *buf, int buf_size)
+{
+    json_gen_str_start(p_jstr, buf, buf_size, NULL, NULL);
+    json_gen_start_object(p_jstr);
+}
+
+static void json_generator_teardown(json_gen_str_t *p_jstr)
+{
+    json_gen_end_object(p_jstr);
+    json_gen_str_end(p_jstr);
+}
+
+TEST_CASE("int64_t test", "[json_generator]")
+{
+#if CONFIG_LIBC_NEWLIB_NANO_FORMAT
+    printf("Using modulo 10 parsing to format the 64-bit integer. Set CONFIG_LIBC_NEWLIB_NANO_FORMAT=n to use snprintf.\n");
+#else /* !CONFIG_LIBC_NEWLIB_NANO_FORMAT */
+    printf("Using snprintf to format the 64-bit integer. Set CONFIG_LIBC_NEWLIB_NANO_FORMAT=y to use modulo 10 parsing.\n");
+#endif /* CONFIG_LIBC_NEWLIB_NANO_FORMAT */
+
+    char buf[1024];
+    json_gen_str_t jstr;
+    json_generator_setup(&jstr, buf, sizeof(buf));
+
+    /* Try to add a int64_t value, positive and negative */
+    const int64_t pos_val = rand();
+    const int64_t neg_val = -rand();
+    json_gen_obj_set_int64(&jstr, "pos", pos_val);
+    json_gen_obj_set_int64(&jstr, "neg", neg_val);
+
+    /* Try boundary values */
+    json_gen_obj_set_int64(&jstr, "zero", 0);
+    json_gen_obj_set_int64(&jstr, "max", INT64_MAX);
+    json_gen_obj_set_int64(&jstr, "min", INT64_MIN);
+
+    json_generator_teardown(&jstr);
+    char expected_str[1024];
+    snprintf(expected_str, sizeof(expected_str), "{\"pos\":%" PRId64 ",\"neg\":%" PRId64 ",\"zero\":0,\"max\":%" PRId64 ",\"min\":%" PRId64 "}", pos_val, neg_val, INT64_MAX, INT64_MIN);
+    printf("Expected string: %s\n", expected_str);
+    printf("Actual string: %s\n", buf);
+    TEST_ASSERT_EQUAL_STRING(expected_str, buf);
+}
 
 void app_main(void)
 {
+    /* Random seed for the test */
+    srand(time(NULL));
 
+    printf("Running json_generator tests\n");
+    unity_run_menu();
 }


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

With Kconfig option `CONFIG_LIBC_NEWLIB_NANO_FORMAT=y` (enabled by default for ESP32C2), formatting for 64-bit integers is not supported, so `snprintf` will not work. In this case, manually generate the number string via modulo 10.
