### PR TITLE
change(esp_gcov): enable idf 6.0 support

### DIFF
--- a/esp_gcov/idf_component.yml
+++ b/esp_gcov/idf_component.yml
@@ -1,7 +1,7 @@
-version: 1.0.3
+version: 1.0.4
 description: Gcov (Source Code Coverage) component for ESP-IDF
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_gcov
 issues: https://github.com/espressif/idf-extra-components/issues
 repository: https://github.com/espressif/idf-extra-components.git
 dependencies:
-  idf: ">=6.1"
+  idf: ">=6.0"


### PR DESCRIPTION
esp_trace changes are merged to idf-6.0 branch now. We can update gcov dependencies as `idf: ">=6.0"`
