### PR TITLE
fix(touch_element): fixed the read stuck issue after deep sleep (IEC-484)

### DIFF
--- a/touch_element/CHANGELOG.md
+++ b/touch_element/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+- Fixed the read stuck issue after deep sleep by resetting the hardware while initializing
+
 ## 1.1.1
 
 - Fixed the incorrect interrupt mask

--- a/touch_element/idf_component.yml
+++ b/touch_element/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.1"
+version: "1.1.2"
 description: Touch Element Library
 url: https://github.com/espressif/idf-extra-components/tree/master/touch_element
 repository: https://github.com/espressif/idf-extra-components.git

--- a/touch_element/touch_sensor_legacy_hal.c
+++ b/touch_element/touch_sensor_legacy_hal.c
@@ -14,6 +14,7 @@ static int s_meas_times = -1;
 void touch_hal_init(void)
 {
     touch_ll_stop_fsm();
+    touch_ll_reset();   // Reset the touch sensor FSM.
     touch_ll_intr_disable((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_ALL);
     touch_ll_intr_clear((touch_pad_intr_mask_t)TOUCH_LL_INTR_MASK_ALL);
     touch_ll_clear_channel_mask(TOUCH_PAD_BIT_MASK_ALL);


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Fixed the read stuck issue after deep sleep by resetting the hardware while initializing
