### PR TITLE
docs(led_strip): fix WS2812 reference link

### DIFF
--- a/led_strip/README.md
+++ b/led_strip/README.md
@@ -2,7 +2,7 @@
 
 [![Component Registry](https://components.espressif.com/components/espressif/led_strip/badge.svg)](https://components.espressif.com/components/espressif/led_strip)
 
-This driver is designed for addressable LEDs like [WS2812](http://www.world-semi.com/Certifications/WS2812B.html), where each LED is controlled by a single data line.
+This driver is designed for addressable LEDs like [WS2812](http://world-semi.com/ws2812-family/), where each LED is controlled by a single data line.
 
 ## Supported Backend Peripherals
 


### PR DESCRIPTION
## Summary
- replace the dead WS2812B vendor link in `led_strip/README.md`
- point the README at the reachable Worldsemi WS2812 family page

Closes #736