### PR TITLE
fix(spi_nand_flash): Linux mmap emulator fixes, docs, and host tests (v1.0.2) (IEC-522)

### DIFF
--- a/spi_nand_flash/CHANGELOG.md
+++ b/spi_nand_flash/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Changelog
+
+Versioning policy: see [VERSIONING.md](VERSIONING.md). From **v1.0.0** onward this component follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.2]
+### Fixes
+- BDL error logging: correct format specifiers for size fields on 64-bit Linux (avoids undefined behavior and wrong log output).
+- Linux NAND emulation: OOB markers and free-page detection aligned with the real hardware path.
+- Linux mmap: correct backing file path selection for the emulated image.
+- Linux mmap layout: on-disk stride accounts for interleaved OOB vs user-visible erase block size (bad-block handling, erase, and OOB clearing).
+
+### Documentation
+- Linux mmap emulator config: note how backing file size maps to interleaved OOB and reported user capacity.
+
+### Testing
+- Linux host tests: broader FTL and BDL coverage.
+- Shared buffer pattern helpers (including seeded patterns) for host tests and the in-tree test application.
+
 ## [1.0.1]
 - fix: fix incorrect flash geometry parameter for flash GD5F4GM8xExxG
 

--- a/spi_nand_flash/README.md
+++ b/spi_nand_flash/README.md
@@ -60,6 +60,8 @@ For layered architecture, BDL usage, API details, and **upgrading from 0.x to 1.
 - **ESP-IDF 5.0–5.x:** Use the **legacy** API only (`spi_nand_flash_init_device()`, page/sector helpers). The BDL Kconfig option is not available on these IDF versions. Component **1.0.0** remains compatible with this range when BDL is not used.
 - **ESP-IDF 6.0 and newer:** You may enable **`CONFIG_NAND_FLASH_ENABLE_BDL`** and use **`spi_nand_flash_init_with_layers()`** with **`esp_blockdev_t`** for block-device consumers. If BDL is **disabled**, the legacy API behaves as on older IDF versions.
 
+**Linux mmap emulation (host tests):** On the Linux target, the driver can use a memory-mapped backing file instead of SPI hardware. Configuration examples and how to build the host test app live in [`host_test/README.md`](host_test/README.md).
+
 ## Supported SPI NAND Flash chips
 
 At present, `spi_nand_flash` component is compatible with the chips produced by the following manufacturers and and their respective model numbers:

--- a/spi_nand_flash/VERSIONING.md
+++ b/spi_nand_flash/VERSIONING.md
@@ -1,0 +1,13 @@
+# Versioning
+
+From **v1.0.0** onward, this component follows **[Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)**. The published version is the `version` field in [`idf_component.yml`](idf_component.yml).
+
+## Summary
+
+| Level   | When to bump |
+|--------|----------------|
+| **MAJOR** | Breaking changes for integrators: removed or incompatible APIs, required migration, or other incompatible contract changes called out under **Breaking Changes** in [`CHANGELOG.md`](CHANGELOG.md). |
+| **MINOR** | Backward-compatible additions: new APIs, new supported devices or modes, new optional Kconfig (default preserves prior behavior). |
+| **PATCH** | Backward-compatible fixes only: bug fixes, documentation corrections, tests, or build/CI changes that do not widen the public API or break existing callers. |
+
+Pre-**1.0.0** releases (`0.x.y` in the changelog) did not consistently apply this split; treat them as historical versioning. Use **1.x.y** and the rules above for current releases.

--- a/spi_nand_flash/host_test/README.md
+++ b/spi_nand_flash/host_test/README.md
@@ -3,13 +3,17 @@
 
 # Host Test for SPI NAND Flash Emulation
 
+Linux host tests use the mmap-backed NAND emulator (`nand_linux_mmap_emul`). Full field semantics (including how OOB is interleaved in the backing file and how that affects usable capacity) are documented on `nand_file_mmap_emul_config_t` in [`nand_linux_mmap_emul.h`](../include/nand_linux_mmap_emul.h).
+
 ## NAND Flash Emulation Configuration
 
-The NAND flash emulation can be configured using the `nand_mmap_emul_config_t` structure:
+The NAND flash emulation can be configured using the `nand_file_mmap_emul_config_t` structure:
 
 ```c
+#include "nand_linux_mmap_emul.h"
+
 // Configuration structure for NAND emulation
-nand_mmap_emul_config_t cfg = {
+nand_file_mmap_emul_config_t cfg = {
     .flash_file_name = "",                  // Empty string for temporary file, or specify path
     .flash_file_size = EMULATED_NAND_SIZE,  // Default is 128MB
     .keep_dump = true                       // true to keep file after tests
@@ -24,9 +28,8 @@ nand_mmap_emul_config_t cfg = {
    - Maximum length: 256 characters
 
 2. **flash_file_size**:
-   - Default: EMULATED_NAND_SIZE (128MB)
-   - Can be customized based on test requirements
-   - Must be aligned to block size
+   - Default: `EMULATED_NAND_SIZE` (128MB)
+   - Must be a multiple of the chip's **user-visible** erase-block size (`page_size * pages_per_block`). The on-disk image is larger per page because OOB bytes are interleaved after each page; see the struct documentation in `nand_linux_mmap_emul.h`.
 
 3. **keep_dump**:
    - true: Keeps the memory-mapped file on disk after testing (for debugging or data persistence)
@@ -36,6 +39,9 @@ nand_mmap_emul_config_t cfg = {
 
 #### Option 1: Direct Device API
 ```c
