### PR TITLE
fix(esp_linenoise): update code to fix static analyzer warning

### DIFF
--- a/esp_linenoise/idf_component.yml
+++ b/esp_linenoise/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.3"
+version: "1.0.4"
 description: "ESP Linenoise - Line editing C library"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_linenoise
 license: Apache-2.0

--- a/esp_linenoise/src/esp_linenoise.c
+++ b/esp_linenoise/src/esp_linenoise.c
@@ -1297,8 +1297,10 @@ void esp_linenoise_add_completion(void *ctx, const char *str)
         free(copy);
         return;
     }
+
+    cvec[lc->len] = copy;  // Store copy in new slot before updating struct
     lc->cvec = cvec;
-    lc->cvec[lc->len++] = copy;
+    lc->len++;
 }
 
 esp_err_t esp_linenoise_history_add(esp_linenoise_handle_t handle, const char *line)


### PR DESCRIPTION
# Checklist
- [x] CI passing

# Change description
- assign 'copy' in 'cvec' before assigning 'cvec' to 'lc->cvec' to prevent the static analyzer from thinking that 'copy' is leaked in esp_linenoise_add_completion function
