### PR TITLE
change: adds CVE-2025-34468 to libcoap exclude list

### DIFF
--- a/coap/sbom_libcoap.yml
+++ b/coap/sbom_libcoap.yml
@@ -34,3 +34,5 @@ cve-exclude-list:
     reason: Resolved in version 4.3.5a
   - cve: CVE-2025-65501
     reason: Resolved in version 4.3.5a
+  - cve: CVE-2025-34468
+    reason: Resolved in version 4.3.5a


### PR DESCRIPTION
# Change description
A new CVE is reported with coap: [CVE-2025-34468](https://nvd.nist.gov/vuln/detail/CVE-2025-34468).

This was fixed with commit [30db3eaa1f0464722ebea2ca2d5084aebfbd344d](https://github.com/obgm/libcoap/commit/30db3ea) and is included in version [4.3.5a](https://github.com/obgm/libcoap/commits/v4.3.5a/).

This PR adds the CVE to exclude list for coap component
