### PR TITLE
fix(libsodium): disable GCC static analyzer for libsodium

### DIFF
--- a/libsodium/CMakeLists.txt
+++ b/libsodium/CMakeLists.txt
@@ -187,3 +187,9 @@ if(CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE)
     # some libsodium variables are only used for asserts
     target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-unused-but-set-variable)
 endif()
+
+if(CONFIG_COMPILER_STATIC_ANALYZER AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    # GCC's -fanalyzer causes the compiler to hang on libsodium's elliptic curve code
+    # due to combinatorial state explosion in the interprocedural analysis
+    target_compile_options(${COMPONENT_LIB} PRIVATE "-fno-analyzer")
+endif()

--- a/libsodium/idf_component.yml
+++ b/libsodium/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.20~4"
+version: "1.0.20~5"
 description: libsodium port to ESP
 url: https://github.com/espressif/idf-extra-components/tree/master/libsodium
 dependencies:


### PR DESCRIPTION
## Summary

- Adds `-fno-analyzer` compile option to the libsodium component when `CONFIG_COMPILER_STATIC_ANALYZER` is enabled with GCC
- GCC's `-fanalyzer` causes the compiler to hang indefinitely on libsodium's elliptic curve code (`ed25519_ref10.c`) due to combinatorial state explosion in the interprocedural analysis
- This is the same approach already used by ESP-IDF for mbedtls, wpa_supplicant, freertos, and other components

Closes https://github.com/espressif/esp-idf/issues/18373

## Test plan

- [x] Verified that without the fix, building a minimal project with `CONFIG_COMPILER_STATIC_ANALYZER=y` and `espressif/libsodium` dependency hangs indefinitely (GCC's `cc1` stuck at 100% CPU on `ed25519_ref10.c`)
- [x] Verified that with the fix, the same project compiles `ed25519_ref10.c` successfully and the build completes