### PR TITLE
feat(esp_schedule): Add CRON expression support for schedule (IEC-465)

### DIFF
--- a/esp_schedule/Kconfig
+++ b/esp_schedule/Kconfig
@@ -17,4 +17,11 @@ menu "ESP Schedule Configuration"
             If disabled, ESP_SCHEDULE_TYPE_SUNRISE and ESP_SCHEDULE_TYPE_SUNSET
             will not be available.
 
+    config ESP_SCHEDULE_ENABLE_CRON_EXPR
+        bool "Enable cron expression schedules"
+        default n
+        help
+            Enable support for cron-like expressions (e.g. "0 9 * * *")
+            to define recurring schedules. Disable this to save code/heap
+            if cron-based scheduling is not needed.
 endmenu

--- a/esp_schedule/examples/get_started/README.md
+++ b/esp_schedule/examples/get_started/README.md
@@ -33,6 +33,13 @@ This example demonstrates how to use the ESP Schedule component to create differ
 - Supports both day-of-week patterns and specific date patterns for solar events
 - Requires `CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT=y` to be enabled
 
+### 5. CRON Expression Schedule (`ESP_SCHEDULE_ENABLE_CRON_EXPR`)
+- Enable `CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR=y`
+- Supports directly inputting a cron expression string
+- Cron fields order: `minute hour day-of-month month day-of-week` (5-field format)
+- Validate your expression with an online checker or unit test to avoid malformed schedules
+- Good for recurring jobs such as daily/weekly/monthly reports, maintenance, or notifications
+
 ## Features Demonstrated
 
 - **Schedule Creation**: How to create schedules with different trigger types
@@ -193,6 +200,7 @@ The example shows how to:
 3. **Check logs**: Look for schedule creation and trigger messages in the serial output
 4. **Solar schedules**: Ensure `CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT=y` is enabled and location coordinates are accurate
 5. **Daylight saving time**: Solar schedules automatically adjust for DST changes
+6. **CRON expression schedules**: Ensure `CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR=y` is enabled, and validate your cron string (e.g., with an online checker) to avoid malformed expressions.
 
 ### NVS Issues
 

--- a/esp_schedule/examples/get_started/main/esp_schedule_example_main.c
+++ b/esp_schedule/examples/get_started/main/esp_schedule_example_main.c
@@ -61,6 +61,16 @@ static void solar_callback(esp_schedule_handle_t handle, void *priv_data)
 }
 #endif // CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
 
+#ifdef CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR
+static void cron_expr_callback(esp_schedule_handle_t handle, void *priv_data)
+{
+    ESP_LOGI(TAG, "CRON expression schedule triggered! Data: %s", (char *)priv_data);
+
+    // Example: Cron expression schedule triggered, etc.
+    // Your application logic here
+}
+#endif // CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR
+
 static void timestamp_callback(esp_schedule_handle_t handle, uint32_t next_timestamp, void *priv_data)
 {
     time_t timestamp = (time_t)next_timestamp;
@@ -79,6 +89,9 @@ static char *relative_data = "Timer schedule";
 #ifdef CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
 static char *solar_data = "Sunrise/Sunset schedule";
 #endif // CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+#ifdef CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR
+static char *cron_expr_data = "CRON expression schedule";
+#endif // CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR
 
 /**
  * @brief Create example schedules
@@ -214,6 +227,29 @@ static void create_example_schedules(void)
         esp_schedule_enable(sunset_handle);
     }
 #endif // CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+
+    // Example 5: CRON expression schedule
+    // Note: This requires CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR to be enabled
+    // Triggers every day at every 10th minute
+#if CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR
+    esp_schedule_config_t cron_expr_schedule = {
+        .name = "cron_expr",
+        .trigger.type = ESP_SCHEDULE_TYPE_CRON_EXPR,
+        .trigger.cron_expr_str = "*/10 * * * *", // At every 10th minute
+        .trigger_cb = cron_expr_callback,
+        .timestamp_cb = timestamp_callback,
+        .priv_data = cron_expr_data,
+        .validity = {
+            .start_time = 0,  // Start immediately
+            .end_time = 0     // No end time
+        }
+    };
+    esp_schedule_handle_t cron_expr_handle = esp_schedule_create(&cron_expr_schedule);
+    if (cron_expr_handle) {
+        ESP_LOGI(TAG, "Created CRON expression schedule successfully");
+        esp_schedule_enable(cron_expr_handle);
+    }
+#endif // CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR
 }
 
 void app_main(void)

--- a/esp_schedule/examples/get_started/sdkconfig.defaults
+++ b/esp_schedule/examples/get_started/sdkconfig.defaults
@@ -5,3 +5,9 @@ CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT=y
 
 # Example can become pretty big, so enable larger partition
 CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y
+
+# Enable CRON Expression schedules for the example
+CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR=y
+
+# Temporary Fix for Timer Overflows
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3120

--- a/esp_schedule/idf_component.yml
+++ b/esp_schedule/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.3.2"
+version: "1.3.3"
 description: Task scheduling based on periodic and one-time events
 url: https://github.com/espressif/idf-extra-components/tree/master/components/esp_schedule
 repository: https://github.com/espressif/idf-extra-components.git
@@ -9,3 +9,6 @@ dependencies:
   espressif/esp_daylight:
     version: "~1.0.1"
     override_path: "../esp_daylight"
+  espressif/supertinycron:
+    version: "~2.0.0"
+    override_path: "../supertinycron"

--- a/esp_schedule/include/esp_schedule.h
+++ b/esp_schedule/include/esp_schedule.h
@@ -22,6 +22,9 @@ typedef void *esp_schedule_handle_t;
 /** Maximum length of the schedule name allowed. This value cannot be more than 16 as it is used for NVS key. */
 #define MAX_SCHEDULE_NAME_LEN 16
 
+/** Maximum length of the cron expression string allowed. */
+#define MAX_CRON_EXPR_STR_LEN 128
+
 /** Callback for schedule trigger
  *
  * This callback is called when the schedule is triggered.
@@ -51,6 +54,9 @@ typedef enum esp_schedule_type {
 #if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
     ESP_SCHEDULE_TYPE_SUNRISE,
     ESP_SCHEDULE_TYPE_SUNSET,
+#endif
+#if CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR
+    ESP_SCHEDULE_TYPE_CRON_EXPR,
 #endif
 } esp_schedule_type_t;
 
@@ -122,6 +128,11 @@ typedef struct esp_schedule_trigger {
         /** Offset in minutes from sunrise/sunset (positive = after, negative = before) */
         int offset_minutes;
     } solar;
+#endif
+#if CONFIG_ESP_SCHEDULE_ENABLE_CRON_EXPR
+    /** For type ESP_SCHEDULE_TYPE_CRON_EXPR */
+    /** CRON expression string */
+    char cron_expr_str[MAX_CRON_EXPR_STR_LEN + 1];
 #endif
     /** For type ESP_SCHEDULE_TYPE_SECONDS */
     int relative_seconds;


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description

- Add CRON expression support for schedule
