### PR TITLE
fix(spi_nand_flash): fix incorrect flash geometry parameter for GD5F4GM8xExxG

### DIFF
--- a/spi_nand_flash/CHANGELOG.md
+++ b/spi_nand_flash/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.1]
+- fix: fix incorrect flash geometry parameter for flash GD5F4GM8xExxG
+
 ## [1.0.0]
 ### Breaking Changes
 - FATFS integration has been moved to a separate `spi_nand_flash_fatfs` component. Projects using FATFS with NAND flash must add `spi_nand_flash_fatfs` as a dependency. FatFs on SPI NAND still requires the **legacy** init path: keep **`CONFIG_NAND_FLASH_ENABLE_BDL` disabled** for that use case (no FatFs-on-BDL support in this release).

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+version: "1.0.1"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/src/devices/nand_gigadevice.c
+++ b/spi_nand_flash/src/devices/nand_gigadevice.c
@@ -50,9 +50,13 @@ esp_err_t spi_nand_gigadevice_init(spi_nand_flash_device_t *dev)
     case GIGADEVICE_DI_45:
     case GIGADEVICE_DI_35:
     case GIGADEVICE_DI_25:
+        dev->chip.num_blocks = 4096;
+        break;
     case GIGADEVICE_DI_95:
     case GIGADEVICE_DI_85:
         dev->chip.num_blocks = 4096;
+        dev->chip.flags = NAND_FLAG_HAS_PROG_PLANE_SELECT | NAND_FLAG_HAS_READ_PLANE_SELECT;
+        dev->chip.num_planes = 2;
         break;
     default:
         return ESP_ERR_INVALID_RESPONSE;


### PR DESCRIPTION
# Change description

This Pull Request resolves an issue where the GD5F4GM8xExxG (4Gb, DID-85h, 95h) NAND flash fails during page copy operations when using the spi_nand_flash driver. While the datasheet does not explicitly label the device as "dual-plane," its architectural constraints for hardware-accelerated data movement necessitate treating it as such. Updated accordingly.

Datasheet Reference (https://download.gigadevice.com/Datasheet/DS-00846-GD5F4GM8UE-Rev1.5.pdf): Added logic to enforce the rule that Internal Data Move "can only be used on blocks with the same parity attribute" and within the same 2Gb partition
