### PR TITLE
refactor(spi_nand_flash): Use esp_vfs_fat_register_cfg instead of esp_vfs_fat_register

### DIFF
--- a/spi_nand_flash/CHANGELOG.md
+++ b/spi_nand_flash/CHANGELOG.md
@@ -1,4 +1,8 @@
- ## [0.17.0]                                                                                                                                                                                                                                                                                                       
+## [0.18.0]                                                                                                                                                                                                                                                                                                       
+- fix: Update esp_vfs_fat_register prototype to esp_vfs_fat_register_cfg to align with ESP-IDF v6.0.
+       The cfg version is now the primary API and remains aliased for compatibility.
+
+## [0.17.0]                                                                                                                                                                                                                                                                                                       
 - fix: fix a compilation error caused by the missing freertos/FreeRTOS.h header when building with ESP-IDF v6.0 and later.
 - update: improvements to the lower-level APIs following updates in esp_driver_spi.
 

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.17.0"
+version: "0.18.0"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/vfs/vfs_fat_spinandflash.c
+++ b/spi_nand_flash/vfs/vfs_fat_spinandflash.c
@@ -38,8 +38,17 @@ esp_err_t esp_vfs_fat_nand_mount(const char *base_path, spi_nand_flash_device_t 
 
     ESP_GOTO_ON_ERROR(spi_nand_flash_get_sector_size(nand_device, &sector_size), fail, TAG, "");
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    esp_vfs_fat_conf_t conf = {
+        .base_path = base_path,
+        .fat_drive = drv,
+        .max_files = mount_config->max_files,
+    };
+    ESP_GOTO_ON_ERROR(esp_vfs_fat_register_cfg(&conf, &fs), fail, TAG, "esp_vfs_fat_register failed");
+#else
     ESP_GOTO_ON_ERROR(esp_vfs_fat_register(base_path, drv, mount_config->max_files, &fs),
                       fail, TAG, "esp_vfs_fat_register failed");
+#endif
 
     // Try to mount partition
     FRESULT fresult = f_mount(fs, drv, 1);


### PR DESCRIPTION
# Change description
The original esp_vfs_fat_register function prototype is getting changed for esp_vfs_fat_register_cfg in IDF v6.0 (breaking change), so esp_vfs_fat_register_cfg and esp_vfs_fat_register will be the same. esp_vfs_fat_register_cfg function will stay as an alias for esp_vfs_fat_register for now.

esp_vfs_fat_register_cfg is used everywhere in the IDF.
