### PR TITLE
fix(esp_cli_commands): static analyzer warnings

### DIFF
--- a/esp_cli_commands/idf_component.yml
+++ b/esp_cli_commands/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.1"
+version: "0.1.2"
 description: "esp_cli_commands - Command handling component"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_cli_commands
 dependencies:

--- a/esp_cli_commands/private_include/esp_cli_dynamic_commands.h
+++ b/esp_cli_commands/private_include/esp_cli_dynamic_commands.h
@@ -110,12 +110,13 @@ esp_err_t esp_cli_dynamic_commands_add(esp_cli_command_t *cmd);
  *
  * If a command with the same name exists, it will be replaced.
  *
- * @param item_cmd Pointer to the new command data.
+ * @param old_cmd Pointer to the existing command to be replaced.
+ * @param new_cmd Pointer to the new command data.
  * @return
  *      - `ESP_OK` on success.
  *      - Appropriate error code on failure.
  */
-esp_err_t esp_cli_dynamic_commands_replace(esp_cli_command_t *item_cmd);
+esp_err_t esp_cli_dynamic_commands_replace(esp_cli_command_t *old_cmd, esp_cli_command_t *new_cmd);
 
 /**
  * @brief Remove a command from the dynamic command list.

--- a/esp_cli_commands/src/esp_cli_commands.c
+++ b/esp_cli_commands/src/esp_cli_commands.c
@@ -226,7 +226,7 @@ esp_err_t esp_cli_commands_register_cmd(esp_cli_command_t *cmd)
     } else {
         /* an item with matching name was found in the list of dynamically
          * registered commands. Replace the command on spot with the new esp_cli_command_t. */
-        ret_val = esp_cli_dynamic_commands_replace(cmd);
+        ret_val = esp_cli_dynamic_commands_replace(list_item_cmd, cmd);
     }
 
     return ret_val;
@@ -520,7 +520,8 @@ static bool call_completion_cb(void *caller_ctx, esp_cli_command_t *cmd)
     call_completion_cb_ctx_t *ctx = (call_completion_cb_ctx_t *)caller_ctx;
 
     /* Check if command starts with buf */
-    if (strncmp(ctx->buf, cmd->name, ctx->buf_len) == 0) {
+    if ((strlen(cmd->name) >= ctx->buf_len) &&
+            (strncmp(ctx->buf, cmd->name, ctx->buf_len) == 0)) {
         ctx->completion_cb(ctx->cb_ctx, cmd->name);
     }
     return true;

--- a/esp_cli_commands/src/esp_cli_dynamic_commands.c
+++ b/esp_cli_commands/src/esp_cli_dynamic_commands.c
@@ -87,12 +87,12 @@ esp_err_t esp_cli_dynamic_commands_add(esp_cli_command_t *cmd)
     return ESP_OK;
 }
 
-esp_err_t esp_cli_dynamic_commands_replace(esp_cli_command_t *item_cmd)
+esp_err_t esp_cli_dynamic_commands_replace(esp_cli_command_t *old_cmd, esp_cli_command_t *new_cmd)
 {
     esp_cli_dynamic_commands_lock();
 
-    esp_cli_command_internal_t *list_item = CONTAINER_OF(item_cmd, esp_cli_command_internal_t, cmd);
-    memcpy(&list_item->cmd, item_cmd, sizeof(esp_cli_command_t));
+    esp_cli_command_internal_t *list_item = CONTAINER_OF(old_cmd, esp_cli_command_internal_t, cmd);
+    memcpy(&list_item->cmd, new_cmd, sizeof(esp_cli_command_t));
 
     esp_cli_dynamic_commands_unlock();
 


### PR DESCRIPTION
# Checklist

- [x] CI passing

# Change description
- update call_completion_cb to make sure the buffer has a smaller size than the command name it compares to in the strncmp function call
- update esp_cli_dynamic_commands_replace to actually fetch the list item of the old command and copy the new command to override the old command
