### PR TITLE
Draft: feat: Add option to save WiFi credentials to flash only after successful connection (IEC-463)

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.2.3 (TBD)
+
+- Add option to store Wi-Fi credentials in RAM initially and save to flash only after successful connection
+  - New config option `CONFIG_NETWORK_PROV_WIFI_SAVE_CREDENTIALS_ON_SUCCESS` (disabled by default)
+  - When enabled, credentials are stored in RAM when received during provisioning to prevent invalid
+    credentials from persisting in flash if the device reboots before connection succeeds
+  - Credentials are saved to flash only after successful IP address assignment
+    (`IP_EVENT_STA_GOT_IP`), ensuring only valid credentials persist across reboots
+  - This prevents the issue where wrong credentials persist in flash if the device reboots
+    before `network_prov_mgr_reset_wifi_sm_state_on_failure()` is called
+  - Legacy behavior (save to flash immediately) is preserved when the option is disabled
+
 # 1.2.2 (18-Dec-2025)
 
 - Fix connection attempts counter not being reset on state reset or new credentials

--- a/network_provisioning/Kconfig
+++ b/network_provisioning/Kconfig
@@ -85,4 +85,16 @@ menu "Network Provisioning Manager"
             help
                     Scan will end after an AP matching with the SSID has been detected.
     endchoice
+
+    config NETWORK_PROV_WIFI_SAVE_CREDENTIALS_ON_SUCCESS
+        bool "Save Wi-Fi credentials to flash only after successful connection"
+        depends on NETWORK_PROV_NETWORK_TYPE_WIFI
+        default n
+        help
+            When enabled, Wi-Fi credentials are stored in RAM initially and saved to flash only
+            after successful connection (IP address assignment). This prevents invalid credentials
+            from persisting in flash if the device reboots before connection succeeds.
+
+            When disabled (default), credentials are saved to flash immediately when received,
+            matching the legacy behavior.
 endmenu

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.2"
+version: "1.2.3"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
- Add CONFIG_NETWORK_PROV_WIFI_SAVE_CREDENTIALS_ON_SUCCESS option (disabled by default)
- When enabled, credentials are stored in RAM initially and saved to flash only after IP_EVENT_STA_GOT_IP
- Prevents invalid credentials from persisting in flash if device reboots before connection succeeds
- Maintains backward compatibility with legacy behavior (save to flash immediately) when option is disabled
- Bump version to 1.2.3
