### PR TITLE
fix(libsodium): disable C11 Annex K declarations to fix build with picolibc and update library to 1.0.22

### DIFF
--- a/libsodium/CMakeLists.txt
+++ b/libsodium/CMakeLists.txt
@@ -153,6 +153,7 @@ target_compile_definitions(${COMPONENT_LIB} PRIVATE
     HAVE_WEAK_SYMBOLS
     __STDC_LIMIT_MACROS
     __STDC_CONSTANT_MACROS
+    __STDC_WANT_LIB_EXT1__=0
     )
 
 # patch around warnings in third-party files

--- a/libsodium/CMakeLists.txt
+++ b/libsodium/CMakeLists.txt
@@ -40,10 +40,15 @@ set(srcs
     "${SRC}/crypto_hash/crypto_hash.c"
     "${SRC}/crypto_hash/sha256/hash_sha256.c"
     "${SRC}/crypto_hash/sha512/hash_sha512.c"
+    "${SRC}/crypto_hash/sha3/hash_sha3.c"
     "${SRC}/crypto_kdf/blake2b/kdf_blake2b.c"
     "${SRC}/crypto_kdf/crypto_kdf.c"
     "${SRC}/crypto_kdf/hkdf/kdf_hkdf_sha256.c"
     "${SRC}/crypto_kdf/hkdf/kdf_hkdf_sha512.c"
+    "${SRC}/crypto_kem/crypto_kem.c"
+    "${SRC}/crypto_kem/mlkem768/kem_mlkem768.c"
+    "${SRC}/crypto_kem/mlkem768/ref/kem_mlkem768_ref.c"
+    "${SRC}/crypto_kem/xwing/kem_xwing.c"
     "${SRC}/crypto_kx/crypto_kx.c"
     "${SRC}/crypto_onetimeauth/crypto_onetimeauth.c"
     "${SRC}/crypto_onetimeauth/poly1305/donna/poly1305_donna.c"
@@ -182,6 +187,16 @@ set_source_files_properties(
     ${SRC}/crypto_shorthash/siphash24/ref/shorthash_siphash24_ref.c
     PROPERTIES COMPILE_FLAGS
     -Wno-implicit-fallthrough
+    )
+
+# Upstream libsodium 1.0.22 KEM sources define parameters as plain pointers
+# while their headers declare them as fixed-size arrays, which trips
+# -Werror=array-parameter on GCC >= 11. Suppress until fixed upstream.
+set_source_files_properties(
+    ${SRC}/crypto_kem/mlkem768/kem_mlkem768.c
+    ${SRC}/crypto_kem/xwing/kem_xwing.c
+    PROPERTIES COMPILE_FLAGS
+    -Wno-array-parameter
     )
 
 set_source_files_properties(

--- a/libsodium/idf_component.yml
+++ b/libsodium/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.21"
+version: "1.0.22"
 description: libsodium port to ESP
 url: https://github.com/espressif/idf-extra-components/tree/master/libsodium
 dependencies:

--- a/libsodium/sbom_libsodium.yml
+++ b/libsodium/sbom_libsodium.yml
@@ -1,10 +1,10 @@
 name: libsodium
-version: "1.0.21"
+version: "1.0.22"
 cpe: cpe:2.3:a:jedisct1:libsodium:{}:*:*:*:*:*:*:*
 supplier: 'Person: Frank Denis (jedisct1)'
 description: A modern, portable, easy to use crypto library
 url: https://github.com/jedisct1/libsodium
-hash: d24faf56214469b354b01c8ba36257e04737101e
+hash: 77e1ce5d6dee871c49ef211222ba18ef0c486bda
 cve-exclude-list:
   - cve: CVE-2025-69277
     reason: Resolved in version 1.0.21 with commit f2da4cd8cb26

--- a/libsodium/test_apps/main/CMakeLists.txt
+++ b/libsodium/test_apps/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 get_filename_component(LS_TESTDIR "${CMAKE_CURRENT_LIST_DIR}/../../libsodium/test/default" ABSOLUTE)
 
-set(TEST_CASES "aead_aegis128l;aead_aegis256;chacha20;aead_chacha20poly1305;box;box2;ed25519_convert;sign;hash")
+set(TEST_CASES "aead_aegis128l;aead_aegis256;chacha20;aead_chacha20poly1305;box;box2;ed25519_convert;sign;hash;kem;kem_mlkem768;kem_xwing")
 
 foreach(test_case ${TEST_CASES})
     file(GLOB test_case_file "${LS_TESTDIR}/${test_case}.c")

--- a/libsodium/test_apps/main/test_sodium.c
+++ b/libsodium/test_apps/main/test_sodium.c
@@ -58,6 +58,9 @@ LIBSODIUM_TEST(box2)
 LIBSODIUM_TEST(ed25519_convert)
 LIBSODIUM_TEST(hash)
 LIBSODIUM_TEST(sign)
+LIBSODIUM_TEST(kem)
+LIBSODIUM_TEST(kem_mlkem768)
+LIBSODIUM_TEST(kem_xwing)
 
 
 TEST_CASE("sha256 sanity check", "[libsodium]")


### PR DESCRIPTION
## Problem

Building libsodium with ESP-IDF v6.0+ (picolibc) fails with:

```
picolibc/include/errno.h:43:9: error: unknown type name '__errno_t'
picolibc/include/string.h:219:9: error: unknown type name '__rsize_t'
```

## Root Cause

libsodium's `utils.c` defines `__STDC_WANT_LIB_EXT1__=1` to request C11 Annex K types. In picolibc those types (`__errno_t`, `__rsize_t`) live in `sys/_types.h`, gated behind that same macro.

Via the force-include in `libsodium/CMakeLists.txt`, the PSA → mbedTLS → libc chain pulls `sys/_types.h` in **before** `utils.c` sets the macro:

```
port_include/sodium/crypto_hash_sha256.h
  └── <psa/crypto.h>
      └── <psa/crypto_struct.h>
          └── <psa/crypto_driver_contexts_primitives.h>
              └── … (PSA driver context chain) …
                  └── <mbedtls/platform_time.h>
                      └── <time.h>
                          └── <sys/_types.h>   ← typedefs gated here
```

Once the include guard fires, `__errno_t` / `__rsize_t` are never declared, and later `errno.h` / `string.h` fail. The libsodium test app doesn't reach this chain, so CI never tripped on it.

## Fix

Add `-D__STDC_WANT_LIB_EXT1__=0` as a compile definition in `libsodium/CMakeLists.txt`. The `-D` applies before any source, overriding `utils.c`, so picolibc skips the Annex K declarations regardless of include order. libsodium on ESP-IDF does not use Annex K functions.

Component version bumped to `1.0.22`.

## References

- [picolibc#868](https://github.com/picolibc/picolibc/pull/868) — upstream fix rejected; per C standard, only applications should define `__STDC_WANT_LIB_EXT1__`
- [zephyr#104666](https://github.com/zephyrproject-rtos/zephyr/issues/104666) — same issue in Zephyr

## Update libsodium to v1.0.22

This PR also bumps the libsodium submodule from `1.0.21-RELEASE` to `1.0.22-RELEASE`, so the `1.0.22` component version actually matches the underlying source.

What changed:
- Submodule pointer moved to the `1.0.22-RELEASE` tag.
- New 1.0.22 sources added to the build: ML-KEM768, X-Wing hybrid KEM (ML-KEM768 + X25519), the high-level `crypto_kem_*` API, and SHA-3.
- `sbom_libsodium.yml` updated with the new version and commit hash.
- Upstream KEM tests (`kem`, `kem_mlkem768`, `kem_xwing`) added to the test app to verify ML-KEM and X-Wing on target.

##### Found no CVE using command `esp-idf-sbom manifest check --local-db --extended-scan libsodium/`