### PR TITLE
fix: Incorrect fail reason in NETWORK_PROV_WIFI_CRED_FAIL (IEC-517)

### DIFF
--- a/network_provisioning/CHANGELOG.md
+++ b/network_provisioning/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.4 (14-April-2026)
+
+- Fix incorrect fail reason reported in `NETWORK_PROV_WIFI_CRED_FAIL` event.
+
 # 1.2.3 (2-April-2026)
 - Fix possible NULL pointer dereference with malformed protobuf messages
 - Fix possible buffer overflow in Thread provisioning

--- a/network_provisioning/idf_component.yml
+++ b/network_provisioning/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.3"
+version: "1.2.4"
 description: Network provisioning component for Wi-Fi or Thread devices
 url: https://github.com/espressif/idf-extra-components/tree/master/network_provisioning
 dependencies:

--- a/network_provisioning/src/manager.c
+++ b/network_provisioning/src/manager.c
@@ -1807,7 +1807,6 @@ static void network_prov_mgr_event_handler_internal(
          * run the event handler with disconnection reason as data */
         if (prov_ctx->wifi_state == NETWORK_PROV_WIFI_STA_DISCONNECTED) {
             prov_ctx->prov_state = NETWORK_PROV_STATE_FAIL;
-            network_prov_wifi_sta_fail_reason_t reason = prov_ctx->wifi_disconnect_reason;
             wifi_event_sta_disconnected_t *disconnected = (wifi_event_sta_disconnected_t *) event_data;
             ESP_LOGE(TAG, "Disconnect reason : %d", disconnected->reason);
 
@@ -1833,6 +1832,7 @@ static void network_prov_mgr_event_handler_internal(
             }
             if (prov_ctx->wifi_state == NETWORK_PROV_WIFI_STA_DISCONNECTED) {
                 /* Execute user registered callback handler */
+                network_prov_wifi_sta_fail_reason_t reason = prov_ctx->wifi_disconnect_reason;
                 execute_event_cb(NETWORK_PROV_WIFI_CRED_FAIL, (void *)&reason, sizeof(reason));
             }
         }


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
In network_provisioning, when Wi-Fi connection fails, the reason code that is sent in the `NETWORK_PROV_WIFI_STA_DISCONNECTED` event uses a stale value from before `wifi_disconnect_reason` was updated.

This commit moves initialization of the temporary variable to after `wifi_disconnect_reason` is updated.

I entered an incorrect wi-fi SSID and exptected a `NETWORK_PROV_WIFI_STA_AP_NOT_FOUND` failure, but I received a `NETWORK_PROV_WIFI_STA_AUTH_ERROR` failure.

My log before the change:
```
I (23879) onboarding: Received Wi-Fi credentials for SSID: this-ssid-is-invalid
I (23879) onboarding: Onboarding state: CONNECTING_TO_WIFI
I (27709) onboarding: event_handler: WIFI_EVENT/5
W (27709) onboarding: Disconnected from Wi-Fi AP
E (27709) network_prov_mgr: STA Disconnected
E (27709) network_prov_mgr: Disconnect reason : 201
E (27719) network_prov_mgr: STA AP Not found
I (27719) onboarding: event_handler: NETWORK_PROV_EVENT/4
W (27729) onboarding: Provisioning failed: NETWORK_PROV_WIFI_STA_AUTH_ERROR
I (27729) onboarding: Onboarding state: WIFI_AUTH_FAILED
```

The same sequence after the change:
```
I (36103) onboarding: Received Wi-Fi credentials for SSID: this-ssid-is-invalid
I (36103) onboarding: Onboarding state: CONNECTING_TO_WIFI
I (39933) onboarding: event_handler: WIFI_EVENT/5
W (39933) onboarding: Disconnected from Wi-Fi AP
E (39933) network_prov_mgr: STA Disconnected
E (39933) network_prov_mgr: Disconnect reason : 201
E (39943) network_prov_mgr: STA AP Not found
I (39943) onboarding: event_handler: NETWORK_PROV_EVENT/4
W (39953) onboarding: Provisioning failed: NETWORK_PROV_WIFI_STA_AP_NOT_FOUND
I (39953) onboarding: Onboarding state: WIFI_AP_NOT_FOUND
```

The second to last line changed from `NETWORK_PROV_WIFI_STA_AUTH_ERROR` to `NETWORK_PROV_WIFI_STA_AP_NOT_FOUND`.