### PR TITLE
feat(libpng): update to v1.6.58

### DIFF
--- a/libpng/idf_component.yml
+++ b/libpng/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.6.56"
+version: "1.6.58"
 description: Portable Network Graphics(png) C library
 url: https://github.com/espressif/idf-extra-components/tree/master/libpng
 repository: "https://github.com/espressif/idf-extra-components.git"

--- a/libpng/pnglibconf.h
+++ b/libpng/pnglibconf.h
@@ -1,6 +1,6 @@
 /* pnglibconf.h - library build configuration */
 
-/* libpng version 1.6.56 */
+/* libpng version 1.6.58 */
 
 /* Copyright (c) 2018-2025 Cosmin Truta */
 /* Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson */

--- a/libpng/sbom_libpng.yml
+++ b/libpng/sbom_libpng.yml
@@ -1,12 +1,12 @@
 name: libpng
-version: 1.6.56
+version: 1.6.58
 cpe:
  - cpe:2.3:a:pnggroup:libpng:{}:*:*:*:*:*:*:*
  - cpe:2.3:a:libpng:libpng:{}:*:*:*:*:*:*:*
 supplier: 'Organization: pnggroup'
 description: Portable Network Graphics support, official PNG reference library
 url: https://github.com/pnggroup/libpng
-hash: d5515b5b8be3901aac04e5bd8bd5c89f287bcd33
+hash: 3061454d980de7d53608f594194cfac722721d2a
 cve-exclude-list:
   - cve: CVE-2026-33636
     reason: Resolved in version 1.6.56
@@ -14,4 +14,6 @@ cve-exclude-list:
     reason: Resolved in version 1.6.56
   - cve: CVE-2026-3713
     reason: Resolved in version 1.6.56
+  - cve: CVE-2026-34757
+    reason: Resolved in version 1.6.57
 


### PR DESCRIPTION
# Change description
This PR updates libpng to v1.6.58 which fixes:

1. [CVE-2026-34757](https://nvd.nist.gov/vuln/detail/CVE-2026-34757)
