### PR TITLE
feat(esp_gcov): Extended idf_create_coverage_report() CMake function (IEC-462)

### DIFF
--- a/esp_gcov/project_include.cmake
+++ b/esp_gcov/project_include.cmake
@@ -1,23 +1,43 @@
 # idf_create_coverage_report
 #
 # Create coverage report.
+#
+# Arguments:
+#   report_dir - Directory where the coverage report will be generated
+#   SOURCE_DIR - (Optional) Source directory to use as root for gcovr.
+#                If not provided, defaults to PROJECT_DIR.
+#   GCOV_OPTIONS - (Optional) Additional options to pass to gcovr.
+#
+# Example:
+#   idf_create_coverage_report(${report_dir})  # Uses PROJECT_DIR
+#   idf_create_coverage_report(${report_dir} SOURCE_DIR ${component_dir})  # Uses custom source dir
+#   idf_create_coverage_report(${report_dir} GCOV_OPTIONS "--gcov-ignore-parse-errors=negative_hits.warn")
+#
 function(idf_create_coverage_report report_dir)
+    cmake_parse_arguments(ARG "" "SOURCE_DIR" "GCOV_OPTIONS" ${ARGN})
+
     set(gcov_tool ${_CMAKE_TOOLCHAIN_PREFIX}gcov)
-    idf_build_get_property(project_name PROJECT_NAME)
-    idf_build_get_property(project_dir PROJECT_DIR)
+
+    # Use provided SOURCE_DIR or default to PROJECT_DIR
+    if(ARG_SOURCE_DIR)
+        set(source_root_dir "${ARG_SOURCE_DIR}")
+    else()
+        idf_build_get_property(source_root_dir PROJECT_DIR)
+    endif()
 
     file(TO_NATIVE_PATH "${report_dir}" _report_dir)
-    file(TO_NATIVE_PATH "${project_dir}" _project_dir)
+    file(TO_NATIVE_PATH "${source_root_dir}" _source_root_dir)
     file(TO_NATIVE_PATH "${report_dir}/html/index.html" _index_path)
 
     add_custom_target(pre-cov-report
         COMMENT "Generating coverage report in: ${_report_dir}"
         COMMAND ${CMAKE_COMMAND} -E echo "Using gcov: ${gcov_tool}"
+        COMMAND ${CMAKE_COMMAND} -E echo "Source root: ${_source_root_dir}"
         COMMAND ${CMAKE_COMMAND} -E make_directory ${_report_dir}/html
         )
 
     add_custom_target(gcovr-report
-        COMMAND gcovr -r ${_project_dir} --gcov-executable ${gcov_tool} -s --html-details ${_index_path}
+        COMMAND gcovr -r ${_source_root_dir} --gcov-executable ${gcov_tool} ${ARG_GCOV_OPTIONS} -s --html-details ${_index_path}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS pre-cov-report
         )


### PR DESCRIPTION
feat(esp_gcov): Extended idf_create_coverage_report() CMake function

This commit extends the idf_create_coverage_report() function to accept the following optional arguments:
    - SOURCE_DIR: Source directory to use as root directory for gcovr. If it is not provided then the PROJECT_DIR is used as before
    - GCOV_OPTIONS: Additional gcovr arguments
