### PR TITLE
fix(cjson): update to upstream master

### DIFF
--- a/cjson/idf_component.yml
+++ b/cjson/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.7.19~1"
+version: "1.7.19~2"
 description: "cJSON: Ultralightweight JSON parser in ANSI C"
 url: https://github.com/espressif/idf-extra-components/tree/master/cjson
 dependencies:

--- a/cjson/sbom_cJSON.yml
+++ b/cjson/sbom_cJSON.yml
@@ -6,4 +6,4 @@ cpe:
 supplier: 'Person: Dave Gamble'
 description: "cJSON: Ultralightweight JSON parser in ANSI C"
 url: https://github.com/DaveGamble/cJSON
-hash: c859b25da02955fef659d658b8f324b5cde87be3
+hash: b2890c8d76bbb64e710585ebc0a917196b9c67e7


### PR DESCRIPTION
Latest cJSON master includes some dos attack related fixes and hence the update.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
