### PR TITLE
fix(coap): Update to libcoap v4.3.5b (IEC-524)

### DIFF
--- a/coap/idf_component.yml
+++ b/coap/idf_component.yml
@@ -1,4 +1,4 @@
-version: "4.3.5~5"
+version: "4.3.5~6"
 description: Constrained Application Protocol (CoAP) C Library
 url: https://github.com/espressif/idf-extra-components/tree/master/coap
 dependencies:

--- a/coap/sbom_libcoap.yml
+++ b/coap/sbom_libcoap.yml
@@ -4,7 +4,7 @@ cpe: cpe:2.3:a:libcoap:libcoap:{}:*:*:*:*:*:*:*
 supplier: 'Organization: libcoap <https://libcoap.net/>'
 description: A CoAP (RFC 7252) implementation in C
 url: https://github.com/obgm/libcoap
-hash: 1c26ef352a4ec19fc07428d7f3d90971d608d456
+hash: d9b4031ee61df1a40ecec46fe3817a1f985b3919
 cve-exclude-list:
   - cve: CVE-2024-31031
     reason: Resolved in version 4.3.5-rc1
@@ -36,3 +36,5 @@ cve-exclude-list:
     reason: Resolved in version 4.3.5a
   - cve: CVE-2025-34468
     reason: Resolved in version 4.3.5a
+  - cve: CVE-2026-29013
+    reason: Resolved in version 4.3.5b


### PR DESCRIPTION


# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Update to tag 4.3.5b.  Fixes some critical issues.
