### PR TITLE
feat(esp_sysview): adapt esp_trace usj transport type

### DIFF
--- a/esp_sysview/idf_component.yml
+++ b/esp_sysview/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.1
+version: 1.0.2
 description: SEGGER SystemView component for ESP-IDF
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_sysview
 issues: https://github.com/espressif/idf-extra-components/issues


### PR DESCRIPTION
A new USB Serial JTAG transport type has been introduced in the esp_trace component. Its write behavior and multi core event routing are identical to UART, so instead of adding another explicit check (== ESP_TRACE_LINK_USJ), the conditions are inverted to != ESP_TRACE_LINK_DEBUG_PROBE. This keeps the debug probe path explicit and makes the common path the default for all other transports, including any added in the future.