### PR TITLE
network_provisioning: Fix prov-ctrl reset handler to return success (IEC-458)

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.2.1 (15-Dec-2025)
+
+- Fix prov-ctrl reset handler to return success when device is already in provisioning mode
+  - If firmware has already called `network_prov_mgr_reset_wifi_sm_state_on_failure()` or
+    `network_prov_mgr_reset_thread_sm_state_on_failure()`, the device state is already reset
+    to provisioning mode. The prov-ctrl handler now returns success in this case instead of
+    an invalid state error, allowing phone apps to successfully reset even if firmware has
+    already performed the reset operation.
+
 # 07-October-2025
 
 - Use managed cJSON component for IDF v6.0 and above

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.2.1"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:

--- a/network_provisioning/src/manager.c
+++ b/network_provisioning/src/manager.c
@@ -2350,6 +2350,13 @@ esp_err_t network_prov_mgr_reset_wifi_sm_state_on_failure(void)
     ACQUIRE_LOCK(prov_ctx_lock);
 
     esp_err_t err = ESP_OK;
+    /* If already in STARTED state, reset has already been performed (e.g., by firmware).
+     * Return success as the device is effectively already reset and in provisioning mode. */
+    if (prov_ctx->prov_state == NETWORK_PROV_STATE_STARTED) {
+        ESP_LOGD(TAG, "Reset already performed, device already in provisioning mode");
+        goto exit;
+    }
+
     if (prov_ctx->prov_state != NETWORK_PROV_STATE_FAIL) {
         ESP_LOGE(TAG, "Trying reset when not in failure state. Current state: %d", prov_ctx->prov_state);
         err = ESP_ERR_INVALID_STATE;
@@ -2448,6 +2455,13 @@ esp_err_t network_prov_mgr_reset_thread_sm_state_on_failure(void)
     otInstance *instance = esp_openthread_get_instance();
 
     esp_openthread_lock_acquire(portMAX_DELAY);
+    /* If already in STARTED state, reset has already been performed (e.g., by firmware).
+     * Return success as the device is effectively already reset and in provisioning mode. */
+    if (prov_ctx->prov_state == NETWORK_PROV_STATE_STARTED) {
+        ESP_LOGD(TAG, "Reset already performed, device already in provisioning mode");
+        goto exit;
+    }
+
     if (prov_ctx->prov_state != NETWORK_PROV_STATE_FAIL) {
         ESP_LOGE(TAG, "Trying reset when not in failure state. Current state: %d", prov_ctx->prov_state);
         err = ESP_ERR_INVALID_STATE;


### PR DESCRIPTION
when already in provisioning mode

# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
If firmware has already called network_prov_mgr_reset_wifi_sm_state_on_failure() or network_prov_mgr_reset_thread_sm_state_on_failure(), the device state is already reset to provisioning mode. The prov-ctrl handler now returns success in this case instead of an invalid state error, allowing phone apps to successfully reset even if the firmware has already performed the reset operation. Without this change, the phone apps get an error unnecessarily since they have no way to know if the firmware has called the reset.