### PR TITLE
task(esp_gcov): Bump up esp_gcov version to 1.0.5 in idf_component.yml (IEC-466)

### DIFF
--- a/esp_gcov/idf_component.yml
+++ b/esp_gcov/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.4
+version: 1.0.5
 description: Gcov (Source Code Coverage) component for ESP-IDF
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_gcov
 issues: https://github.com/espressif/idf-extra-components/issues


### PR DESCRIPTION
This PR bumps up the `esp_gcov` version to `1.0.5` in the `idf_component.yml` file.
