### PR TITLE
fix(esp_cli_commands): Help not visible when command_set used

### DIFF
--- a/esp_cli_commands/idf_component.yml
+++ b/esp_cli_commands/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.1.2"
+version: "0.1.3"
 description: "esp_cli_commands - Command handling component"
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_cli_commands
 dependencies:


### PR DESCRIPTION

# Checklist
- [x] CI passing

# Change description
when a command set is used in esp_cli config, the help command is not shown by the cli if not explicitly mentioned in the command set. Fix this by making sure help is always made available by esp_cli_commands APIs
