### PR TITLE
fix(esp_schedule): Using timestamp_cb pulled from NVS could cause crash

### DIFF
--- a/esp_schedule/idf_component.yml
+++ b/esp_schedule/idf_component.yml
@@ -1,9 +1,9 @@
 ## IDF Component Manager Manifest File
-version: "1.3.2"
+version: "1.3.3"
 description: Task scheduling based on periodic and one-time events
 url: https://github.com/espressif/idf-extra-components/tree/master/components/esp_schedule
 repository: https://github.com/espressif/idf-extra-components.git
-issues: https://github.com/espressif/esp-rainmaker/issues
+issues: https://github.com/espressif/idf-extra-components/issues
 dependencies:
   idf: ">=5.1"
   espressif/esp_daylight:

--- a/esp_schedule/include/esp_schedule.h
+++ b/esp_schedule/include/esp_schedule.h
@@ -161,7 +161,7 @@ typedef struct esp_schedule_config {
  * This initializes ESP Schedule. This must be called first before calling any of the other APIs.
  * This API also gets all the schedules from NVS (if it has been enabled).
  *
- * Note: After calling this API, the pointers to the callbacks should be updated for all the schedules by calling
+ * @warning After calling this API, the pointers to the callbacks should be updated for all the schedules by calling
  * esp_schedule_get() followed by esp_schedule_edit() with the correct callbacks.
  *
  * @param[in] enable_nvs If NVS is to be enabled or not.

--- a/esp_schedule/src/esp_schedule.c
+++ b/esp_schedule/src/esp_schedule.c
@@ -831,6 +831,7 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
     for (size_t handle_count = 0; handle_count < *schedule_count; handle_count++) {
         schedule = (esp_schedule_t *)handle_list[handle_count];
         schedule->trigger_cb = NULL;
+        schedule->timestamp_cb = NULL;
         schedule->timer = NULL;
         /* Check for ONCE and expired schedules and delete them. */
         if (esp_schedule_is_expired(&schedule->trigger)) {


### PR DESCRIPTION
Using timestamp_cb pulled from NVS could cause crash on reboot due to potential function address change during recompilation.

Closes https://github.com/espressif/idf-extra-components/issues/734

# Checklist

- [ ] CI passing

# Change description

Added `schedule->timestamp_cb = NULL;` to `esp_schedule_init` funtion.
