### PR TITLE
chore(esp_jpeg): Change maintenance to as-is

### DIFF
--- a/esp_jpeg/README.md
+++ b/esp_jpeg/README.md
@@ -1,7 +1,9 @@
 # JPEG Decoder: TJpgDec - Tiny JPEG Decompressor
 
 [![Component Registry](https://components.espressif.com/components/espressif/esp_jpeg/badge.svg)](https://components.espressif.com/components/espressif/esp_jpeg)
-![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
+![maintenance-status](https://img.shields.io/badge/maintenance-as--is-yellow.svg)
+
+:warning: **This driver is provided as-is. For new projects, it is recommended to use [esp_new_jpeg](https://components.espressif.com/components/espressif/esp_new_jpeg)**, which provides better performance and hardware JPEG decoder on supported targets.
 
 TJpgDec is a lightweight JPEG image decompressor optimized for embedded systems with minimal memory consumption.
 

--- a/esp_jpeg/idf_component.yml
+++ b/esp_jpeg/idf_component.yml
@@ -1,5 +1,8 @@
-version: "1.3.1"
+version: "1.3.1~1"
 description: "JPEG Decoder: TJpgDec"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_jpeg/
+repository: "https://github.com/espressif/idf-extra-components.git"
+repository_info:
+  path: "esp_jpeg"
 dependencies:
   idf: ">=5.0"


### PR DESCRIPTION
Change esp_jpeg maintenance status to as-is.

Users are advised to use esp_new_jpeg
