### PR TITLE
fix(esp_cli): update the call to on_exit in esp_cli()

### DIFF
--- a/esp_cli/idf_component.yml
+++ b/esp_cli/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.1"
+version: "0.1.2"
 description: "esp_cli — A command-line interface component that uses a REPL as its main execution loop."
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_cli
 dependencies:

--- a/esp_cli/src/esp_cli.c
+++ b/esp_cli/src/esp_cli.c
@@ -279,11 +279,11 @@ void esp_cli(esp_cli_handle_t handle)
     /* free the memory allocated for the cmd_line buffer */
     free(cmd_line);
 
-    /* release the semaphore to indicate esp_cli_stop that the esp_cli returned */
-    xSemaphoreGive(state->mux);
-
     /* call the on_exit callback before returning from esp_cli */
     if (config->on_exit.func != NULL) {
         config->on_exit.func(config->on_exit.ctx, handle);
     }
+
+    /* release the semaphore to indicate esp_cli_stop that the esp_cli returned */
+    xSemaphoreGive(state->mux);
 }


### PR DESCRIPTION
# Checklist

- [x] CI passing

# Change description
Make sure the on_exit function is called before the semaphore is released to make sure any operation done in the on_exit callback will be done before the esp_cli_stop returns.
