### PR TITLE
feat(esp_prov): add --ble_adapter option for HCI adapter selection

### DIFF
--- a/network_provisioning/tool/esp_prov/README.md
+++ b/network_provisioning/tool/esp_prov/README.md
@@ -89,6 +89,11 @@ python esp_prov.py --transport < mode of provisioning : softap \ ble \ console >
 * `--reprov` (Optional)
     - Resets internal state machine of the device and clears provisioned credentials; to be used only in case the device is to be provisioned again for new credentials after a previous successful provisioning
 
+* `--ble_adapter <HCI adapter>` (Optional)
+    - For specifying the HCI adapter to use for Bluetooth LE transport (default: `hci0`).
+    - Useful when working with `vhci_bridge` for emulated devices, e.g. `--ble_adapter hci1`.
+    - Only relevant when transport mode is `ble`
+
 * `--custom_data <some string>` (Optional)
     An information string can be sent to the `custom-data` endpoint during provisioning using this argument.
     (Assumes the provisioning app has an endpoint called `custom-data` - see [wifi_prov](../../examples/wifi_prov/) example for implementation details).

--- a/network_provisioning/tool/esp_prov/esp_prov.py
+++ b/network_provisioning/tool/esp_prov/esp_prov.py
@@ -59,7 +59,7 @@ def get_thread_dataset_tlvs(network_info, network_key):
     return dataset_tlvs
 
 
-async def get_transport(sel_transport, service_name):
+async def get_transport(sel_transport, service_name, ble_adapter=transport.DEFAULT_BLE_ADAPTER):
     try:
         tp = None
         if (sel_transport in ['softap', 'httpd']):
@@ -76,7 +76,7 @@ async def get_transport(sel_transport, service_name):
             # will fallback to using the provided UUIDs instead
             nu_lookup = {'prov-session': 'ff51', 'prov-config': 'ff52', 'proto-ver': 'ff53'}
             tp = transport.Transport_BLE(service_uuid='021a9004-0382-4aea-bff4-6b3f1c5adfb4',
-                                         nu_lookup=nu_lookup)
+                                         nu_lookup=nu_lookup, ble_adapter=ble_adapter)
             await tp.connect(devname=service_name)
         elif (sel_transport == 'console'):
             tp = transport.Transport_Console()
@@ -554,6 +554,11 @@ async def main():
 
     parser.add_argument('-v','--verbose', help='Increase output verbosity', action='store_true')
 
+    parser.add_argument('--ble_adapter', dest='ble_adapter', type=str, default=transport.DEFAULT_BLE_ADAPTER,
+                        help=desc_format(
+                            f'HCI adapter to use for BLE (default: {transport.DEFAULT_BLE_ADAPTER}).',
+                            'Use with vhci_bridge for emulated devices, e.g. --ble_adapter hci1'))
+
     args = parser.parse_args()
 
     if args.secver == 2 and args.sec2_gen_cred:
@@ -564,7 +569,7 @@ async def main():
         security.sec2_gen_salt_verifier(args.sec2_usr, args.sec2_pwd, args.sec2_salt_len)
         sys.exit()
 
-    obj_transport = await get_transport(args.mode.lower(), args.name)
+    obj_transport = await get_transport(args.mode.lower(), args.name, args.ble_adapter)
     if obj_transport is None:
         raise RuntimeError('Failed to establish connection')
 

--- a/network_provisioning/tool/esp_prov/transport/ble_cli.py
+++ b/network_provisioning/tool/esp_prov/transport/ble_cli.py
@@ -46,7 +46,7 @@ class BLE_Bleak_Client:
 
         print('Discovering...')
         try:
-            discovery = await bleak.BleakScanner.discover(return_adv=True)
+            discovery = await bleak.BleakScanner.discover(return_adv=True, adapter=self.iface)
             devices = list(discovery.values())
         except bleak.exc.BleakDBusError as e:
             if str(e) == '[org.bluez.Error.NotReady] Resource Not Ready':
@@ -80,7 +80,7 @@ class BLE_Bleak_Client:
                 if select != 0:
                     break
 
-                discovery = await bleak.BleakScanner.discover(return_adv=True)
+                discovery = await bleak.BleakScanner.discover(return_adv=True, adapter=self.iface)
                 devices = list(discovery.values())
 
             self.devname = devices[select - 1][0].name
@@ -103,7 +103,7 @@ class BLE_Bleak_Client:
             self.srv_uuid_adv = uuids[0]
 
         print('Connecting...')
-        self.device = bleak.BleakClient(found_device[0].address)
+        self.device = bleak.BleakClient(found_device[0].address, adapter=self.iface)
         await self.device.connect()
         # must be paired on Windows to access characteristics;
         # cannot be paired on Mac

--- a/network_provisioning/tool/esp_prov/transport/transport_ble.py
+++ b/network_provisioning/tool/esp_prov/transport/transport_ble.py
@@ -5,12 +5,15 @@
 from . import ble_cli
 from .transport import Transport
 
+DEFAULT_BLE_ADAPTER = 'hci0'
+
 
 class Transport_BLE(Transport):
-    def __init__(self, service_uuid, nu_lookup):
+    def __init__(self, service_uuid, nu_lookup, ble_adapter=DEFAULT_BLE_ADAPTER):
         self.nu_lookup = nu_lookup
         self.service_uuid = service_uuid
         self.name_uuid_lookup = None
+        self.ble_adapter = ble_adapter
         # Expect service UUID like '0000ffff-0000-1000-8000-00805f9b34fb'
         for name in nu_lookup.keys():
             # Calculate characteristic UUID for each endpoint
@@ -22,7 +25,7 @@ class Transport_BLE(Transport):
 
     async def connect(self, devname):
         # Use client to connect to BLE device and bind to service
-        if not await self.cli.connect(devname=devname, iface='hci0',
+        if not await self.cli.connect(devname=devname, iface=self.ble_adapter,
                                       chrc_names=self.nu_lookup.keys(),
                                       fallback_srv_uuid=self.service_uuid):
             raise RuntimeError('Failed to initialize transport')


### PR DESCRIPTION
Allows specifying which HCI adapter Bleak uses for BLE provisioning. This enables use with vhci_bridge where the emulated device appears on a different adapter (e.g. hci1) than the system default.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
