### PR TITLE
feat(led_strip): WS2816 support for led_strip including 16-bit color (IEC-467)

### DIFF
--- a/led_strip/CHANGELOG.md
+++ b/led_strip/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.3
+
+- Support WS2816 with 16-bit color
+
 ## 3.0.1
 
 - Support WS2811 bit timing

--- a/led_strip/idf_component.yml
+++ b/led_strip/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.0.2"
+version: "3.0.3"
 description: Driver for Addressable LED Strip (WS2812, etc)
 url: https://github.com/espressif/idf-extra-components/tree/master/led_strip
 repository: https://github.com/espressif/idf-extra-components.git

--- a/led_strip/include/led_strip.h
+++ b/led_strip/include/led_strip.h
@@ -67,6 +67,22 @@ esp_err_t led_strip_set_pixel_rgbw(led_strip_handle_t strip, uint32_t index, uin
 esp_err_t led_strip_set_pixel_hsv(led_strip_handle_t strip, uint32_t index, uint16_t hue, uint8_t saturation, uint8_t value);
 
 /**
+ * @brief Set HSV for a specific pixel in 16-bit resolution
+ *
+ * @param strip: LED strip
+ * @param index: index of pixel to set
+ * @param hue: hue part of color (0 - 360)
+ * @param saturation: saturation part of color (0 - 65535, rescaled from 0 - 1. e.g. saturation = 0.5, rescaled to 32767)
+ * @param value: value part of color (0 - 65535, rescaled from 0 - 1. e.g. value = 0.5, rescaled to 32767)
+ *
+ * @return
+ *      - ESP_OK: Set HSV color for a specific pixel successfully
+ *      - ESP_ERR_INVALID_ARG: Set HSV color for a specific pixel failed because of an invalid argument
+ *      - ESP_FAIL: Set HSV color for a specific pixel failed because other error occurred
+ */
+esp_err_t led_strip_set_pixel_hsv_16(led_strip_handle_t strip, uint32_t index, uint16_t hue, uint16_t saturation, uint16_t value);
+
+/**
  * @brief Refresh memory colors to LEDs
  *
  * @param strip: LED strip

--- a/led_strip/include/led_strip_types.h
+++ b/led_strip/include/led_strip_types.h
@@ -24,6 +24,7 @@ typedef enum {
     LED_MODEL_WS2812, /*!< LED strip model: WS2812 */
     LED_MODEL_SK6812, /*!< LED strip model: SK6812 */
     LED_MODEL_WS2811, /*!< LED strip model: WS2811 */
+    LED_MODEL_WS2816, /*!< LED strip model: WS2816 */
     LED_MODEL_INVALID /*!< Invalid LED strip model */
 } led_model_t;
 
@@ -33,21 +34,26 @@ typedef enum {
  */
 typedef union {
     struct format_layout {
-        uint32_t r_pos: 2;          /*!< Position of the red channel in the color order: 0~3 */
-        uint32_t g_pos: 2;          /*!< Position of the green channel in the color order: 0~3 */
-        uint32_t b_pos: 2;          /*!< Position of the blue channel in the color order: 0~3 */
-        uint32_t w_pos: 2;          /*!< Position of the white channel in the color order: 0~3 */
-        uint32_t reserved: 21;      /*!< Reserved */
-        uint32_t num_components: 3; /*!< Number of color components per pixel: 3 or 4. If set to 0, it will fallback to 3 */
-    } format;                       /*!< Format layout */
-    uint32_t format_id;             /*!< Format ID */
+        uint32_t r_pos: 2;           /*!< Position of the red channel in the color order: 0~3 */
+        uint32_t g_pos: 2;           /*!< Position of the green channel in the color order: 0~3 */
+        uint32_t b_pos: 2;           /*!< Position of the blue channel in the color order: 0~3 */
+        uint32_t w_pos: 2;           /*!< Position of the white channel in the color order: 0~3 */
+        uint32_t reserved: 19;       /*!< Reserved */
+        uint32_t bytes_per_color: 2; /*!< Bytes per color component: 1 or 2. If set to 0, it will fallback to 1 */
+        uint32_t num_components: 3;  /*!< Number of color components per pixel: 3 or 4. If set to 0, it will fallback to 3 */
+    } format;                        /*!< Format layout */
+    uint32_t format_id;              /*!< Format ID */
 } led_color_component_format_t;
 
 /// Helper macros to set the color component format
