### PR TITLE
fix(esp_sysview): generate linker fragment from template

### DIFF
--- a/esp_sysview/CMakeLists.txt
+++ b/esp_sysview/CMakeLists.txt
@@ -26,10 +26,12 @@ if(CONFIG_ESP_TRACE_LIB_EXTERNAL)
         endif()
     endif()
 
+    configure_file(linker.lf.in ${CMAKE_CURRENT_BINARY_DIR}/linker.lf)
+
     idf_component_register(SRCS "${srcs}"
                         INCLUDE_DIRS "${include_dirs}"
                         REQUIRES     esp_trace
-                        LDFRAGMENTS linker.lf
+                        LDFRAGMENTS ${CMAKE_CURRENT_BINARY_DIR}/linker.lf
                         WHOLE_ARCHIVE TRUE # Link all symbols so self-registering adapters (ESP_TRACE_REGISTER_*) are not discarded
                         )
 

--- a/esp_sysview/idf_component.yml
+++ b/esp_sysview/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.0
+version: 1.0.1
 description: SEGGER SystemView component for ESP-IDF
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_sysview
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/esp_sysview/linker.lf.in
+++ b/esp_sysview/linker.lf.in
@@ -1,9 +1,10 @@
 [mapping:esp_sysview]
-archive: libesp_sysview.a
+archive: lib${COMPONENT_NAME}.a
 entries:
     # Place all the symbols in the IRAM to allow tracing when flash cache is disabled
     SEGGER_SYSVIEW (noflash)
     SEGGER_RTT_esp (noflash)
+    SEGGER_SYSVIEW_esp (noflash)
     SEGGER_SYSVIEW_Config_FreeRTOS (noflash)
     SEGGER_SYSVIEW_FreeRTOS (noflash)
     adapter_encoder_sysview (noflash)


### PR DESCRIPTION
While building locally I didn’t notice that the component name changes when pulled from the registry. It is `esp_sysview` locally but `espressif__esp_sysview` from the registry. Because of this, the archive name hardcoded in linker.lf was incorrect. 

This PR introduces a template linker fragment file and configures it during the build. And adds missing c file to IRAM entries 