### PR TITLE
change(freetype): exclude cve-2026-23865

### DIFF
--- a/freetype/sbom_freetype.yml
+++ b/freetype/sbom_freetype.yml
@@ -5,3 +5,6 @@ supplier: 'Organization: freetype <https://www.freetype.org>'
 description: FreeType is a software font engine
 url: https://github.com/freetype/freetype
 hash: f4205da14867c5387cd6a329b90ee10a6df6eeff
+cve-exclude-list:
+  - cve: CVE-2026-23865
+    reason: Fixed in version 2.14.2 with commit https://github.com/freetype/freetype/commit/fc85a255849229c024c8e65f536fe1875d84841c


### PR DESCRIPTION
# Change description
`freetype` was recently update to v2.14.2 with this [PR](https://github.com/espressif/idf-extra-components/pull/694), however even after the update, `esp-idf-sbom` still mentions [CVE-2026-23865](https://nvd.nist.gov/vuln/detail/CVE-2026-23865) (The CVE description mentions `Freetype`).

This PR adds `CVE-2026-23865` to the exclude list as it is fixed in the current version.
