### PR TITLE
test(spi_nand_flash): add FTL-level host tests via logical-sector and BDL APIs (IEC-515)

### DIFF
--- a/spi_nand_flash/host_test/main/CMakeLists.txt
+++ b/spi_nand_flash/host_test/main/CMakeLists.txt
@@ -4,6 +4,7 @@ if(CONFIG_NAND_FLASH_ENABLE_BDL)
     list(APPEND src "test_nand_flash_bdl.cpp")
 else()
     list(APPEND src "test_nand_flash.cpp")
+    list(APPEND src "test_nand_flash_ftl.cpp")
 endif()
 
 idf_component_register(SRCS ${src}

--- a/spi_nand_flash/host_test/main/test_nand_flash_bdl.cpp
+++ b/spi_nand_flash/host_test/main/test_nand_flash_bdl.cpp
@@ -1,11 +1,13 @@
 /*
- * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#include <cstdlib>
 
 #include "spi_nand_flash.h"
 #include "spi_nand_flash_test_helpers.h"
@@ -14,6 +16,31 @@
 #include "esp_nand_blockdev.h"
 
 #include <catch2/catch_test_macros.hpp>
+
+/* Linux mmap file: each page is k_page data + k_oob, so the file uses k_ppb * (k_page + k_oob)
+ * bytes per erase block. chip.block_size is k_ppb * k_page (same as real chips); num_blocks
+ * is file_size / (k_ppb * (k_page + k_oob)). BDL disk_size must be num_blocks * chip.block_size.
+ * Regression: storing the file stride in chip.block_size broke BDL erase decode. */
+TEST_CASE("BDL geometry matches Linux mmap file and chip.block_size", "[spi_nand_flash][bdl]")
+{
+    constexpr uint32_t k_file_bytes = 16u * 1024u * 1024u;
+    constexpr uint32_t k_page = 2048u;
+    constexpr uint32_t k_oob = 64u;
+    constexpr uint32_t k_ppb = 64u;
+    const uint32_t file_bytes_per_physical_block = k_ppb * (k_page + k_oob);
+    const uint32_t bdl_bytes_per_erase_block = k_ppb * k_page;
+    const uint32_t num_physical_blocks = k_file_bytes / file_bytes_per_physical_block;
+    const uint64_t expected_disk_size = (uint64_t)num_physical_blocks * bdl_bytes_per_erase_block;
+
+    nand_file_mmap_emul_config_t conf = {"", k_file_bytes, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+    REQUIRE(bdl->geometry.write_size == k_page);
+    REQUIRE(bdl->geometry.erase_size == bdl_bytes_per_erase_block);
+    REQUIRE(bdl->geometry.disk_size == expected_disk_size);
+    bdl->ops->release(bdl);
+}
 
 TEST_CASE("verify mark_bad_block works with bdl interface", "[spi_nand_flash][bdl]")
 {
@@ -240,3 +267,512 @@ TEST_CASE("Release and no use-after-free: create, release, create again, minimal
     bdl->ops->release(bdl);
 }
 
+TEST_CASE("Flash BDL last physical page write/read", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint64_t disk_size = bdl->geometry.disk_size;
+    const uint32_t num_pages = (uint32_t)(disk_size / page_size);
+    const uint32_t pages_per_block = block_size / page_size;
+    const uint32_t last_page = num_pages - 1u;
+    const uint32_t last_block = last_page / pages_per_block;
+    const uint64_t block_addr = (uint64_t)last_block * block_size;
+
+    REQUIRE(bdl->ops->erase(bdl, block_addr, block_size) == ESP_OK);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    const uint64_t last_off = (uint64_t)last_page * page_size;
+    REQUIRE(bdl->ops->write(bdl, w, last_off, page_size) == ESP_OK);
+    memset(r, 0, page_size);
+    REQUIRE(bdl->ops->read(bdl, r, page_size, last_off, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL 16 MiB full erase+program sweep then read-back all pages", "[spi_nand_flash][bdl][raw][sequential]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint64_t disk_size = bdl->geometry.disk_size;
+    const uint32_t num_blocks = (uint32_t)(disk_size / block_size);
+    const uint32_t pages_per_block = block_size / page_size;
+
+    for (uint32_t b = 0; b < num_blocks; b++) {
+        const uint64_t ba = (uint64_t)b * block_size;
+        REQUIRE(bdl->ops->erase(bdl, ba, block_size) == ESP_OK);
+        for (uint32_t i = 0; i < pages_per_block; i++) {
+            const uint32_t page = b * pages_per_block + i;
+            uint8_t *w = (uint8_t *)malloc(page_size);
+            REQUIRE(w != nullptr);
+            spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+            REQUIRE(bdl->ops->write(bdl, w, (uint64_t)page * page_size, page_size) == ESP_OK);
+            free(w);
+        }
+    }
+
+    const uint32_t num_pages = (uint32_t)(disk_size / page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(r != nullptr);
+    for (uint32_t page = 0; page < num_pages; page++) {
+        memset(r, 0, page_size);
+        REQUIRE(bdl->ops->read(bdl, r, page_size, (uint64_t)page * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL overwrite same physical page many times", "[spi_nand_flash][bdl][raw][stress]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    REQUIRE(bdl->ops->erase(bdl, 0, block_size) == ESP_OK);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    constexpr int kRounds = 150;
+    for (int i = 0; i < kRounds; i++) {
+        spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+        REQUIRE(bdl->ops->write(bdl, w, 0, page_size) == ESP_OK);
+    }
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    REQUIRE(bdl->ops->read(bdl, r, page_size, 0, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL multi-page write in one call", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint32_t n = 4;
+    REQUIRE(block_size >= n * page_size);
+
+    REQUIRE(bdl->ops->erase(bdl, 0, block_size) == ESP_OK);
+
+    const size_t total = (size_t)n * page_size;
+    uint8_t *w = (uint8_t *)malloc(total);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    for (uint32_t p = 0; p < n; p++) {
+        spi_nand_flash_fill_buffer(w + (size_t)p * page_size, page_size / sizeof(uint32_t));
+    }
+    REQUIRE(bdl->ops->write(bdl, w, 0, total) == ESP_OK);
+
+    for (uint32_t p = 0; p < n; p++) {
+        memset(r, 0, page_size);
+        REQUIRE(bdl->ops->read(bdl, r, page_size, (uint64_t)p * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL sub-page read and misaligned write rejected", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    REQUIRE(bdl->ops->erase(bdl, 0, block_size) == ESP_OK);
+
+    uint8_t *full = (uint8_t *)malloc(page_size);
+    uint8_t *slice = (uint8_t *)malloc(page_size);
+    REQUIRE(full != nullptr);
+    REQUIRE(slice != nullptr);
+    spi_nand_flash_fill_buffer(full, page_size / sizeof(uint32_t));
+    REQUIRE(bdl->ops->write(bdl, full, 0, page_size) == ESP_OK);
+
+    const size_t off = 64;
+    const size_t len = page_size - 128;
+    REQUIRE(off + len <= page_size);
+    memset(slice, 0, len);
+    REQUIRE(bdl->ops->read(bdl, slice, len, off, len) == ESP_OK);
+    REQUIRE(memcmp(slice, full + off, len) == 0);
+
+    REQUIRE(bdl->ops->write(bdl, full, 1, page_size) == ESP_ERR_INVALID_SIZE);
+
+    free(full);
+    free(slice);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL COPY_PAGE same page is idempotent", "[spi_nand_flash][bdl][raw][copy]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint32_t page = 3 * (block_size / page_size);
+
+    REQUIRE(bdl->ops->erase(bdl, (page / (block_size / page_size)) * (uint64_t)block_size, block_size) == ESP_OK);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    const uint64_t addr = (uint64_t)page * page_size;
+    REQUIRE(bdl->ops->write(bdl, w, addr, page_size) == ESP_OK);
+
+    esp_blockdev_cmd_arg_copy_page_t copy_cmd = {.src_page = page, .dst_page = page};
+    REQUIRE(bdl->ops->ioctl(bdl, ESP_BLOCKDEV_CMD_COPY_PAGE, &copy_cmd) == ESP_OK);
+
+    memset(r, 0, page_size);
+    REQUIRE(bdl->ops->read(bdl, r, page_size, addr, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL COPY_PAGE does not alter source page", "[spi_nand_flash][bdl][raw][copy]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint32_t ppb = block_size / page_size;
+    const uint32_t src_page = 2u * ppb;
+    const uint32_t dst_page = 2u * ppb + 1u;
+
+    REQUIRE(bdl->ops->erase(bdl, 2u * (uint64_t)block_size, block_size) == ESP_OK);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    REQUIRE(bdl->ops->write(bdl, w, (uint64_t)src_page * page_size, page_size) == ESP_OK);
+
+    esp_blockdev_cmd_arg_copy_page_t copy_cmd = {.src_page = src_page, .dst_page = dst_page};
+    REQUIRE(bdl->ops->ioctl(bdl, ESP_BLOCKDEV_CMD_COPY_PAGE, &copy_cmd) == ESP_OK);
+
+    memset(r, 0, page_size);
+    REQUIRE(bdl->ops->read(bdl, r, page_size, (uint64_t)src_page * page_size, page_size) == ESP_OK);
+    REQUIRE(memcmp(w, r, page_size) == 0);
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL invalid write/read geometry returns error", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint64_t disk = bdl->geometry.disk_size;
+    uint8_t *buf = (uint8_t *)malloc(page_size * 2);
+    REQUIRE(buf != nullptr);
+    spi_nand_flash_fill_buffer(buf, page_size / sizeof(uint32_t));
+
+    REQUIRE(bdl->ops->write(bdl, buf, page_size / 2u, page_size) == ESP_ERR_INVALID_SIZE);
+    if (page_size >= 512u) {
+        REQUIRE(bdl->ops->write(bdl, buf, 0, page_size / 2u) == ESP_ERR_INVALID_SIZE);
+    }
+
+    memset(buf, 0, page_size);
+    REQUIRE(bdl->ops->read(bdl, buf, page_size, disk, page_size) == ESP_ERR_INVALID_SIZE);
+    REQUIRE(bdl->ops->write(bdl, buf, disk, page_size) == ESP_ERR_INVALID_SIZE);
+
+    free(buf);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL GET_PAGE_ECC_STATUS and GET_ECC_STATS (small image)", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 4 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    REQUIRE(bdl->ops->erase(bdl, 0, block_size) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)malloc(page_size);
+    REQUIRE(buf != nullptr);
+    spi_nand_flash_fill_buffer(buf, page_size / sizeof(uint32_t));
+    REQUIRE(bdl->ops->write(bdl, buf, 0, page_size) == ESP_OK);
+
+    esp_blockdev_cmd_arg_ecc_status_t ecc_page = {};
+    ecc_page.page_num = 0;
+    REQUIRE(bdl->ops->ioctl(bdl, ESP_BLOCKDEV_CMD_GET_PAGE_ECC_STATUS, &ecc_page) == ESP_OK);
+
+    esp_blockdev_cmd_arg_ecc_stats_t ecc_stats = {};
+    REQUIRE(bdl->ops->ioctl(bdl, ESP_BLOCKDEV_CMD_GET_ECC_STATS, &ecc_stats) == ESP_OK);
+
+    free(buf);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("WL BDL sync after write preserves data", "[spi_nand_flash][bdl][wl]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    REQUIRE(wl_bdl->ops->write(wl_bdl, w, page_size, page_size) == ESP_OK);
+    REQUIRE(wl_bdl->ops->sync(wl_bdl) == ESP_OK);
+    memset(r, 0, page_size);
+    REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, page_size, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL MARK_DELETED then rewrite same logical page", "[spi_nand_flash][bdl][wl]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    const uint32_t page_index = 5;
+    const uint64_t off = (uint64_t)page_index * page_size;
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    memset(w, 0x22, page_size);
+    REQUIRE(wl_bdl->ops->write(wl_bdl, w, off, page_size) == ESP_OK);
+
+    esp_blockdev_cmd_arg_erase_t trim_arg = {.start_addr = off, .erase_len = page_size};
+    REQUIRE(wl_bdl->ops->ioctl(wl_bdl, ESP_BLOCKDEV_CMD_MARK_DELETED, &trim_arg) == ESP_OK);
+
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    REQUIRE(wl_bdl->ops->write(wl_bdl, w, off, page_size) == ESP_OK);
+    memset(r, 0, page_size);
+    REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, off, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL MARK_DELETED misaligned range returns ESP_ERR_INVALID_SIZE", "[spi_nand_flash][bdl][wl]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    esp_blockdev_cmd_arg_erase_t bad = {.start_addr = 1, .erase_len = page_size};
+    REQUIRE(wl_bdl->ops->ioctl(wl_bdl, ESP_BLOCKDEV_CMD_MARK_DELETED, &bad) == ESP_ERR_INVALID_SIZE);
+
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL 16 MiB sequential logical page fill and read-back", "[spi_nand_flash][bdl][wl][sequential]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    const uint32_t num_pages = (uint32_t)(wl_bdl->geometry.disk_size / page_size);
+    REQUIRE(wl_bdl->geometry.disk_size == (uint64_t)num_pages * page_size);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+
+    for (uint32_t p = 0; p < num_pages; p++) {
+        spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+        REQUIRE(wl_bdl->ops->write(wl_bdl, w, (uint64_t)p * page_size, page_size) == ESP_OK);
+    }
+    REQUIRE(wl_bdl->ops->sync(wl_bdl) == ESP_OK);
+
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(r != nullptr);
+    for (uint32_t p = 0; p < num_pages; p++) {
+        memset(r, 0, page_size);
+        REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, (uint64_t)p * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL hot-set random writes then read-back", "[spi_nand_flash][bdl][wl][stress]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    constexpr uint32_t kHotSetSize = 30u;
+    constexpr uint32_t kTotalWrites = 1200u;
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    const uint32_t num_pages = (uint32_t)(wl_bdl->geometry.disk_size / page_size);
+    REQUIRE(num_pages >= kHotSetSize);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    bool written[kHotSetSize] = {};
+
+    std::srand(0xDEADBEEFu);
+    for (uint32_t op = 0; op < kTotalWrites; op++) {
+        const uint32_t lp = (uint32_t)((unsigned)std::rand() % kHotSetSize);
+        spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+        REQUIRE(wl_bdl->ops->write(wl_bdl, w, (uint64_t)lp * page_size, page_size) == ESP_OK);
+        written[lp] = true;
+    }
+
+    REQUIRE(wl_bdl->ops->sync(wl_bdl) == ESP_OK);
+
+    for (uint32_t s = 0; s < kHotSetSize; s++) {
+        if (!written[s]) {
+            continue;
+        }
+        REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, (uint64_t)s * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL hot-set with interleaved MARK_DELETED", "[spi_nand_flash][bdl][wl][stress][trim]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    constexpr uint32_t kHotSetSize = 30u;
+    constexpr uint32_t kTotalWrites = 1200u;
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    const uint32_t num_pages = (uint32_t)(wl_bdl->geometry.disk_size / page_size);
+    REQUIRE(num_pages >= kHotSetSize);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    bool trimmed[kHotSetSize] = {};
+    bool written[kHotSetSize] = {};
+
+    std::srand(0xCAFEBABEu);
+    for (uint32_t op = 0; op < kTotalWrites; op++) {
+        const uint32_t lp = (uint32_t)((unsigned)std::rand() % kHotSetSize);
+
+        if (op % 100u == 99u) {
+            const uint32_t t = (uint32_t)((unsigned)std::rand() % kHotSetSize);
+            esp_blockdev_cmd_arg_erase_t trim_arg = {
+                .start_addr = (uint64_t)t * page_size,
+                .erase_len = page_size,
+            };
+            if (wl_bdl->ops->ioctl(wl_bdl, ESP_BLOCKDEV_CMD_MARK_DELETED, &trim_arg) == ESP_OK) {
+                trimmed[t] = true;
+            }
+        }
+
+        spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+        REQUIRE(wl_bdl->ops->write(wl_bdl, w, (uint64_t)lp * page_size, page_size) == ESP_OK);
+        trimmed[lp] = false;
+        written[lp] = true;
+    }
+
+    REQUIRE(wl_bdl->ops->sync(wl_bdl) == ESP_OK);
+
+    for (uint32_t s = 0; s < kHotSetSize; s++) {
+        if (trimmed[s] || !written[s]) {
+            continue;
+        }
+        REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, (uint64_t)s * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}

--- a/spi_nand_flash/host_test/main/test_nand_flash_ftl.cpp
+++ b/spi_nand_flash/host_test/main/test_nand_flash_ftl.cpp
@@ -1,0 +1,785 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * FTL-level host tests for spi_nand_flash.
+ *
+ * All tests exercise the public logical-sector API exclusively:
+ *   spi_nand_flash_write_sector / read_sector / copy_sector / trim /
+ *   sync / get_capacity / get_sector_size / get_block_size /
+ *   get_block_num / spi_nand_erase_chip
+ *
+ * Raw NAND page operations (nand_wrap_*) are intentionally NOT used here.
+ * See test_nand_flash.cpp for raw-level coverage.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "spi_nand_flash.h"
+#include "spi_nand_flash_test_helpers.h"
+#include "nand_linux_mmap_emul.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+/* -------------------------------------------------------------------------
+ * Fixture helpers
+ * ---------------------------------------------------------------------- */
+
+/** Default flash size used by most tests (16 MiB — fast init / GC pressure). */
+#define FTL_TEST_FLASH_SIZE  ((size_t)16u * 1024u * 1024u)
+
+/** Larger flash used for the full-capacity sequential sweep. */
+#define FTL_TEST_FLASH_LARGE ((size_t)32u * 1024u * 1024u)
+
+/**
+ * Open a fresh emulated NAND device backed by an anonymous temp file.
+ * gc_factor == 0 selects the driver default.
+ */
+static spi_nand_flash_device_t *make_ftl_dev(size_t flash_size = FTL_TEST_FLASH_SIZE,
+        uint8_t gc_factor = 0)
+{
+    nand_file_mmap_emul_config_t emul = {"", flash_size, /*keep_dump=*/false};
+    spi_nand_flash_config_t cfg = {&emul, gc_factor, SPI_NAND_IO_MODE_SIO, 0};
+    spi_nand_flash_device_t *dev = nullptr;
+    REQUIRE(spi_nand_flash_init_device(&cfg, &dev) == ESP_OK);
+    REQUIRE(dev != nullptr);
+    return dev;
+}
+
+static void destroy_ftl_dev(spi_nand_flash_device_t *dev)
+{
+    REQUIRE(spi_nand_flash_deinit_device(dev) == ESP_OK);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 1: Device info / capacity API
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL get_capacity returns non-zero sector count", "[ftl][info]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(sectors > 0);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL get_sector_size returns a power-of-two >= 512", "[ftl][info]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+    REQUIRE(sz >= 512u);
+    /* Must be a power of two */
+    REQUIRE((sz & (sz - 1u)) == 0u);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL get_block_size is a multiple of sector_size", "[ftl][info]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sector_size = 0, block_size = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sector_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_block_size(dev, &block_size) == ESP_OK);
+    REQUIRE(block_size > 0);
+    REQUIRE(block_size % sector_size == 0);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL get_block_num is consistent with capacity and block/sector sizes",
+          "[ftl][info]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0, sector_size = 0, block_size = 0, blocks = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sector_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_block_size(dev, &block_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_block_num(dev, &blocks) == ESP_OK);
+    REQUIRE(blocks > 0);
+    /* Total logical flash bytes derived from blocks must match capacity-derived bytes.
+     * Dhara reserves some blocks for GC, so the logical sector count is <= physical. */
+    uint32_t pages_per_block = block_size / sector_size;
+    REQUIRE(blocks * pages_per_block >= sectors);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 2: Single-sector write / read round-trip
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL write then read back sector 0 produces correct data", "[ftl][rw]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 0) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 0) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL write then read back last valid sector", "[ftl][rw]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    uint32_t last = sectors - 1u;
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, last) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, last) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL overwrite same sector multiple times, each read-back is correct",
+          "[ftl][rw]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    const uint32_t TARGET_SECTOR = 7;
+    const int OVERWRITE_ROUNDS = 20;
+
+    for (int i = 0; i < OVERWRITE_ROUNDS; i++) {
+        spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, TARGET_SECTOR) == ESP_OK);
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, TARGET_SECTOR) == ESP_OK);
+        REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL multiple sectors hold independent data after interleaved writes",
+          "[ftl][rw]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    const uint32_t N = 8;
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    /* Write each sector with the shared test pattern */
+    for (uint32_t s = 0; s < N; s++) {
+        spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, s) == ESP_OK);
+    }
+
+    /* Read them all back and verify the pattern */
+    for (uint32_t s = 0; s < N; s++) {
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, s) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(rbuf, sz / sizeof(uint32_t)) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 3: sync
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL sync returns ESP_OK on a freshly initialised device", "[ftl][sync]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL sync after writes returns ESP_OK and data survives", "[ftl][sync]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 3) == ESP_OK);
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 3) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 4: copy_sector
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL copy_sector duplicates data to a different logical sector",
+          "[ftl][copy]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 10) == ESP_OK);
+    REQUIRE(spi_nand_flash_copy_sector(dev, 10, 20) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 20) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL copy_sector to same sector id is idempotent", "[ftl][copy]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 5) == ESP_OK);
+    /* Copying a sector onto itself should succeed (or at least not corrupt) */
+    esp_err_t rc = spi_nand_flash_copy_sector(dev, 5, 5);
+    /* Behaviour is either ESP_OK or a graceful error — must not crash */
+    if (rc == ESP_OK) {
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 5) == ESP_OK);
+        REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+    }
+    /* If it returned an error that is also acceptable — just must not corrupt data */
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL copy does not alter source sector data", "[ftl][copy]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 11) == ESP_OK);
+    REQUIRE(spi_nand_flash_copy_sector(dev, 11, 22) == ESP_OK);
+
+    /* Source must be unchanged */
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 11) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 5: trim
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL trim returns ESP_OK on a written sector", "[ftl][trim]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)malloc(sz);
+    REQUIRE(buf != nullptr);
+    memset(buf, 0xAB, sz);
+
+    REQUIRE(spi_nand_flash_write_sector(dev, buf, 4) == ESP_OK);
+    REQUIRE(spi_nand_flash_trim(dev, 4) == ESP_OK);
+
+    free(buf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL trim then write to the same sector succeeds", "[ftl][trim]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    memset(wbuf, 0x11, sz);
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 6) == ESP_OK);
+    REQUIRE(spi_nand_flash_trim(dev, 6) == ESP_OK);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 6) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 6) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL trim on unwritten sector returns ESP_OK", "[ftl][trim]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    /* Sector 9 has never been written — trim should still succeed gracefully */
+    REQUIRE(spi_nand_flash_trim(dev, 9) == ESP_OK);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 6: erase_chip
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL erase_chip succeeds and write/read works afterwards",
+          "[ftl][erase-chip]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    /* Write something before the chip erase */
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 0) == ESP_OK);
+
+    REQUIRE(spi_nand_erase_chip(dev) == ESP_OK);
+
+    /* After erase the FTL must accept new writes */
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 0) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 0) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 7: Logical sector IDs beyond capacity
+ *
+ * NOTE: Dhara does NOT bounds-check logical sector IDs at the FTL level.
+ * Writing or reading beyond the reported capacity succeeds (returns ESP_OK)
+ * rather than returning an error.  These tests document that observed
+ * behaviour so that any future change in Dhara that adds bounds-checking
+ * will be caught explicitly.
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL write to sector_id == capacity succeeds",
+          "[ftl][bounds]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)calloc(1, sz);
+    REQUIRE(buf != nullptr);
+
+    /* Dhara does not validate the sector ID — expect success, not an error. */
+    esp_err_t rc = spi_nand_flash_write_sector(dev, buf, sectors);
+    REQUIRE(rc == ESP_OK);
+
+    free(buf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL read from sector_id == capacity succeeds",
+          "[ftl][bounds]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)calloc(1, sz);
+    REQUIRE(buf != nullptr);
+
+    /* Dhara does not validate the sector ID — expect success, not an error. */
+    esp_err_t rc = spi_nand_flash_read_sector(dev, buf, sectors);
+    REQUIRE(rc == ESP_OK);
+
+    free(buf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL write to UINT32_MAX sector_id succeeds",
+          "[ftl][bounds]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)calloc(1, sz);
+    REQUIRE(buf != nullptr);
+
+    /* Dhara does not validate the sector ID — expect success, not an error. */
+    esp_err_t rc = spi_nand_flash_write_sector(dev, buf, UINT32_MAX);
+    REQUIRE(rc == ESP_OK);
+
+    free(buf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 8: Sequential full-capacity write sweep
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL sequential write to every logical sector, then read-back all",
+          "[ftl][sequential]")
+{
+    /* Use larger flash so we have a meaningful number of logical sectors */
+    spi_nand_flash_device_t *dev = make_ftl_dev(FTL_TEST_FLASH_LARGE);
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    /* Write pass */
+    for (uint32_t s = 0; s < sectors; s++) {
+        spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, s) == ESP_OK);
+    }
+
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+
+    /* Verify capacity has not changed */
+    uint32_t sectors_after = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors_after) == ESP_OK);
+    REQUIRE(sectors_after == sectors);
+
+    /* Read-back pass */
+    for (uint32_t s = 0; s < sectors; s++) {
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, s) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(rbuf, sz / sizeof(uint32_t)) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 9: GC stability — hot-set repeated overwrites
+ *
+ * Write to a small set of logical sectors (HOT_SET_SIZE) many times
+ * (TOTAL_WRITES).  This forces Dhara to perform garbage collection
+ * repeatedly.  Asserts:
+ *   1. Every write returns ESP_OK.
+ *   2. After the run, get_capacity() still returns the original value.
+ *   3. Each sector in the hot-set reads back the last value written.
+ *   4. spi_nand_flash_sync() returns ESP_OK.
+ * ---------------------------------------------------------------------- */
+
+#define HOT_SET_SIZE  50u
+#define TOTAL_WRITES  5000u
+
+TEST_CASE("FTL GC stability: 50-sector hot-set written 5000 times",
+          "[ftl][gc][stability]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    /* The hot-set must fit within the device's logical address space */
+    REQUIRE(sectors >= HOT_SET_SIZE);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    bool written[HOT_SET_SIZE] = {};
+
+    srand(0xDEADBEEFu); /* reproducible */
+
+    for (uint32_t op = 0; op < TOTAL_WRITES; op++) {
+        uint32_t lsector = (uint32_t)((unsigned)rand() % HOT_SET_SIZE);
+        spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, lsector) == ESP_OK);
+        written[lsector] = true;
+    }
+
+    /* Capacity must be unchanged — the Dhara map must not have grown OOB */
+    uint32_t sectors_after = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors_after) == ESP_OK);
+    REQUIRE(sectors_after == sectors);
+
+    /* Flush any in-memory state */
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+
+    /* Every hot sector must read back the last write's pattern */
+    for (uint32_t s = 0; s < HOT_SET_SIZE; s++) {
+        if (!written[s]) {
+            continue; /* rand() never selected this logical sector */
+        }
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, s) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(rbuf, sz / sizeof(uint32_t)) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL GC stability with trim: hot-set with interleaved trims",
+          "[ftl][gc][trim][stability]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+    REQUIRE(sectors >= HOT_SET_SIZE);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    bool trimmed[HOT_SET_SIZE] = {};
+    bool written[HOT_SET_SIZE] = {};
+
+    srand(0xCAFEBABEu);
+
+    for (uint32_t op = 0; op < TOTAL_WRITES; op++) {
+        uint32_t lsector = (uint32_t)((unsigned)rand() % HOT_SET_SIZE);
+
+        /* Every 100 ops trim a random sector in the hot-set */
+        if (op % 100 == 99) {
+            uint32_t t = (uint32_t)((unsigned)rand() % HOT_SET_SIZE);
+            if (spi_nand_flash_trim(dev, t) == ESP_OK) {
+                trimmed[t] = true;
+            }
+        }
+
+        spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, lsector) == ESP_OK);
+        trimmed[lsector] = false;
+        written[lsector] = true;
+    }
+
+    uint32_t sectors_after = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors_after) == ESP_OK);
+    REQUIRE(sectors_after == sectors);
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+
+    /* Verify untrimmed sectors */
+    for (uint32_t s = 0; s < HOT_SET_SIZE; s++) {
+        if (trimmed[s] || !written[s]) {
+            continue; /* skip trimmed or never-written */
+        }
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, s) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(rbuf, sz / sizeof(uint32_t)) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 10: Single-sector hammer — one sector written thousands of times
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL single sector written 2000 times stays readable and correct",
+          "[ftl][gc][hammer]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    const uint32_t TARGET = 0;
+    const uint32_t ROUNDS = 2000;
+
+    for (uint32_t i = 0; i < ROUNDS; i++) {
+        spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, TARGET) == ESP_OK);
+    }
+
+    /* Final read must reflect the last write */
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, TARGET) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 11: Alternating write / read pattern
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL alternating write-read on two sectors never corrupts either",
+          "[ftl][rw][alternating]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    const uint32_t ITERS = 500;
+
+    for (uint32_t i = 0; i < ITERS; i++) {
+        /* Write A, then read B, then write B, then read A */
+        spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 1) == ESP_OK);
+
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 2) == ESP_OK);
+        if (i > 0) {
+            REQUIRE(spi_nand_flash_check_buffer(rbuf, sz / sizeof(uint32_t)) == 0);
+        }
+
+        spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 2) == ESP_OK);
+
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 1) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(rbuf, sz / sizeof(uint32_t)) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 12: All-zeros and all-ones patterns (edge-case data values)
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL write/read all-zeros pattern", "[ftl][rw][patterns]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)calloc(1, sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(buf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    REQUIRE(spi_nand_flash_write_sector(dev, buf, 0) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 0) == ESP_OK);
+    REQUIRE(memcmp(buf, rbuf, sz) == 0);
+
+    free(buf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL write/read all-0xFF pattern", "[ftl][rw][patterns]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf  = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(buf != nullptr);
+    REQUIRE(rbuf != nullptr);
+    memset(buf, 0xFF, sz);
+
+    REQUIRE(spi_nand_flash_write_sector(dev, buf, 1) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 1) == ESP_OK);
+    REQUIRE(memcmp(buf, rbuf, sz) == 0);
+
+    free(buf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL write/read alternating 0xAA/0x55 pattern", "[ftl][rw][patterns]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf  = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(buf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    for (size_t i = 0; i < sz; i++) {
+        buf[i] = (i & 1u) ? 0x55u : 0xAAu;
+    }
+
+    REQUIRE(spi_nand_flash_write_sector(dev, buf, 2) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 2) == ESP_OK);
+    REQUIRE(memcmp(buf, rbuf, sz) == 0);
+
+    free(buf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}

--- a/spi_nand_flash/src/nand_impl_linux.c
+++ b/spi_nand_flash/src/nand_impl_linux.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <inttypes.h>
+#include <stdint.h>
 #include <string.h>
 #include "esp_check.h"
 #include "esp_err.h"
@@ -12,6 +14,22 @@
 #include "nand_linux_mmap_emul.h"
 
 static const char *TAG = "nand_linux";
+
+/* Start of erase block `block` in the mmap file: ppb slots of (data + OOB) per page. */
+static esp_err_t linux_mmap_block_file_offset(const spi_nand_flash_device_t *h, uint32_t block, size_t *out_offset)
+{
+    ESP_RETURN_ON_FALSE(out_offset != NULL, ESP_ERR_INVALID_ARG, TAG, "out_offset is NULL");
+    ESP_RETURN_ON_FALSE(h->chip.num_blocks > 0, ESP_ERR_INVALID_STATE, TAG, "num_blocks is 0");
+    ESP_RETURN_ON_FALSE(block < h->chip.num_blocks, ESP_ERR_INVALID_ARG, TAG, "block index out of range");
+
+    const uint64_t ppb = 1ull << h->chip.log2_ppb;
+    const uint64_t bytes_per_block = ppb * (uint64_t)h->chip.emulated_page_size;
+    const uint64_t off = (uint64_t)block * bytes_per_block;
+
+    ESP_RETURN_ON_FALSE(off <= (uint64_t)SIZE_MAX, ESP_ERR_INVALID_SIZE, TAG, "mmap block offset overflow");
+    *out_offset = (size_t)off;
+    return ESP_OK;
+}
 
 static esp_err_t detect_chip(spi_nand_flash_device_t *dev)
 {
@@ -31,15 +49,19 @@ static esp_err_t detect_chip(spi_nand_flash_device_t *dev)
         dev->chip.emulated_page_oob = 128;
     }
     dev->chip.emulated_page_size = dev->chip.page_size + dev->chip.emulated_page_oob;
-    dev->chip.block_size = (1 << dev->chip.log2_ppb) * dev->chip.emulated_page_size;
+    /* chip.block_size: user-visible data per erase block (matches nand_impl.c / BDL).
+     * File layout interleaves OOB after each page; use file_bytes_per_block for num_blocks
+     * and linux_mmap_block_file_offset() for mmap byte addresses. */
+    dev->chip.block_size = (1u << dev->chip.log2_ppb) * dev->chip.page_size;
+    const uint32_t file_bytes_per_block = (1u << dev->chip.log2_ppb) * dev->chip.emulated_page_size;
 
-    if (dev->chip.block_size == 0) {
+    if (dev->chip.block_size == 0 || file_bytes_per_block == 0) {
         ESP_LOGE(TAG, "Invalid block size (0)");
         ret = ESP_ERR_INVALID_SIZE;
         goto fail;
     }
 
-    dev->chip.num_blocks = config->emul_conf->flash_file_size / dev->chip.block_size;
+    dev->chip.num_blocks = config->emul_conf->flash_file_size / file_bytes_per_block;
     dev->chip.erase_block_delay_us = 3000;
     dev->chip.program_page_delay_us = 630;
     dev->chip.read_page_delay_us = 60;
@@ -75,7 +97,6 @@ esp_err_t nand_init_device(spi_nand_flash_config_t *config, spi_nand_flash_devic
     (*handle)->chip.page_size = 1 << (*handle)->chip.log2_page_size;
     (*handle)->chip.block_size = (1 << (*handle)->chip.log2_ppb) * (*handle)->chip.page_size;
 
-
     ESP_GOTO_ON_ERROR(detect_chip(*handle), fail, TAG, "Failed to detect nand chip");
 
     (*handle)->work_buffer = heap_caps_malloc((*handle)->chip.page_size, MALLOC_CAP_DEFAULT);
@@ -106,13 +127,15 @@ esp_err_t nand_is_bad(spi_nand_flash_device_t *handle, uint32_t block, bool *is_
 {
     uint16_t bad_block_indicator = 0xFFFF;
     esp_err_t ret = ESP_OK;
-    uint32_t block_offset = block * handle->chip.block_size;
+    size_t block_offset = 0;
+
+    ESP_RETURN_ON_ERROR(linux_mmap_block_file_offset(handle, block, &block_offset), TAG, "nand_is_bad: mmap block offset failed");
 
     // Read the first 2 bytes on the OOB of the first page in the block. This should be 0xFFFF for a good block
     ESP_RETURN_ON_ERROR(nand_emul_read(handle, block_offset + handle->chip.page_size, (uint8_t *) &bad_block_indicator, 2),
                         TAG, "Error in nand_is_bad %d", ret);
 
-    ESP_LOGD(TAG, "is_bad, block=%"PRIu32", page=%"PRIu32",indicator = %04x", block, block_offset, bad_block_indicator);
+    ESP_LOGD(TAG, "is_bad, block=%"PRIu32", file_off=%zu,indicator = %04x", block, block_offset, bad_block_indicator);
     *is_bad_status = bad_block_indicator != 0xFFFF;
     return ret;
 }
@@ -120,14 +143,16 @@ esp_err_t nand_is_bad(spi_nand_flash_device_t *handle, uint32_t block, bool *is_
 esp_err_t nand_mark_bad(spi_nand_flash_device_t *handle, uint32_t block)
 {
     esp_err_t ret = ESP_OK;
+    size_t block_base = 0;
 
-    uint32_t first_block_page = block * (1 << handle->chip.log2_ppb);
+    uint64_t first_block_page = (uint64_t)block * (1ull << handle->chip.log2_ppb);
     uint16_t bad_block_indicator = 0;
-    ESP_LOGD(TAG, "mark_bad, block=%"PRIu32", page=%"PRIu32",indicator = %04x", block, first_block_page, bad_block_indicator);
+    ESP_LOGD(TAG, "mark_bad, block=%"PRIu32", first_page=%"PRIu64",indicator = %04x", block, first_block_page, bad_block_indicator);
 
-    ESP_RETURN_ON_ERROR(nand_emul_erase_block(handle, block * handle->chip.block_size), TAG, "Error in nand_mark_bad %d", ret);
+    ESP_RETURN_ON_ERROR(linux_mmap_block_file_offset(handle, block, &block_base), TAG, "nand_mark_bad: mmap block offset failed");
+    ESP_RETURN_ON_ERROR(nand_emul_erase_block(handle, block_base), TAG, "Error in nand_mark_bad %d", ret);
 
-    ESP_RETURN_ON_ERROR(nand_emul_write(handle, block * handle->chip.block_size + handle->chip.page_size,
+    ESP_RETURN_ON_ERROR(nand_emul_write(handle, block_base + handle->chip.page_size,
                                         (const uint8_t *) &bad_block_indicator, 2), TAG, "Error in nand_mark_bad %d", ret);
 
     return ret;
@@ -137,8 +162,9 @@ esp_err_t nand_erase_block(spi_nand_flash_device_t *handle, uint32_t block)
 {
     ESP_LOGD(TAG, "erase_block, block=%"PRIu32",", block);
     esp_err_t ret = ESP_OK;
+    size_t address = 0;
 
-    uint32_t address = block * handle->chip.block_size;
+    ESP_RETURN_ON_ERROR(linux_mmap_block_file_offset(handle, block, &address), TAG, "nand_erase_block: mmap block offset failed");
 
     ESP_RETURN_ON_ERROR(nand_emul_erase_block(handle, address), TAG, "Error in nand_erase %x", ret);
     return ESP_OK;

--- a/spi_nand_flash/src/nand_linux_mmap_emul.c
+++ b/spi_nand_flash/src/nand_linux_mmap_emul.c
@@ -196,12 +196,14 @@ esp_err_t nand_emul_erase_block(spi_nand_flash_device_t *handle, size_t offset)
         return ESP_ERR_INVALID_STATE;
     }
 
-    if (offset + handle->chip.block_size > emul_handle->file_mmap_ctrl.flash_file_size) {
+    const size_t nbytes = (size_t)(1u << handle->chip.log2_ppb) * (size_t)handle->chip.emulated_page_size;
+
+    if (offset + nbytes > emul_handle->file_mmap_ctrl.flash_file_size) {
         return ESP_ERR_INVALID_SIZE;
     }
 
     void *dst_addr = emul_handle->mem_file_buf + offset;
-    memset(dst_addr, 0xFF,  handle->chip.block_size);
+    memset(dst_addr, 0xFF, nbytes);
 
 #ifdef CONFIG_NAND_ENABLE_STATS
     emul_handle->stats.erase_ops++;


### PR DESCRIPTION
## spi_nand_flash: Linux mmap fix, FTL host tests, and BDL host tests

This PR contains three commits (oldest first):

1. **`test(spi_nand_flash): add FTL-level host tests via logical-sector API`** — adds `host_test/main/test_nand_flash_ftl.cpp` (~785 lines, 28 Catch2 cases) and wires it in `host_test/main/CMakeLists.txt`. Exercises the public logical-sector API on the Linux mmap emulator without going through raw NAND page paths (those stay in `test_nand_flash.cpp`).

2. **`test(spi_nand_flash): add comprehensive BDL tests for write/read operations`** — extends `host_test/main/test_nand_flash_bdl.cpp` with a large set of Block Device Layer cases (~778 lines total in tree, ~537 lines added in that commit), covering Flash BDL and WL BDL geometry, IOCTLs, error paths, sequential/stress workloads, and raw-page behaviour behind BDL.

3. **`fix(spi_nand_flash): correct Linux emulator block-size and mmap offset calculation`** — fixes `nand_impl_linux.c` and `nand_linux_mmap_emul.c`: `chip.block_size` must be user-visible data only (`ppb * page_size`), not data+OOB. Adds `linux_mmap_block_file_offset()` so file layout (page slot = `page_size` + OOB) matches what `nand_is_bad` / `nand_mark_bad` / `nand_erase_block` and `nand_emul_erase_block` expect, so bad-block handling and erase clear the full emulated block including OOB.

**Why the tests:** FTL-level coverage gives a baseline for Dhara/FTL/WL experiments without hardware. BDL coverage validates the block-device path (including wear-levelling integration) on the same Linux emulator. The mmap fix aligns the emulator with the rest of the stack so those tests exercise correct geometry and file offsets.