### PR TITLE
fix(network_provisioning): reset connection attempts counter on state reset (IEC-459)

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.2 (18-Dec-2025)
+
+- Fix connection attempts counter not being reset on state reset or new credentials
+  - Reset `connection_attempts_completed` to 0 in `network_prov_mgr_reset_wifi_sm_state_on_failure()`
+    and `network_prov_mgr_configure_wifi_sta()` to ensure full `wifi_conn_attempts` retries
+    after reset or when applying new credentials.
+
 # 1.2.1 (15-Dec-2025)
 
 - Fix prov-ctrl reset handler to return success when device is already in provisioning mode

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.1"
+version: "1.2.2"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:

--- a/network_provisioning/src/manager.c
+++ b/network_provisioning/src/manager.c
@@ -1311,6 +1311,8 @@ esp_err_t network_prov_mgr_configure_wifi_sta(wifi_config_t *wifi_cfg)
 
     /* Reset Wi-Fi station state for provisioning app */
     prov_ctx->wifi_state = NETWORK_PROV_WIFI_STA_CONNECTING;
+    /* Reset connection attempts counter for new credentials */
+    prov_ctx->connection_attempts_completed = 0;
     prov_ctx->prov_state = NETWORK_PROV_STATE_CRED_RECV;
     /* Execute user registered callback handler */
     execute_event_cb(NETWORK_PROV_WIFI_CRED_RECV, (void *)&wifi_cfg->sta, sizeof(wifi_cfg->sta));
@@ -2371,6 +2373,8 @@ esp_err_t network_prov_mgr_reset_wifi_sm_state_on_failure(void)
         goto exit;
     }
 
+    /* Reset connection attempts counter to allow full wifi_conn_attempts retries */
+    prov_ctx->connection_attempts_completed = 0;
     prov_ctx->prov_state = NETWORK_PROV_STATE_STARTED;
 
 exit:


### PR DESCRIPTION

# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description

Reset connection_attempts_completed to 0 when resetting WiFi state machine or applying new credentials to ensure full wifi_conn_attempts retries. Without this change, for subsequent provisioning attempts, the firmware tries connection just once, instead of multiple times, as indicated by wifi_conn_attempts