### PR TITLE
fix(led_strip): use IRAM_ATTR for RMT encoder functions (IEC-451)

### DIFF
--- a/led_strip/src/led_strip_rmt_encoder.c
+++ b/led_strip/src/led_strip_rmt_encoder.c
@@ -4,10 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "sdkconfig.h"
+#include "esp_idf_version.h"
 #include "esp_check.h"
+#include "esp_attr.h"
 #include "led_strip_rmt_encoder.h"
 
 static const char *TAG = "led_rmt_encoder";
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
+#if CONFIG_RMT_ISR_IRAM_SAFE
+#define RMT_ENCODER_FUNC_ATTR IRAM_ATTR
+#else
+#define RMT_ENCODER_FUNC_ATTR
+#endif // CONFIG_RMT_ISR_IRAM_SAFE
+#endif // ESP_IDF_VERSION
 
 typedef struct {
     rmt_encoder_t base;
@@ -17,6 +28,7 @@ typedef struct {
     rmt_symbol_word_t reset_code;
 } rmt_led_strip_encoder_t;
 
+RMT_ENCODER_FUNC_ATTR
 static size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
 {
     rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
@@ -62,6 +74,7 @@ static esp_err_t rmt_del_led_strip_encoder(rmt_encoder_t *encoder)
     return ESP_OK;
 }
 
+RMT_ENCODER_FUNC_ATTR
 static esp_err_t rmt_led_strip_encoder_reset(rmt_encoder_t *encoder)
 {
     rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

Closes https://github.com/espressif/idf-extra-components/issues/636

According to the [documentation](https://docs.espressif.com/projects/esp-idf/en/v5.5.1/esp32s3/api-reference/peripherals/rmt.html#cache-safe), the RMT encoder functions should have `IRAM_ATTR` when RMT ISR is placed in IRAM.

`RMT_ENCODER_FUNC_ATTR` has been introduced in ESP-IDF v5.5, so for earlier versions it is defined locally.
