### PR TITLE
feat(sh2lib): capture HTTP2 GOAWAY (IEC-428)

### DIFF
--- a/sh2lib/sh2lib.h
+++ b/sh2lib/sh2lib.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include "esp_tls.h"
 #include <nghttp2/nghttp2.h>
 
@@ -33,6 +34,7 @@ struct sh2lib_handle {
     char            *hostname;     /*!< The hostname we are connected to */
     struct esp_tls  *http2_tls;    /*!< Pointer to the TLS session handle */
     int             http2_tls_rc;  /*!< Error code from http2_tls */
+    bool            http2_goaway;  /*!< HTTP2 server sent GOAWAY */
 };
 
 /**


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [X] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [X] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

Before this patch, GOAWAY silently leaves the client in a very strange state: New requests will fail. Processing requests will continue working.

Log this and let the client know, so that they may take appropriate action.

Closes #559
