### PR TITLE
Exclude 2 already resolved CVE:

### DIFF
--- a/libpng/sbom_libpng.yml
+++ b/libpng/sbom_libpng.yml
@@ -22,3 +22,7 @@ cve-exclude-list:
     reason: Resolved in version 1.6.54
   - cve: CVE-2026-22695
     reason: Resolved in version 1.6.54
+  - cve: CVE-2025-28164
+    reason: Resolved in version 1.6.47
+  - cve: CVE-2025-28162
+    reason: Resolved in version 1.6.47


### PR DESCRIPTION
This PR adds in 2 already resolved CVEs to `sbom_libpng.yml`

* [CVE-2025-28164](https://nvd.nist.gov/vuln/detail/CVE-2025-28164)
* [CVE-2025-28162](https://nvd.nist.gov/vuln/detail/CVE-2025-28162)

Both of these CVEs were resolved by https://github.com/pnggroup/libpng/pull/657 and integrated in [v1.6.47](https://github.com/pnggroup/libpng/commits/v1.6.47/)

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