+#include "nand_linux_mmap_emul.h"
+#include "spi_nand_flash.h"
+
 // Initialize with custom settings
 nand_file_mmap_emul_config_t cfg = {
     .flash_file_name = "/tmp/my_nand.bin",
@@ -61,7 +67,14 @@ spi_nand_flash_deinit_device(handle);
 ```
 
 #### Option 2: Block Device API
+
+Requires **ESP-IDF 6.0+** with **`CONFIG_NAND_FLASH_ENABLE_BDL`** enabled (same as on-target BDL tests).
+
 ```c
+#include "nand_linux_mmap_emul.h"
+#include "spi_nand_flash.h"
+#include "esp_nand_blockdev.h"
+
 // Initialize with block device interface
 nand_file_mmap_emul_config_t cfg = {"", 50 * 1024 * 1024, false};
 spi_nand_flash_config_t nand_flash_config = {&cfg, 0, SPI_NAND_IO_MODE_SIO, 0};
@@ -79,3 +92,14 @@ nand_bdl->ops->write(nand_bdl, buffer, offset, size);
 // Cleanup
 nand_bdl->ops->release(nand_bdl);
 ```
+
+## Building and running
+
+From this directory (with ESP-IDF environment loaded):
+
+```bash
+idf.py --preview set-target linux
+idf.py build monitor
+```
+
+Catch2-based suites are selected from `test_app_main.cpp` according to Kconfig (see the **Linux Host Testing** section in [`layered_architecture.md`](../layered_architecture.md)): legacy raw/device tests vs BDL-enabled sources such as `test_nand_flash_bdl.cpp` and `test_nand_flash_ftl.cpp`.

--- a/spi_nand_flash/host_test/main/CMakeLists.txt
+++ b/spi_nand_flash/host_test/main/CMakeLists.txt
@@ -3,7 +3,7 @@ set(src "test_app_main.cpp")
 if(CONFIG_NAND_FLASH_ENABLE_BDL)
     list(APPEND src "test_nand_flash_bdl.cpp")
 else()
-    list(APPEND src "test_nand_flash.cpp")
+    list(APPEND src  "test_nand_flash.cpp" "test_nand_flash_ftl.cpp")
 endif()
 
 idf_component_register(SRCS ${src}

--- a/spi_nand_flash/host_test/main/test_nand_flash_bdl.cpp
+++ b/spi_nand_flash/host_test/main/test_nand_flash_bdl.cpp
@@ -1,11 +1,13 @@
 /*
- * SPDX-FileCopyrightText: 2023-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2023-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#include <cstdlib>
 
 #include "spi_nand_flash.h"
 #include "spi_nand_flash_test_helpers.h"
@@ -14,6 +16,31 @@
 #include "esp_nand_blockdev.h"
 
 #include <catch2/catch_test_macros.hpp>
+
+/* Linux mmap file: each page is k_page data + k_oob, so the file uses k_ppb * (k_page + k_oob)
+ * bytes per erase block. chip.block_size is k_ppb * k_page (same as real chips); num_blocks
+ * is file_size / (k_ppb * (k_page + k_oob)). BDL disk_size must be num_blocks * chip.block_size.
+ * Regression: storing the file stride in chip.block_size broke BDL erase decode. */
+TEST_CASE("BDL geometry matches Linux mmap file and chip.block_size", "[spi_nand_flash][bdl]")
+{
+    constexpr uint32_t k_file_bytes = 16u * 1024u * 1024u;
+    constexpr uint32_t k_page = 2048u;
+    constexpr uint32_t k_oob = 64u;
+    constexpr uint32_t k_ppb = 64u;
+    const uint32_t file_bytes_per_physical_block = k_ppb * (k_page + k_oob);
+    const uint32_t bdl_bytes_per_erase_block = k_ppb * k_page;
+    const uint32_t num_physical_blocks = k_file_bytes / file_bytes_per_physical_block;
+    const uint64_t expected_disk_size = (uint64_t)num_physical_blocks * bdl_bytes_per_erase_block;
+
+    nand_file_mmap_emul_config_t conf = {"", k_file_bytes, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+    REQUIRE(bdl->geometry.write_size == k_page);
+    REQUIRE(bdl->geometry.erase_size == bdl_bytes_per_erase_block);
+    REQUIRE(bdl->geometry.disk_size == expected_disk_size);
+    bdl->ops->release(bdl);
+}
 
 TEST_CASE("verify mark_bad_block works with bdl interface", "[spi_nand_flash][bdl]")
 {
@@ -240,3 +267,512 @@ TEST_CASE("Release and no use-after-free: create, release, create again, minimal
     bdl->ops->release(bdl);
 }
 
+TEST_CASE("Flash BDL last physical page write/read", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint64_t disk_size = bdl->geometry.disk_size;
+    const uint32_t num_pages = (uint32_t)(disk_size / page_size);
+    const uint32_t pages_per_block = block_size / page_size;
+    const uint32_t last_page = num_pages - 1u;
+    const uint32_t last_block = last_page / pages_per_block;
+    const uint64_t block_addr = (uint64_t)last_block * block_size;
+
+    REQUIRE(bdl->ops->erase(bdl, block_addr, block_size) == ESP_OK);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    const uint64_t last_off = (uint64_t)last_page * page_size;
+    REQUIRE(bdl->ops->write(bdl, w, last_off, page_size) == ESP_OK);
+    memset(r, 0, page_size);
+    REQUIRE(bdl->ops->read(bdl, r, page_size, last_off, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL 16 MiB full erase+program sweep then read-back all pages", "[spi_nand_flash][bdl][raw][sequential]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint64_t disk_size = bdl->geometry.disk_size;
+    const uint32_t num_blocks = (uint32_t)(disk_size / block_size);
+    const uint32_t pages_per_block = block_size / page_size;
+
+    for (uint32_t b = 0; b < num_blocks; b++) {
+        const uint64_t ba = (uint64_t)b * block_size;
+        REQUIRE(bdl->ops->erase(bdl, ba, block_size) == ESP_OK);
+        for (uint32_t i = 0; i < pages_per_block; i++) {
+            const uint32_t page = b * pages_per_block + i;
+            uint8_t *w = (uint8_t *)malloc(page_size);
+            REQUIRE(w != nullptr);
+            spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+            REQUIRE(bdl->ops->write(bdl, w, (uint64_t)page * page_size, page_size) == ESP_OK);
+            free(w);
+        }
+    }
+
+    const uint32_t num_pages = (uint32_t)(disk_size / page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(r != nullptr);
+    for (uint32_t page = 0; page < num_pages; page++) {
+        memset(r, 0, page_size);
+        REQUIRE(bdl->ops->read(bdl, r, page_size, (uint64_t)page * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL overwrite same physical page many times", "[spi_nand_flash][bdl][raw][stress]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    REQUIRE(bdl->ops->erase(bdl, 0, block_size) == ESP_OK);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    constexpr int kRounds = 150;
+    for (int i = 0; i < kRounds; i++) {
+        spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+        REQUIRE(bdl->ops->write(bdl, w, 0, page_size) == ESP_OK);
+    }
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    REQUIRE(bdl->ops->read(bdl, r, page_size, 0, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL multi-page write in one call", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint32_t n = 4;
+    REQUIRE(block_size >= n * page_size);
+
+    REQUIRE(bdl->ops->erase(bdl, 0, block_size) == ESP_OK);
+
+    const size_t total = (size_t)n * page_size;
+    uint8_t *w = (uint8_t *)malloc(total);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    for (uint32_t p = 0; p < n; p++) {
+        spi_nand_flash_fill_buffer(w + (size_t)p * page_size, page_size / sizeof(uint32_t));
+    }
+    REQUIRE(bdl->ops->write(bdl, w, 0, total) == ESP_OK);
+
+    for (uint32_t p = 0; p < n; p++) {
+        memset(r, 0, page_size);
+        REQUIRE(bdl->ops->read(bdl, r, page_size, (uint64_t)p * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL sub-page read and misaligned write rejected", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    REQUIRE(bdl->ops->erase(bdl, 0, block_size) == ESP_OK);
+
+    uint8_t *full = (uint8_t *)malloc(page_size);
+    uint8_t *slice = (uint8_t *)malloc(page_size);
+    REQUIRE(full != nullptr);
+    REQUIRE(slice != nullptr);
+    spi_nand_flash_fill_buffer(full, page_size / sizeof(uint32_t));
+    REQUIRE(bdl->ops->write(bdl, full, 0, page_size) == ESP_OK);
+
+    const size_t off = 64;
+    const size_t len = page_size - 128;
+    REQUIRE(off + len <= page_size);
+    memset(slice, 0, len);
+    REQUIRE(bdl->ops->read(bdl, slice, len, off, len) == ESP_OK);
+    REQUIRE(memcmp(slice, full + off, len) == 0);
+
+    REQUIRE(bdl->ops->write(bdl, full, 1, page_size) == ESP_ERR_INVALID_SIZE);
+
+    free(full);
+    free(slice);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL COPY_PAGE same page is idempotent", "[spi_nand_flash][bdl][raw][copy]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint32_t page = 3 * (block_size / page_size);
+
+    REQUIRE(bdl->ops->erase(bdl, (page / (block_size / page_size)) * (uint64_t)block_size, block_size) == ESP_OK);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    const uint64_t addr = (uint64_t)page * page_size;
+    REQUIRE(bdl->ops->write(bdl, w, addr, page_size) == ESP_OK);
+
+    esp_blockdev_cmd_arg_copy_page_t copy_cmd = {.src_page = page, .dst_page = page};
+    REQUIRE(bdl->ops->ioctl(bdl, ESP_BLOCKDEV_CMD_COPY_PAGE, &copy_cmd) == ESP_OK);
+
+    memset(r, 0, page_size);
+    REQUIRE(bdl->ops->read(bdl, r, page_size, addr, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL COPY_PAGE does not alter source page", "[spi_nand_flash][bdl][raw][copy]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    const uint32_t ppb = block_size / page_size;
+    const uint32_t src_page = 2u * ppb;
+    const uint32_t dst_page = 2u * ppb + 1u;
+
+    REQUIRE(bdl->ops->erase(bdl, 2u * (uint64_t)block_size, block_size) == ESP_OK);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    REQUIRE(bdl->ops->write(bdl, w, (uint64_t)src_page * page_size, page_size) == ESP_OK);
+
+    esp_blockdev_cmd_arg_copy_page_t copy_cmd = {.src_page = src_page, .dst_page = dst_page};
+    REQUIRE(bdl->ops->ioctl(bdl, ESP_BLOCKDEV_CMD_COPY_PAGE, &copy_cmd) == ESP_OK);
+
+    memset(r, 0, page_size);
+    REQUIRE(bdl->ops->read(bdl, r, page_size, (uint64_t)src_page * page_size, page_size) == ESP_OK);
+    REQUIRE(memcmp(w, r, page_size) == 0);
+
+    free(w);
+    free(r);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL invalid write/read geometry returns error", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint64_t disk = bdl->geometry.disk_size;
+    uint8_t *buf = (uint8_t *)malloc(page_size * 2);
+    REQUIRE(buf != nullptr);
+    spi_nand_flash_fill_buffer(buf, page_size / sizeof(uint32_t));
+
+    REQUIRE(bdl->ops->write(bdl, buf, page_size / 2u, page_size) == ESP_ERR_INVALID_SIZE);
+    if (page_size >= 512u) {
+        REQUIRE(bdl->ops->write(bdl, buf, 0, page_size / 2u) == ESP_ERR_INVALID_SIZE);
+    }
+
+    memset(buf, 0, page_size);
+    REQUIRE(bdl->ops->read(bdl, buf, page_size, disk, page_size) == ESP_ERR_INVALID_SIZE);
+    REQUIRE(bdl->ops->write(bdl, buf, disk, page_size) == ESP_ERR_INVALID_SIZE);
+
+    free(buf);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("Flash BDL GET_PAGE_ECC_STATUS and GET_ECC_STATS (small image)", "[spi_nand_flash][bdl][raw]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 4 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &bdl) == ESP_OK);
+
+    const uint32_t page_size = bdl->geometry.write_size;
+    const uint32_t block_size = bdl->geometry.erase_size;
+    REQUIRE(bdl->ops->erase(bdl, 0, block_size) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)malloc(page_size);
+    REQUIRE(buf != nullptr);
+    spi_nand_flash_fill_buffer(buf, page_size / sizeof(uint32_t));
+    REQUIRE(bdl->ops->write(bdl, buf, 0, page_size) == ESP_OK);
+
+    esp_blockdev_cmd_arg_ecc_status_t ecc_page = {};
+    ecc_page.page_num = 0;
+    REQUIRE(bdl->ops->ioctl(bdl, ESP_BLOCKDEV_CMD_GET_PAGE_ECC_STATUS, &ecc_page) == ESP_OK);
+
+    esp_blockdev_cmd_arg_ecc_stats_t ecc_stats = {};
+    REQUIRE(bdl->ops->ioctl(bdl, ESP_BLOCKDEV_CMD_GET_ECC_STATS, &ecc_stats) == ESP_OK);
+
+    free(buf);
+    bdl->ops->release(bdl);
+}
+
+TEST_CASE("WL BDL sync after write preserves data", "[spi_nand_flash][bdl][wl]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    REQUIRE(wl_bdl->ops->write(wl_bdl, w, page_size, page_size) == ESP_OK);
+    REQUIRE(wl_bdl->ops->sync(wl_bdl) == ESP_OK);
+    memset(r, 0, page_size);
+    REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, page_size, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL MARK_DELETED then rewrite same logical page", "[spi_nand_flash][bdl][wl]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    const uint32_t page_index = 5;
+    const uint64_t off = (uint64_t)page_index * page_size;
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    memset(w, 0x22, page_size);
+    REQUIRE(wl_bdl->ops->write(wl_bdl, w, off, page_size) == ESP_OK);
+
+    esp_blockdev_cmd_arg_erase_t trim_arg = {.start_addr = off, .erase_len = page_size};
+    REQUIRE(wl_bdl->ops->ioctl(wl_bdl, ESP_BLOCKDEV_CMD_MARK_DELETED, &trim_arg) == ESP_OK);
+
+    spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+    REQUIRE(wl_bdl->ops->write(wl_bdl, w, off, page_size) == ESP_OK);
+    memset(r, 0, page_size);
+    REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, off, page_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL MARK_DELETED misaligned range returns ESP_ERR_INVALID_SIZE", "[spi_nand_flash][bdl][wl]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 20 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    esp_blockdev_cmd_arg_erase_t bad = {.start_addr = 1, .erase_len = page_size};
+    REQUIRE(wl_bdl->ops->ioctl(wl_bdl, ESP_BLOCKDEV_CMD_MARK_DELETED, &bad) == ESP_ERR_INVALID_SIZE);
+
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL 16 MiB sequential logical page fill and read-back", "[spi_nand_flash][bdl][wl][sequential]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    const uint32_t num_pages = (uint32_t)(wl_bdl->geometry.disk_size / page_size);
+    REQUIRE(wl_bdl->geometry.disk_size == (uint64_t)num_pages * page_size);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+
+    for (uint32_t p = 0; p < num_pages; p++) {
+        spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+        REQUIRE(wl_bdl->ops->write(wl_bdl, w, (uint64_t)p * page_size, page_size) == ESP_OK);
+    }
+    REQUIRE(wl_bdl->ops->sync(wl_bdl) == ESP_OK);
+
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(r != nullptr);
+    for (uint32_t p = 0; p < num_pages; p++) {
+        memset(r, 0, page_size);
+        REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, (uint64_t)p * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL hot-set random writes then read-back", "[spi_nand_flash][bdl][wl][stress]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    constexpr uint32_t kHotSetSize = 30u;
+    constexpr uint32_t kTotalWrites = 1200u;
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    const uint32_t num_pages = (uint32_t)(wl_bdl->geometry.disk_size / page_size);
+    REQUIRE(num_pages >= kHotSetSize);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    bool written[kHotSetSize] = {};
+
+    std::srand(0xDEADBEEFu);
+    for (uint32_t op = 0; op < kTotalWrites; op++) {
+        const uint32_t lp = (uint32_t)((unsigned)std::rand() % kHotSetSize);
+        spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+        REQUIRE(wl_bdl->ops->write(wl_bdl, w, (uint64_t)lp * page_size, page_size) == ESP_OK);
+        written[lp] = true;
+    }
+
+    REQUIRE(wl_bdl->ops->sync(wl_bdl) == ESP_OK);
+
+    for (uint32_t s = 0; s < kHotSetSize; s++) {
+        if (!written[s]) {
+            continue;
+        }
+        REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, (uint64_t)s * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}
+
+TEST_CASE("WL BDL hot-set with interleaved MARK_DELETED", "[spi_nand_flash][bdl][wl][stress][trim]")
+{
+    nand_file_mmap_emul_config_t conf = {"", 16 * 1024 * 1024, false};
+    spi_nand_flash_config_t nand_flash_config = {&conf, 0, SPI_NAND_IO_MODE_SIO, 0};
+    esp_blockdev_handle_t flash_bdl = nullptr;
+    REQUIRE(nand_flash_get_blockdev(&nand_flash_config, &flash_bdl) == ESP_OK);
+    esp_blockdev_handle_t wl_bdl = nullptr;
+    REQUIRE(spi_nand_flash_wl_get_blockdev(flash_bdl, &wl_bdl) == ESP_OK);
+
+    constexpr uint32_t kHotSetSize = 30u;
+    constexpr uint32_t kTotalWrites = 1200u;
+
+    const uint32_t page_size = wl_bdl->geometry.write_size;
+    const uint32_t num_pages = (uint32_t)(wl_bdl->geometry.disk_size / page_size);
+    REQUIRE(num_pages >= kHotSetSize);
+
+    uint8_t *w = (uint8_t *)malloc(page_size);
+    uint8_t *r = (uint8_t *)malloc(page_size);
+    REQUIRE(w != nullptr);
+    REQUIRE(r != nullptr);
+
+    bool trimmed[kHotSetSize] = {};
+    bool written[kHotSetSize] = {};
+
+    std::srand(0xCAFEBABEu);
+    for (uint32_t op = 0; op < kTotalWrites; op++) {
+        const uint32_t lp = (uint32_t)((unsigned)std::rand() % kHotSetSize);
+
+        if (op % 100u == 99u) {
+            const uint32_t t = (uint32_t)((unsigned)std::rand() % kHotSetSize);
+            esp_blockdev_cmd_arg_erase_t trim_arg = {
+                .start_addr = (uint64_t)t * page_size,
+                .erase_len = page_size,
+            };
+            if (wl_bdl->ops->ioctl(wl_bdl, ESP_BLOCKDEV_CMD_MARK_DELETED, &trim_arg) == ESP_OK) {
+                trimmed[t] = true;
+            }
+        }
+
+        spi_nand_flash_fill_buffer(w, page_size / sizeof(uint32_t));
+        REQUIRE(wl_bdl->ops->write(wl_bdl, w, (uint64_t)lp * page_size, page_size) == ESP_OK);
+        trimmed[lp] = false;
+        written[lp] = true;
+    }
+
+    REQUIRE(wl_bdl->ops->sync(wl_bdl) == ESP_OK);
+
+    for (uint32_t s = 0; s < kHotSetSize; s++) {
+        if (trimmed[s] || !written[s]) {
+            continue;
+        }
+        REQUIRE(wl_bdl->ops->read(wl_bdl, r, page_size, (uint64_t)s * page_size, page_size) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer(r, page_size / sizeof(uint32_t)) == 0);
+    }
+
+    free(w);
+    free(r);
+    wl_bdl->ops->release(wl_bdl);
+}

--- a/spi_nand_flash/host_test/main/test_nand_flash_ftl.cpp
+++ b/spi_nand_flash/host_test/main/test_nand_flash_ftl.cpp
@@ -1,0 +1,790 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * FTL-level host tests for spi_nand_flash.
+ *
+ * All tests exercise the public logical-sector API exclusively:
+ *   spi_nand_flash_write_sector / read_sector / copy_sector / trim /
+ *   sync / get_capacity / get_sector_size / get_block_size /
+ *   get_block_num / spi_nand_erase_chip
+ *
+ * Raw NAND page operations (nand_wrap_*) are intentionally NOT used here.
+ * See test_nand_flash.cpp for raw-level coverage.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "spi_nand_flash.h"
+#include "spi_nand_flash_test_helpers.h"
+#include "nand_linux_mmap_emul.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+/* -------------------------------------------------------------------------
+ * Fixture helpers
+ * ---------------------------------------------------------------------- */
+
+/** Default flash size used by most tests (16 MiB — fast init / GC pressure). */
+#define FTL_TEST_FLASH_SIZE  ((size_t)16u * 1024u * 1024u)
+
+/** Larger flash used for the full-capacity sequential sweep. */
+#define FTL_TEST_FLASH_LARGE ((size_t)32u * 1024u * 1024u)
+
+/**
+ * Open a fresh emulated NAND device backed by an anonymous temp file.
+ * gc_factor == 0 selects the driver default.
+ */
+static spi_nand_flash_device_t *make_ftl_dev(size_t flash_size = FTL_TEST_FLASH_SIZE,
+        uint8_t gc_factor = 0)
+{
+    nand_file_mmap_emul_config_t emul = {"", flash_size, /*keep_dump=*/false};
+    spi_nand_flash_config_t cfg = {&emul, gc_factor, SPI_NAND_IO_MODE_SIO, 0};
+    spi_nand_flash_device_t *dev = nullptr;
+    REQUIRE(spi_nand_flash_init_device(&cfg, &dev) == ESP_OK);
+    REQUIRE(dev != nullptr);
+    return dev;
+}
+
+static void destroy_ftl_dev(spi_nand_flash_device_t *dev)
+{
+    REQUIRE(spi_nand_flash_deinit_device(dev) == ESP_OK);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 1: Device info / capacity API
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL get_capacity returns non-zero sector count", "[ftl][info]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(sectors > 0);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL get_sector_size returns a power-of-two >= 512", "[ftl][info]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+    REQUIRE(sz >= 512u);
+    /* Must be a power of two */
+    REQUIRE((sz & (sz - 1u)) == 0u);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL get_block_size is a multiple of sector_size", "[ftl][info]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sector_size = 0, block_size = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sector_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_block_size(dev, &block_size) == ESP_OK);
+    REQUIRE(block_size > 0);
+    REQUIRE(block_size % sector_size == 0);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL get_block_num is consistent with capacity and block/sector sizes",
+          "[ftl][info]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0, sector_size = 0, block_size = 0, blocks = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sector_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_block_size(dev, &block_size) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_block_num(dev, &blocks) == ESP_OK);
+    REQUIRE(blocks > 0);
+    /* Total logical flash bytes derived from blocks must match capacity-derived bytes.
+     * Dhara reserves some blocks for GC, so the logical sector count is <= physical. */
+    uint32_t pages_per_block = block_size / sector_size;
+    REQUIRE(blocks * pages_per_block >= sectors);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 2: Single-sector write / read round-trip
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL write then read back sector 0 produces correct data", "[ftl][rw]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 0) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 0) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL write then read back last valid sector", "[ftl][rw]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    uint32_t last = sectors - 1u;
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, last) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, last) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL overwrite same sector multiple times, each read-back is correct",
+          "[ftl][rw]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    const uint32_t TARGET_SECTOR = 7;
+    const int OVERWRITE_ROUNDS = 20;
+
+    for (int i = 0; i < OVERWRITE_ROUNDS; i++) {
+        /* Round-varying seed so each write is distinct; *0x1000 spreads seeds for remap checks. */
+        spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), (uint32_t)i * 0x1000u);
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, TARGET_SECTOR) == ESP_OK);
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, TARGET_SECTOR) == ESP_OK);
+        REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL multiple sectors hold independent data after interleaved writes",
+          "[ftl][rw]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    const uint32_t N = 8;
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    /* Write each sector with the shared test pattern */
+    for (uint32_t s = 0; s < N; s++) {
+        spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), s);
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, s) == ESP_OK);
+    }
+
+    /* Read them all back and verify the pattern */
+    for (uint32_t s = 0; s < N; s++) {
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, s) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer_seeded(rbuf, sz / sizeof(uint32_t), s) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 3: sync
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL sync returns ESP_OK on a freshly initialised device", "[ftl][sync]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL sync after writes returns ESP_OK and data survives", "[ftl][sync]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 3) == ESP_OK);
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 3) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 4: copy_sector
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL copy_sector duplicates data to a different logical sector",
+          "[ftl][copy]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 10) == ESP_OK);
+    REQUIRE(spi_nand_flash_copy_sector(dev, 10, 20) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 20) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL copy_sector to same sector id is idempotent", "[ftl][copy]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 5) == ESP_OK);
+    /* Copying a sector onto itself should succeed (or at least not corrupt) */
+    esp_err_t rc = spi_nand_flash_copy_sector(dev, 5, 5);
+    /* Behaviour is either ESP_OK or a graceful error — must not crash */
+    if (rc == ESP_OK) {
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 5) == ESP_OK);
+        REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+    }
+    /* If it returned an error that is also acceptable — just must not corrupt data */
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL copy does not alter source sector data", "[ftl][copy]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 11) == ESP_OK);
+    REQUIRE(spi_nand_flash_copy_sector(dev, 11, 22) == ESP_OK);
+
+    /* Source must be unchanged */
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 11) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 5: trim
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL trim returns ESP_OK on a written sector", "[ftl][trim]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)malloc(sz);
+    REQUIRE(buf != nullptr);
+    memset(buf, 0xAB, sz);
+
+    REQUIRE(spi_nand_flash_write_sector(dev, buf, 4) == ESP_OK);
+    REQUIRE(spi_nand_flash_trim(dev, 4) == ESP_OK);
+
+    free(buf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL trim then write to the same sector succeeds", "[ftl][trim]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    memset(wbuf, 0x11, sz);
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 6) == ESP_OK);
+    REQUIRE(spi_nand_flash_trim(dev, 6) == ESP_OK);
+
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 6) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 6) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL trim on unwritten sector returns ESP_OK", "[ftl][trim]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    /* Sector 9 has never been written — trim should still succeed gracefully */
+    REQUIRE(spi_nand_flash_trim(dev, 9) == ESP_OK);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 6: erase_chip
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL erase_chip succeeds and write/read works afterwards",
+          "[ftl][erase-chip]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    /* Write something before the chip erase */
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 0) == ESP_OK);
+
+    REQUIRE(spi_nand_erase_chip(dev) == ESP_OK);
+
+    /* After erase the FTL must accept new writes */
+    spi_nand_flash_fill_buffer(wbuf, sz / sizeof(uint32_t));
+    REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 0) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 0) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 7: Logical sector IDs beyond capacity
+ *
+ * NOTE: Dhara does NOT bounds-check logical sector IDs at the FTL level.
+ * Writing or reading beyond the reported capacity succeeds (returns ESP_OK)
+ * rather than returning an error.  These tests document that observed
+ * behaviour so that any future change in Dhara that adds bounds-checking
+ * will be caught explicitly.
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL write to sector_id == capacity succeeds",
+          "[ftl][bounds]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)calloc(1, sz);
+    REQUIRE(buf != nullptr);
+
+    /* Dhara does not validate the sector ID — expect success, not an error. */
+    esp_err_t rc = spi_nand_flash_write_sector(dev, buf, sectors);
+    REQUIRE(rc == ESP_OK);
+
+    free(buf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL read from sector_id == capacity succeeds",
+          "[ftl][bounds]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)calloc(1, sz);
+    REQUIRE(buf != nullptr);
+
+    /* Dhara does not validate the sector ID — expect success, not an error. */
+    esp_err_t rc = spi_nand_flash_read_sector(dev, buf, sectors);
+    REQUIRE(rc == ESP_OK);
+
+    free(buf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL write to UINT32_MAX sector_id succeeds",
+          "[ftl][bounds]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)calloc(1, sz);
+    REQUIRE(buf != nullptr);
+
+    /* Dhara does not validate the sector ID — expect success, not an error. */
+    esp_err_t rc = spi_nand_flash_write_sector(dev, buf, UINT32_MAX);
+    REQUIRE(rc == ESP_OK);
+
+    free(buf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 8: Sequential full-capacity write sweep
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL sequential write to every logical sector, then read-back all",
+          "[ftl][sequential]")
+{
+    /* Use larger flash so we have a meaningful number of logical sectors */
+    spi_nand_flash_device_t *dev = make_ftl_dev(FTL_TEST_FLASH_LARGE);
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    /* Write pass */
+    for (uint32_t s = 0; s < sectors; s++) {
+        spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), s);
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, s) == ESP_OK);
+    }
+
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+
+    /* Verify capacity has not changed */
+    uint32_t sectors_after = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors_after) == ESP_OK);
+    REQUIRE(sectors_after == sectors);
+
+    /* Read-back pass */
+    for (uint32_t s = 0; s < sectors; s++) {
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, s) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer_seeded(rbuf, sz / sizeof(uint32_t), s) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 9: GC stability — hot-set repeated overwrites
+ *
+ * Write to a small set of logical sectors (HOT_SET_SIZE) many times
+ * (TOTAL_WRITES).  This forces Dhara to perform garbage collection
+ * repeatedly.  Asserts:
+ *   1. Every write returns ESP_OK.
+ *   2. After the run, get_capacity() still returns the original value.
+ *   3. Each sector in the hot-set reads back the last value written.
+ *   4. spi_nand_flash_sync() returns ESP_OK.
+ * ---------------------------------------------------------------------- */
+
+#define HOT_SET_SIZE  50u
+#define TOTAL_WRITES  5000u
+
+TEST_CASE("FTL GC stability: 50-sector hot-set written 5000 times",
+          "[ftl][gc][stability]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    /* The hot-set must fit within the device's logical address space */
+    REQUIRE(sectors >= HOT_SET_SIZE);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    bool written[HOT_SET_SIZE] = {};
+    uint32_t last_seed[HOT_SET_SIZE] = {};
+
+    srand(0xDEADBEEFu); /* reproducible */
+
+    for (uint32_t op = 0; op < TOTAL_WRITES; op++) {
+        uint32_t lsector = (uint32_t)((unsigned)rand() % HOT_SET_SIZE);
+        spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), op);
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, lsector) == ESP_OK);
+        written[lsector] = true;
+        last_seed[lsector] = op;
+    }
+
+    /* Capacity must be unchanged — the Dhara map must not have grown OOB */
+    uint32_t sectors_after = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors_after) == ESP_OK);
+    REQUIRE(sectors_after == sectors);
+
+    /* Flush any in-memory state */
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+
+    /* Every hot sector must read back the last write's pattern */
+    for (uint32_t s = 0; s < HOT_SET_SIZE; s++) {
+        if (!written[s]) {
+            continue; /* rand() never selected this logical sector */
+        }
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, s) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer_seeded(rbuf, sz / sizeof(uint32_t), last_seed[s]) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL GC stability with trim: hot-set with interleaved trims",
+          "[ftl][gc][trim][stability]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+
+    uint32_t sectors = 0, sz = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors) == ESP_OK);
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+    REQUIRE(sectors >= HOT_SET_SIZE);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    bool trimmed[HOT_SET_SIZE] = {};
+    bool written[HOT_SET_SIZE] = {};
+    uint32_t last_seed[HOT_SET_SIZE] = {};
+
+    srand(0xCAFEBABEu);
+
+    for (uint32_t op = 0; op < TOTAL_WRITES; op++) {
+        uint32_t lsector = (uint32_t)((unsigned)rand() % HOT_SET_SIZE);
+
+        /* Every 100 ops trim a random sector in the hot-set */
+        if (op % 100 == 99) {
+            uint32_t t = (uint32_t)((unsigned)rand() % HOT_SET_SIZE);
+            if (spi_nand_flash_trim(dev, t) == ESP_OK) {
+                trimmed[t] = true;
+            }
+        }
+
+        spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), op);
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, lsector) == ESP_OK);
+        trimmed[lsector] = false;
+        written[lsector] = true;
+        last_seed[lsector] = op;
+    }
+
+    uint32_t sectors_after = 0;
+    REQUIRE(spi_nand_flash_get_capacity(dev, &sectors_after) == ESP_OK);
+    REQUIRE(sectors_after == sectors);
+    REQUIRE(spi_nand_flash_sync(dev) == ESP_OK);
+
+    /* Verify untrimmed sectors */
+    for (uint32_t s = 0; s < HOT_SET_SIZE; s++) {
+        if (trimmed[s] || !written[s]) {
+            continue; /* skip trimmed or never-written */
+        }
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, s) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer_seeded(rbuf, sz / sizeof(uint32_t), last_seed[s]) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 10: Single-sector hammer — one sector written thousands of times
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL single sector written 2000 times stays readable and correct",
+          "[ftl][gc][hammer]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    const uint32_t TARGET = 0;
+    const uint32_t ROUNDS = 2000;
+
+    for (uint32_t i = 0; i < ROUNDS; i++) {
+        spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), i);
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, TARGET) == ESP_OK);
+    }
+
+    /* Final read must reflect the last write (seed ROUNDS - 1). */
+    spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), ROUNDS - 1u);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, TARGET) == ESP_OK);
+    REQUIRE(memcmp(wbuf, rbuf, sz) == 0);
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 11: Alternating write / read pattern
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL alternating write-read on two sectors never corrupts either",
+          "[ftl][rw][alternating]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *wbuf = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(wbuf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    const uint32_t ITERS = 500;
+
+    for (uint32_t i = 0; i < ITERS; i++) {
+        /* Write A, then read B, then write B, then read A */
+        spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), i);
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 1) == ESP_OK);
+
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 2) == ESP_OK);
+        if (i > 0) {
+            REQUIRE(spi_nand_flash_check_buffer_seeded(rbuf, sz / sizeof(uint32_t), i - 1u) == 0);
+        }
+
+        spi_nand_flash_fill_buffer_seeded(wbuf, sz / sizeof(uint32_t), i);
+        REQUIRE(spi_nand_flash_write_sector(dev, wbuf, 2) == ESP_OK);
+
+        REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 1) == ESP_OK);
+        REQUIRE(spi_nand_flash_check_buffer_seeded(rbuf, sz / sizeof(uint32_t), i) == 0);
+    }
+
+    free(wbuf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+/* -------------------------------------------------------------------------
+ * Group 12: All-zeros and all-ones patterns (edge-case data values)
+ * ---------------------------------------------------------------------- */
+
+TEST_CASE("FTL write/read all-zeros pattern", "[ftl][rw][patterns]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf = (uint8_t *)calloc(1, sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(buf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    REQUIRE(spi_nand_flash_write_sector(dev, buf, 0) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 0) == ESP_OK);
+    REQUIRE(memcmp(buf, rbuf, sz) == 0);
+
+    free(buf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL write/read all-0xFF pattern", "[ftl][rw][patterns]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf  = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(buf != nullptr);
+    REQUIRE(rbuf != nullptr);
+    memset(buf, 0xFF, sz);
+
+    REQUIRE(spi_nand_flash_write_sector(dev, buf, 1) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 1) == ESP_OK);
+    REQUIRE(memcmp(buf, rbuf, sz) == 0);
+
+    free(buf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}
+
+TEST_CASE("FTL write/read alternating 0xAA/0x55 pattern", "[ftl][rw][patterns]")
+{
+    spi_nand_flash_device_t *dev = make_ftl_dev();
+    uint32_t sz = 0;
+    REQUIRE(spi_nand_flash_get_sector_size(dev, &sz) == ESP_OK);
+
+    uint8_t *buf  = (uint8_t *)malloc(sz);
+    uint8_t *rbuf = (uint8_t *)malloc(sz);
+    REQUIRE(buf != nullptr);
+    REQUIRE(rbuf != nullptr);
+
+    for (size_t i = 0; i < sz; i++) {
+        buf[i] = (i & 1u) ? 0x55u : 0xAAu;
+    }
+
+    REQUIRE(spi_nand_flash_write_sector(dev, buf, 2) == ESP_OK);
+    REQUIRE(spi_nand_flash_read_sector(dev, rbuf, 2) == ESP_OK);
+    REQUIRE(memcmp(buf, rbuf, sz) == 0);
+
+    free(buf);
+    free(rbuf);
+    destroy_ftl_dev(dev);
+}

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.1"
+version: "1.0.2"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/include/nand_linux_mmap_emul.h
+++ b/spi_nand_flash/include/nand_linux_mmap_emul.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +18,22 @@ extern "C" {
 // Control structure for NAND emulation
 typedef struct {
     char flash_file_name[256];
+    /**
+     * Size of the backing mmap file in bytes. Must be a multiple of the chip's
+     * user-visible block size (page_size * pages_per_block).
+     *
+     * Note: the file on disk is slightly larger than the user-visible NAND capacity
+     * because each page has OOB bytes interleaved after it. The actual number of
+     * usable blocks is derived internally as:
+     *   num_blocks = flash_file_size / (pages_per_block * (page_size + oob_size))
+     * and the effective user-visible capacity is num_blocks * block_size, which
+     * will be slightly less than flash_file_size due to the OOB overhead.
+     *
+     * Example: passing 8 MiB with 2 KiB pages, 64 B OOB, 64 pages/block gives
+     *   file_bytes_per_block = 64 * (2048 + 64) = 135168 B
+     *   num_blocks = 8388608 / 135168 = 62 blocks
+     *   effective capacity = 62 * 131072 = 7.75 MiB (user-visible)
+     */
     size_t flash_file_size;
     bool keep_dump;
 } nand_file_mmap_emul_config_t;
@@ -50,7 +66,7 @@ typedef struct {
  * @param cfg mmap emulation configuration setting
  * @return ESP_OK on success
  *         ESP_ERR_INVALID_STATE if already initialized
- *         ESP_ERR_NOT_FOUND if file creation fails
+ *         ESP_ERR_NOT_FOUND if backing file cannot be created or opened (named path or default temp file via mkstemp)
  *         ESP_ERR_INVALID_SIZE if file size setting fails
  *         ESP_ERR_NO_MEM if memory not available or mmap fails
  */
@@ -60,8 +76,8 @@ esp_err_t nand_emul_init(spi_nand_flash_device_t *handle, nand_file_mmap_emul_co
  * @brief Clean up NAND flash emulation
  *
  * @param handle spi_nand_flash_device_t handle for nand device
- * @return ESP_OK on success
- *         ESP_ERR_INVALID_STATE if not initialized
+ * @return ESP_OK on success, or if @p handle is NULL or emulation was never initialized / already deinitialized (idempotent)
+ *         ESP_ERR_INVALID_STATE if emulation handle exists but is not mapped (inconsistent state)
  *         ESP_ERR_INVALID_RESPONSE if cleanup operations fail
  */
 esp_err_t nand_emul_deinit(spi_nand_flash_device_t *handle);
@@ -74,7 +90,7 @@ esp_err_t nand_emul_deinit(spi_nand_flash_device_t *handle);
  * @param dst Destination buffer
  * @param size Number of bytes to read
  * @return ESP_OK on success
- *         ESP_ERR_INVALID_STATE if not initialized
+ *         ESP_ERR_INVALID_STATE if there is no emulation handle or the backing mmap is not ready
  *         ESP_ERR_INVALID_SIZE if read would exceed flash size
  */
 esp_err_t nand_emul_read(spi_nand_flash_device_t *handle, size_t addr, void *dst, size_t size);
@@ -87,7 +103,7 @@ esp_err_t nand_emul_read(spi_nand_flash_device_t *handle, size_t addr, void *dst
  * @param src Source data buffer
  * @param size Number of bytes to write
  * @return ESP_OK on success
- *         ESP_ERR_INVALID_STATE if not initialized
+ *         ESP_ERR_INVALID_STATE if there is no emulation handle or the backing mmap is not ready
  *         ESP_ERR_INVALID_SIZE if write would exceed flash size
  */
 esp_err_t nand_emul_write(spi_nand_flash_device_t *handle, size_t addr, const void *src, size_t size);
@@ -98,8 +114,8 @@ esp_err_t nand_emul_write(spi_nand_flash_device_t *handle, size_t addr, const vo
  * @param handle spi_nand_flash_device_t handle for nand device
  * @param offset Block Address offset to erase
  * @return ESP_OK on success
- *         ESP_ERR_INVALID_STATE if not initialized
- *         ESP_ERR_INVALID_ARG if address is not block-aligned or exceeds flash size
+ *         ESP_ERR_INVALID_STATE if there is no emulation handle or the backing mmap is not ready
+ *         ESP_ERR_INVALID_SIZE if erase range would exceed emulated flash size
  */
 esp_err_t nand_emul_erase_block(spi_nand_flash_device_t *handle, size_t offset);
 

--- a/spi_nand_flash/include/spi_nand_flash_test_helpers.h
+++ b/spi_nand_flash/include/spi_nand_flash_test_helpers.h
@@ -17,10 +17,28 @@ extern "C" {
 void spi_nand_flash_fill_buffer(uint8_t *dst, size_t count);
 
 /**
+ * @brief Fill buffer with a deterministic pattern using a caller-supplied seed.
+ *
+ * Pattern: word[i] = seed + i (uint32_t words). Use a different seed per write
+ * round to produce distinct data across multiple overwrites of the same sector.
+ *
+ * @param dst   Destination buffer (must be 4-byte aligned, count * 4 bytes)
+ * @param count Number of uint32_t words to fill
+ * @param seed  Pattern seed value
+ */
+void spi_nand_flash_fill_buffer_seeded(uint8_t *dst, size_t count, uint32_t seed);
+
+/**
  * Check buffer against the same deterministic pattern.
  * @return 0 on match, 1-based index of first mismatch on failure.
  */
 int spi_nand_flash_check_buffer(const uint8_t *src, size_t count);
+
+/**
+ * Check buffer against spi_nand_flash_fill_buffer_seeded(@p seed).
+ * @return 0 on match, 1-based index of first mismatch on failure.
+ */
+int spi_nand_flash_check_buffer_seeded(const uint8_t *src, size_t count, uint32_t seed);
 
 #ifdef __cplusplus
 }

--- a/spi_nand_flash/src/nand_flash_blockdev.c
+++ b/spi_nand_flash/src/nand_flash_blockdev.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <inttypes.h>
 #include <string.h>
 #include "esp_check.h"
 #include "esp_err.h"
@@ -90,7 +91,8 @@ static esp_err_t nand_flash_blockdev_write(esp_blockdev_handle_t handle, const u
     }
 
     if ((dst_addr % handle->geometry.write_size) != 0) {
-        ESP_LOGE(TAG, "Write address 0x%" PRIx64 " not aligned to page size %zu", dst_addr, handle->geometry.write_size);
+        ESP_LOGE(TAG, "Write address 0x%" PRIx64 " not aligned to page size %" PRIu32, dst_addr,
+                 (uint32_t)handle->geometry.write_size);
         return ESP_ERR_INVALID_SIZE;
     }
 
@@ -129,12 +131,12 @@ static esp_err_t nand_flash_blockdev_erase(esp_blockdev_handle_t handle, uint64_
     }
 
     if ((start_addr % erase_size) != 0) {
-        ESP_LOGE(TAG, "Erase address 0x%" PRIx64 " not aligned to block size %zu", start_addr, erase_size);
+        ESP_LOGE(TAG, "Erase address 0x%" PRIx64 " not aligned to block size %" PRIu32, start_addr, erase_size);
         return ESP_ERR_INVALID_SIZE;
     }
 
     if (erase_len == 0 || (erase_len % erase_size) != 0) {
-        ESP_LOGE(TAG, "Erase length %zu must be non-zero and a multiple of block size %zu", erase_len, erase_size);
+        ESP_LOGE(TAG, "Erase length %zu must be non-zero and a multiple of block size %" PRIu32, erase_len, erase_size);
         return ESP_ERR_INVALID_SIZE;
     }
 

--- a/spi_nand_flash/src/nand_impl_linux.c
+++ b/spi_nand_flash/src/nand_impl_linux.c
@@ -1,9 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <inttypes.h>
+#include <stdint.h>
 #include <string.h>
 #include "esp_check.h"
 #include "esp_err.h"
@@ -12,6 +14,28 @@
 #include "nand_linux_mmap_emul.h"
 
 static const char *TAG = "nand_linux";
+
+/* OOB marker layout at page data offset `page_size` (matches nand_impl.c HW path):
+ * bytes 0-1: bad-block marker (0xFFFF = good / erased, 0x0000 = bad)
+ * bytes 2-3: page-used marker (0xFFFF = free, 0x0000 = used after program) */
+static const uint8_t s_oob_used_page_markers[4] = { 0xFF, 0xFF, 0x00, 0x00 };
+static const uint8_t s_oob_mark_bad_markers[4] = { 0x00, 0x00, 0xFF, 0xFF };
+
+/* Start of erase block `block` in the mmap file: ppb slots of (data + OOB) per page. */
+static esp_err_t linux_mmap_block_file_offset(const spi_nand_flash_device_t *handle, uint32_t block, size_t *out_offset)
+{
+    ESP_RETURN_ON_FALSE(out_offset != NULL, ESP_ERR_INVALID_ARG, TAG, "out_offset is NULL");
+    ESP_RETURN_ON_FALSE(handle->chip.num_blocks > 0, ESP_ERR_INVALID_STATE, TAG, "num_blocks is 0");
+    ESP_RETURN_ON_FALSE(block < handle->chip.num_blocks, ESP_ERR_INVALID_ARG, TAG, "block index out of range");
+
+    const uint64_t ppb = 1ull << handle->chip.log2_ppb;
+    const uint64_t bytes_per_block = ppb * (uint64_t)handle->chip.emulated_page_size;
+    const uint64_t off = (uint64_t)block * bytes_per_block;
+
+    ESP_RETURN_ON_FALSE(off <= (uint64_t)SIZE_MAX, ESP_ERR_INVALID_SIZE, TAG, "mmap block offset overflow");
+    *out_offset = (size_t)off;
+    return ESP_OK;
+}
 
 static esp_err_t detect_chip(spi_nand_flash_device_t *dev)
 {
@@ -31,15 +55,26 @@ static esp_err_t detect_chip(spi_nand_flash_device_t *dev)
         dev->chip.emulated_page_oob = 128;
     }
     dev->chip.emulated_page_size = dev->chip.page_size + dev->chip.emulated_page_oob;
-    dev->chip.block_size = (1 << dev->chip.log2_ppb) * dev->chip.emulated_page_size;
+    /* chip.block_size: user-visible data per erase block (matches nand_impl.c / BDL).
+     * File layout interleaves OOB after each page; use file_bytes_per_block for num_blocks
+     * and linux_mmap_block_file_offset() for mmap byte addresses. */
+    dev->chip.block_size = (1u << dev->chip.log2_ppb) * dev->chip.page_size;
+    const uint32_t file_bytes_per_block = (1u << dev->chip.log2_ppb) * dev->chip.emulated_page_size;
 
-    if (dev->chip.block_size == 0) {
+    if (dev->chip.block_size == 0 || file_bytes_per_block == 0) {
         ESP_LOGE(TAG, "Invalid block size (0)");
         ret = ESP_ERR_INVALID_SIZE;
         goto fail;
     }
 
-    dev->chip.num_blocks = config->emul_conf->flash_file_size / dev->chip.block_size;
+    if (config->emul_conf->flash_file_size % dev->chip.block_size != 0) {
+        ESP_LOGE(TAG, "flash_file_size (0x%" PRIx64 ") is not a multiple of chip.block_size (0x%" PRIx32 ")",
+                 config->emul_conf->flash_file_size, dev->chip.block_size);
+        ret = ESP_ERR_INVALID_SIZE;
+        goto fail;
+    }
+
+    dev->chip.num_blocks = config->emul_conf->flash_file_size / file_bytes_per_block;
     dev->chip.erase_block_delay_us = 3000;
     dev->chip.program_page_delay_us = 630;
     dev->chip.read_page_delay_us = 60;
@@ -75,7 +110,6 @@ esp_err_t nand_init_device(spi_nand_flash_config_t *config, spi_nand_flash_devic
     (*handle)->chip.page_size = 1 << (*handle)->chip.log2_page_size;
     (*handle)->chip.block_size = (1 << (*handle)->chip.log2_ppb) * (*handle)->chip.page_size;
 
-
     ESP_GOTO_ON_ERROR(detect_chip(*handle), fail, TAG, "Failed to detect nand chip");
 
     (*handle)->work_buffer = heap_caps_malloc((*handle)->chip.page_size, MALLOC_CAP_DEFAULT);
@@ -104,41 +138,42 @@ fail:
 
 esp_err_t nand_is_bad(spi_nand_flash_device_t *handle, uint32_t block, bool *is_bad_status)
 {
-    uint16_t bad_block_indicator = 0xFFFF;
-    esp_err_t ret = ESP_OK;
-    uint32_t block_offset = block * handle->chip.block_size;
+    uint8_t markers[4];
+    size_t block_offset = 0;
 
-    // Read the first 2 bytes on the OOB of the first page in the block. This should be 0xFFFF for a good block
-    ESP_RETURN_ON_ERROR(nand_emul_read(handle, block_offset + handle->chip.page_size, (uint8_t *) &bad_block_indicator, 2),
-                        TAG, "Error in nand_is_bad %d", ret);
+    ESP_RETURN_ON_ERROR(linux_mmap_block_file_offset(handle, block, &block_offset), TAG, "nand_is_bad: mmap block offset failed");
 
-    ESP_LOGD(TAG, "is_bad, block=%"PRIu32", page=%"PRIu32",indicator = %04x", block, block_offset, bad_block_indicator);
-    *is_bad_status = bad_block_indicator != 0xFFFF;
-    return ret;
+    ESP_RETURN_ON_ERROR(nand_emul_read(handle, block_offset + handle->chip.page_size, markers, sizeof(markers)),
+                        TAG, "Error in nand_is_bad");
+
+    ESP_LOGD(TAG, "is_bad, block=%"PRIu32", file_off=%zu,indicator = %02x,%02x", block, block_offset, markers[0], markers[1]);
+    *is_bad_status = (markers[0] != 0xFF || markers[1] != 0xFF);
+    return ESP_OK;
 }
 
 esp_err_t nand_mark_bad(spi_nand_flash_device_t *handle, uint32_t block)
 {
-    esp_err_t ret = ESP_OK;
+    size_t block_base = 0;
 
-    uint32_t first_block_page = block * (1 << handle->chip.log2_ppb);
-    uint16_t bad_block_indicator = 0;
-    ESP_LOGD(TAG, "mark_bad, block=%"PRIu32", page=%"PRIu32",indicator = %04x", block, first_block_page, bad_block_indicator);
+    uint64_t first_block_page = (uint64_t)block * (1ull << handle->chip.log2_ppb);
+    ESP_LOGD(TAG, "mark_bad, block=%"PRIu32", first_page=%"PRIu64"", block, first_block_page);
 
-    ESP_RETURN_ON_ERROR(nand_emul_erase_block(handle, block * handle->chip.block_size), TAG, "Error in nand_mark_bad %d", ret);
+    ESP_RETURN_ON_ERROR(linux_mmap_block_file_offset(handle, block, &block_base), TAG, "nand_mark_bad: mmap block offset failed");
+    ESP_RETURN_ON_ERROR(nand_emul_erase_block(handle, block_base), TAG, "nand_mark_bad: erase failed");
 
-    ESP_RETURN_ON_ERROR(nand_emul_write(handle, block * handle->chip.block_size + handle->chip.page_size,
-                                        (const uint8_t *) &bad_block_indicator, 2), TAG, "Error in nand_mark_bad %d", ret);
+    ESP_RETURN_ON_ERROR(nand_emul_write(handle, block_base + handle->chip.page_size,
+                                        s_oob_mark_bad_markers, sizeof(s_oob_mark_bad_markers)), TAG, "nand_mark_bad: OOB marker write failed");
 
-    return ret;
+    return ESP_OK;
 }
 
 esp_err_t nand_erase_block(spi_nand_flash_device_t *handle, uint32_t block)
 {
     ESP_LOGD(TAG, "erase_block, block=%"PRIu32",", block);
     esp_err_t ret = ESP_OK;
+    size_t address = 0;
 
-    uint32_t address = block * handle->chip.block_size;
+    ESP_RETURN_ON_ERROR(linux_mmap_block_file_offset(handle, block, &address), TAG, "nand_erase_block: mmap block offset failed");
 
     ESP_RETURN_ON_ERROR(nand_emul_erase_block(handle, address), TAG, "Error in nand_erase %x", ret);
     return ESP_OK;
@@ -181,12 +216,11 @@ esp_err_t nand_prog(spi_nand_flash_device_t *handle, uint32_t page, const uint8_
 {
     ESP_LOGV(TAG, "prog, page=%"PRIu32",", page);
     esp_err_t ret = ESP_OK;
-    uint16_t used_marker = 0;
     uint32_t data_offset = page * handle->chip.emulated_page_size;
 
     ESP_RETURN_ON_ERROR(nand_emul_write(handle, data_offset, data, handle->chip.page_size), TAG, "Error in nand_prog %d", ret);
-    ESP_RETURN_ON_ERROR(nand_emul_write(handle, data_offset + handle->chip.page_size + 2,
-                                        (uint8_t *)&used_marker, 2), TAG, "Error in nand_prog %d", ret);
+    ESP_RETURN_ON_ERROR(nand_emul_write(handle, data_offset + handle->chip.page_size,
+                                        s_oob_used_page_markers, sizeof(s_oob_used_page_markers)), TAG, "Error in nand_prog %d", ret);
 
     return ret;
 }
@@ -194,13 +228,14 @@ esp_err_t nand_prog(spi_nand_flash_device_t *handle, uint32_t page, const uint8_
 esp_err_t nand_is_free(spi_nand_flash_device_t *handle, uint32_t page, bool *is_free_status)
 {
     esp_err_t ret = ESP_OK;
-    uint16_t used_marker = 0xFF;
+    uint8_t markers[4];
 
-    ESP_RETURN_ON_ERROR(nand_emul_read(handle, page * handle->chip.emulated_page_size + handle->chip.page_size + 2, (uint8_t *)&used_marker, 2),
+    ESP_RETURN_ON_ERROR(nand_emul_read(handle, page * handle->chip.emulated_page_size + handle->chip.page_size,
+                                       markers, sizeof(markers)),
                         TAG, "Error in nand_is_free %d", ret);
 
-    ESP_LOGD(TAG, "is free, page=%"PRIu32", used_marker=%04x,", page, used_marker);
-    *is_free_status = (used_marker == 0xFFFF);
+    ESP_LOGD(TAG, "is free, page=%"PRIu32", used_marker=%02x%02x,", page, markers[2], markers[3]);
+    *is_free_status = (markers[2] == 0xFF && markers[3] == 0xFF);
     return ret;
 }
 
@@ -222,10 +257,13 @@ esp_err_t nand_copy(spi_nand_flash_device_t *handle, uint32_t src, uint32_t dst)
     esp_err_t ret = ESP_OK;
     uint32_t dst_offset = dst * handle->chip.emulated_page_size;
     uint32_t src_offset = src * handle->chip.emulated_page_size;
+
     ESP_RETURN_ON_ERROR(nand_emul_read(handle, (size_t)src_offset, (void *)handle->read_buffer, handle->chip.page_size),
                         TAG, "Error in nand_copy %d", ret);
     ESP_RETURN_ON_ERROR(nand_emul_write(handle, (size_t)dst_offset, (void *)handle->read_buffer, handle->chip.page_size),
                         TAG, "Error in nand_copy %d", ret);
+    ESP_RETURN_ON_ERROR(nand_emul_write(handle, (size_t)dst_offset + handle->chip.page_size,
+                                        s_oob_used_page_markers, sizeof(s_oob_used_page_markers)), TAG, "Error in nand_copy %d", ret);
 
     return ret;
 }

--- a/spi_nand_flash/src/nand_linux_mmap_emul.c
+++ b/spi_nand_flash/src/nand_linux_mmap_emul.c
@@ -1,6 +1,8 @@
 /*
- * NAND Flash Memory Emulation for Linux Host
- */
+* SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -28,11 +30,10 @@ static esp_err_t nand_emul_mmap_init(nand_mmap_emul_handle_t *emul_handle)
         return ESP_ERR_INVALID_STATE;
     }
 
-    // Create or open file
-    if (emul_handle->file_mmap_ctrl.flash_file_name[0] != '\0') {
+    // Open the backing file. If nand_emul_init already opened it via mkstemp(),
+    // mem_file_fd is valid and we skip open().
+    if (emul_handle->mem_file_fd == -1) {
         emul_handle->mem_file_fd = open(emul_handle->file_mmap_ctrl.flash_file_name, O_RDWR | O_CREAT, 0600);
-    } else {
-        emul_handle->mem_file_fd = mkstemp(emul_handle->file_mmap_ctrl.flash_file_name);
     }
 
     if (emul_handle->mem_file_fd == -1) {
@@ -124,19 +125,44 @@ esp_err_t nand_emul_init(spi_nand_flash_device_t *handle, nand_file_mmap_emul_co
     if (!cfg->flash_file_size) {
         cfg->flash_file_size = EMULATED_NAND_SIZE;
     }
-    strlcpy(emul_handle->file_mmap_ctrl.flash_file_name,
-            *(cfg->flash_file_name) ? cfg->flash_file_name : "/tmp/idf-nand-XXXXXX",
-            sizeof(emul_handle->file_mmap_ctrl.flash_file_name));
+    if (*(cfg->flash_file_name)) {
+        // Named file: copy the caller-provided path
+        strlcpy(emul_handle->file_mmap_ctrl.flash_file_name,
+                cfg->flash_file_name,
+                sizeof(emul_handle->file_mmap_ctrl.flash_file_name));
+    } else {
+        // Temporary file: copy the template and let mkstemp resolve it now,
+        // so that nand_emul_mmap_init sees the real path and an already-open fd.
+        strlcpy(emul_handle->file_mmap_ctrl.flash_file_name,
+                "/tmp/idf-nand-XXXXXX",
+                sizeof(emul_handle->file_mmap_ctrl.flash_file_name));
+        emul_handle->mem_file_fd = mkstemp(emul_handle->file_mmap_ctrl.flash_file_name);
+        if (emul_handle->mem_file_fd == -1) {
+            ESP_LOGE(TAG, "Failed to create temporary NAND file: %s", strerror(errno));
+            free(emul_handle);
+            handle->emul_handle = NULL;
+            return ESP_ERR_NOT_FOUND;
+        }
+    }
     emul_handle->file_mmap_ctrl.flash_file_size = cfg->flash_file_size ? cfg->flash_file_size : EMULATED_NAND_SIZE;
     emul_handle->file_mmap_ctrl.keep_dump = cfg->keep_dump;
 
-    return nand_emul_mmap_init(emul_handle);
+    esp_err_t err = nand_emul_mmap_init(emul_handle);
+    if (err != ESP_OK) {
+        free(emul_handle);
+        handle->emul_handle = NULL;
+    }
+    return err;
 }
 
 esp_err_t nand_emul_deinit(spi_nand_flash_device_t *handle)
 {
+    if (handle == NULL || handle->emul_handle == NULL) {
+        return ESP_OK;
+    }
     esp_err_t ret = nand_emul_mmap_deinit(handle->emul_handle);
     free(handle->emul_handle);
+    handle->emul_handle = NULL;
     return ret;
 }
 
@@ -144,10 +170,18 @@ esp_err_t nand_emul_deinit(spi_nand_flash_device_t *handle)
 esp_err_t nand_emul_read(spi_nand_flash_device_t *handle, size_t addr, void *dst, size_t size)
 {
     nand_mmap_emul_handle_t *emul_handle = handle->emul_handle;
+    if (emul_handle == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
     if (emul_handle->mem_file_buf == NULL) {
         return ESP_ERR_INVALID_STATE;
     }
-    if (addr + size > emul_handle->file_mmap_ctrl.flash_file_size) {
+    size_t limit = emul_handle->file_mmap_ctrl.flash_file_size;
+    /* Avoid computing addr + size for the bounds test: with unsigned size_t that sum can
+     * wrap, so addr + size > limit could be false even when the access runs past the end.
+     * If size > limit the range is invalid. Otherwise size <= limit makes (limit - size)
+     * well defined, and addr > limit - size is equivalent to addr + size > limit. */
+    if (size > limit || addr > limit - size) {
         return ESP_ERR_INVALID_SIZE;
     }
 
@@ -166,10 +200,15 @@ esp_err_t nand_emul_read(spi_nand_flash_device_t *handle, size_t addr, void *dst
 esp_err_t nand_emul_write(spi_nand_flash_device_t *handle, size_t addr, const void *src, size_t size)
 {
     nand_mmap_emul_handle_t *emul_handle = handle->emul_handle;
+    if (emul_handle == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
     if (emul_handle->mem_file_buf == NULL) {
         return ESP_ERR_INVALID_STATE;
     }
-    if (addr + size > emul_handle->file_mmap_ctrl.flash_file_size) {
+    size_t limit = emul_handle->file_mmap_ctrl.flash_file_size;
+    /* Overflow-safe range check; see comment in nand_emul_read. */
+    if (size > limit || addr > limit - size) {
         return ESP_ERR_INVALID_SIZE;
     }
 
@@ -192,16 +231,24 @@ esp_err_t nand_emul_write(spi_nand_flash_device_t *handle, size_t addr, const vo
 esp_err_t nand_emul_erase_block(spi_nand_flash_device_t *handle, size_t offset)
 {
     nand_mmap_emul_handle_t *emul_handle = handle->emul_handle;
+    if (emul_handle == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
     if (emul_handle->mem_file_buf == NULL) {
         return ESP_ERR_INVALID_STATE;
     }
 
-    if (offset + handle->chip.block_size > emul_handle->file_mmap_ctrl.flash_file_size) {
+    /* Erase one physical block in the mmap file: ppb pages × (data + OOB) each.
+     * chip.block_size is data-only (BDL); nbytes is the on-disk stride for this layer. */
+    const size_t nbytes = (size_t)(1u << handle->chip.log2_ppb) * (size_t)handle->chip.emulated_page_size;
+    size_t limit = emul_handle->file_mmap_ctrl.flash_file_size;
+    /* Same principle as read/write: do not test offset + nbytes (unsigned wrap). */
+    if (nbytes > limit || offset > limit - nbytes) {
         return ESP_ERR_INVALID_SIZE;
     }
 
     void *dst_addr = emul_handle->mem_file_buf + offset;
-    memset(dst_addr, 0xFF,  handle->chip.block_size);
+    memset(dst_addr, 0xFF, nbytes);
 
 #ifdef CONFIG_NAND_ENABLE_STATS
     emul_handle->stats.erase_ops++;
@@ -215,6 +262,9 @@ esp_err_t nand_emul_erase_block(spi_nand_flash_device_t *handle, size_t offset)
 void nand_emul_clear_stats(spi_nand_flash_device_t *handle)
 {
     nand_mmap_emul_handle_t *emul_handle = handle->emul_handle;
+    if (emul_handle == NULL) {
+        return;
+    }
     emul_handle->stats.read_ops = 0;
     emul_handle->stats.write_ops = 0;
     emul_handle->stats.erase_ops = 0;

--- a/spi_nand_flash/src/spi_nand_flash_test_helpers.c
+++ b/spi_nand_flash/src/spi_nand_flash_test_helpers.c
@@ -16,11 +16,30 @@ void spi_nand_flash_fill_buffer(uint8_t *dst, size_t count)
     }
 }
 
+void spi_nand_flash_fill_buffer_seeded(uint8_t *dst, size_t count, uint32_t seed)
+{
+    uint32_t *p = (uint32_t *)dst;
+    for (size_t i = 0; i < count; ++i) {
+        p[i] = seed + (uint32_t)i;
+    }
+}
+
 int spi_nand_flash_check_buffer(const uint8_t *src, size_t count)
 {
     const uint32_t *p = (const uint32_t *)src;
     for (size_t i = 0; i < count; ++i) {
         if (p[i] != SPI_NAND_FLASH_PATTERN_SEED + (uint32_t)i) {
+            return (int)(i + 1);
+        }
+    }
+    return 0;
+}
+
+int spi_nand_flash_check_buffer_seeded(const uint8_t *src, size_t count, uint32_t seed)
+{
+    const uint32_t *p = (const uint32_t *)src;
+    for (size_t i = 0; i < count; ++i) {
+        if (p[i] != seed + (uint32_t)i) {
             return (int)(i + 1);
         }
     }


### PR DESCRIPTION
## Description
Patch release for `spi_nand_flash` (**1.0.2** in `idf_component.yml`). Focus is **Linux mmap NAND emulation correctness**, **BDL logging fixes**, and **expanded Linux host tests**. Fault-injection work is **not** part of this change set.
### Fixes
- BDL: correct `printf`-style format specifiers for size-related fields on 64-bit Linux (avoids UB and bogus logs).
- Linux NAND emulation: OOB markers and free-page detection aligned with the real hardware path.
- Linux mmap: correct backing file path selection for the emulated image.
- Linux mmap layout: on-disk stride accounts for interleaved OOB vs user-visible erase-block size (bad-block handling, erase, and OOB clearing).
### Documentation
- `nand_file_mmap_emul_config_t`: document how backing file size relates to interleaved OOB and reported user capacity.
- `README.md` / `host_test/README.md`: align with current mmap config API, build/run notes, and BDL prerequisites where relevant.
### Testing
- Linux host: broader **FTL** and **BDL** coverage.
- Shared buffer pattern helpers (including seeded patterns) for host tests and the in-tree test app.
### Release note
See `spi_nand_flash/CHANGELOG.md` section **[1.0.2]** for the authoritative list.