### PR TITLE
fix(thorvg): Strip quoted flags from response file for Meson compatibility

### DIFF
--- a/thorvg/CMakeLists.txt
+++ b/thorvg/CMakeLists.txt
@@ -70,6 +70,9 @@ function(expand_response_file input_flags output_var)
         separate_arguments(flags)
     endif()
     list(FILTER flags EXCLUDE REGEX "^$")
+    # Strip surrounding double quotes from each flag e.g. "-specs=path" -> -specs=path)
+    # Response files from ESP-IDF v6 may contain quoted flags which cause issues with Meson
+    list(TRANSFORM flags REPLACE "^\"(.*)\"$" "\\1")
     set(${output_var} ${flags} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION

Response files generated by ESP-IDF v6 may contain flags wrapped in double quotes (e.g. "-specs=path"). These quoted flags cause issues when passed to Meson. Strip surrounding quotes after parsing.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