-#define LED_STRIP_COLOR_COMPONENT_FMT_GRB (led_color_component_format_t){.format = {.r_pos = 1, .g_pos = 0, .b_pos = 2, .w_pos = 3, .reserved = 0, .num_components = 3}}
-#define LED_STRIP_COLOR_COMPONENT_FMT_GRBW (led_color_component_format_t){.format = {.r_pos = 1, .g_pos = 0, .b_pos = 2, .w_pos = 3, .reserved = 0, .num_components = 4}}
-#define LED_STRIP_COLOR_COMPONENT_FMT_RGB (led_color_component_format_t){.format = {.r_pos = 0, .g_pos = 1, .b_pos = 2, .w_pos = 3, .reserved = 0, .num_components = 3}}
-#define LED_STRIP_COLOR_COMPONENT_FMT_RGBW (led_color_component_format_t){.format = {.r_pos = 0, .g_pos = 1, .b_pos = 2, .w_pos = 3, .reserved = 0, .num_components = 4}}
+#define LED_STRIP_COLOR_COMPONENT_FMT_GRB (led_color_component_format_t){.format = {.r_pos = 1, .g_pos = 0, .b_pos = 2, .w_pos = 3, .reserved = 0, .bytes_per_color = 1, .num_components = 3}}
+#define LED_STRIP_COLOR_COMPONENT_FMT_GRB_16 (led_color_component_format_t){.format = {.r_pos = 1, .g_pos = 0, .b_pos = 2, .w_pos = 3, .reserved = 0, .bytes_per_color = 2, .num_components = 3}}
+#define LED_STRIP_COLOR_COMPONENT_FMT_GRBW (led_color_component_format_t){.format = {.r_pos = 1, .g_pos = 0, .b_pos = 2, .w_pos = 3, .reserved = 0, .bytes_per_color = 1, .num_components = 4}}
+#define LED_STRIP_COLOR_COMPONENT_FMT_GRBW_16 (led_color_component_format_t){.format = {.r_pos = 1, .g_pos = 0, .b_pos = 2, .w_pos = 3, .reserved = 0, .bytes_per_color = 2, .num_components = 4}}
+#define LED_STRIP_COLOR_COMPONENT_FMT_RGB (led_color_component_format_t){.format = {.r_pos = 0, .g_pos = 1, .b_pos = 2, .w_pos = 3, .reserved = 0, .bytes_per_color = 1, .num_components = 3}}
+#define LED_STRIP_COLOR_COMPONENT_FMT_RGB_16 (led_color_component_format_t){.format = {.r_pos = 0, .g_pos = 1, .b_pos = 2, .w_pos = 3, .reserved = 0, .bytes_per_color = 2, .num_components = 3}}
+#define LED_STRIP_COLOR_COMPONENT_FMT_RGBW (led_color_component_format_t){.format = {.r_pos = 0, .g_pos = 1, .b_pos = 2, .w_pos = 3, .reserved = 0, .bytes_per_color = 1, .num_components = 4}}
+#define LED_STRIP_COLOR_COMPONENT_FMT_RGBW_16 (led_color_component_format_t){.format = {.r_pos = 0, .g_pos = 1, .b_pos = 2, .w_pos = 3, .reserved = 0, .bytes_per_color = 2, .num_components = 4}}
 
 /**
  * @brief LED Strip common configurations

--- a/led_strip/src/led_strip_api.c
+++ b/led_strip/src/led_strip_api.c
@@ -25,7 +25,60 @@ esp_err_t led_strip_set_pixel_hsv(led_strip_handle_t strip, uint32_t index, uint
     uint32_t blue = 0;
 
     uint32_t rgb_max = value;
-    uint32_t rgb_min = rgb_max * (255 - saturation) / 255.0f;
+    uint32_t rgb_min = rgb_max * (255 - saturation) / 255;
+
+    uint32_t i = hue / 60;
+    uint32_t diff = hue % 60;
+
+    // RGB adjustment amount by hue
+    uint32_t rgb_adj = (rgb_max - rgb_min) * diff / 60;
+
+    switch (i) {
+    case 0:
+        red = rgb_max;
+        green = rgb_min + rgb_adj;
+        blue = rgb_min;
+        break;
+    case 1:
+        red = rgb_max - rgb_adj;
+        green = rgb_max;
+        blue = rgb_min;
+        break;
+    case 2:
+        red = rgb_min;
+        green = rgb_max;
+        blue = rgb_min + rgb_adj;
+        break;
+    case 3:
+        red = rgb_min;
+        green = rgb_max - rgb_adj;
+        blue = rgb_max;
+        break;
+    case 4:
+        red = rgb_min + rgb_adj;
+        green = rgb_min;
+        blue = rgb_max;
+        break;
+    default:
+        red = rgb_max;
+        green = rgb_min;
+        blue = rgb_max - rgb_adj;
+        break;
+    }
+
+    return strip->set_pixel(strip, index, red, green, blue);
+}
+
+esp_err_t led_strip_set_pixel_hsv_16(led_strip_handle_t strip, uint32_t index, uint16_t hue, uint16_t saturation, uint16_t value)
+{
+    ESP_RETURN_ON_FALSE(strip, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+
+    uint32_t red = 0;
+    uint32_t green = 0;
+    uint32_t blue = 0;
+
+    uint32_t rgb_max = value;
+    uint32_t rgb_min = rgb_max * (65535 - saturation) / 65535;
 
     uint32_t i = hue / 60;
     uint32_t diff = hue % 60;

--- a/led_strip/src/led_strip_rmt_encoder.c
+++ b/led_strip/src/led_strip_rmt_encoder.c
@@ -148,6 +148,23 @@ esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rm
             .flags.msb_first = 1
         };
         reset_ticks = config->resolution / 1000000 * 50 / 2; // divide by 2... signal is sent twice
+    } else if (config->led_model == LED_MODEL_WS2816) {
+        // different led strip might have its own timing requirements, following parameter is for WS2816
+        bytes_encoder_config = (rmt_bytes_encoder_config_t) {
+            .bit0 = {
+                .level0 = 1,
+                .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
+                .level1 = 0,
+                .duration1 = 0.95 * config->resolution / 1000000, // T0L=0.95us
+            },
+            .bit1 = {
+                .level0 = 1,
+                .duration0 = 0.75 * config->resolution / 1000000, // T1H=0.75us
+                .level1 = 0,
+                .duration1 = 0.5 * config->resolution / 1000000, // T1L=0.5us
+            },
+            .flags.msb_first = 1
+        };
     } else {
         assert(false);
     }


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
I've extended upon the led_strip package to allow for the WS2816 to work (including 16-bit color). No breaking changes required but did need an additional function for 16-bit HSV calculations because of it.
