### PR TITLE
fix(cbor): Fix build with picolibc (IEC-512)

### DIFF
--- a/cbor/CMakeLists.txt
+++ b/cbor/CMakeLists.txt
@@ -13,8 +13,13 @@ idf_component_register(SRCS "tinycbor/src/cborencoder_close_container_checked.c"
                     INCLUDE_DIRS "tinycbor/src")
 
 # for open_memstream.c
-set_source_files_properties(tinycbor/src/open_memstream.c PROPERTIES
-                            COMPILE_DEFINITIONS "__linux__")
+if(CONFIG_LIBC_PICOLIBC)
+        set_source_files_properties(tinycbor/src/open_memstream.c PROPERTIES
+                                COMPILE_DEFINITIONS "__APPLE__")
+else()
+        set_source_files_properties(tinycbor/src/open_memstream.c PROPERTIES
+                                COMPILE_DEFINITIONS "__linux__")
+endif()
 
 # Fix unreachable macro redefinition issue between ESP-IDF toolchain and tinycbor
 # by force-including a header that resolves the conflict


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
Build of project that uses `espressif/cbor^0.6.1~4` component and picolibc (with idf v6+) fails since picolibc does not have implementation of `fopencookie` function and `cookie_io_functions_t` typedef.

By defining `__APPLE__` we are switching to picolibc supported `funopen` alternative that makes project successfully compiled on idf v6+ using picolibc. Note that `CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY` still needs to be enabled to compile with picolibc, even if we switch to `__APPLE__`.

It would be nice if cbor component could work without defining `CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY` and rely completely on picolibc without any hacks.

I've opened a PR in origin tinycbor's repo as well to support picolibc, so maybe we will accomplish something:
https://github.com/intel/tinycbor/pull/319

Maybe to wait if intel's tinycbor is going to support picolibc...