### PR TITLE
feat(expat): Update to v2.8.1

### DIFF
--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.8.0"
+version: "2.8.1"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:

--- a/expat/port/include/expat_config.h
+++ b/expat/port/include/expat_config.h
@@ -70,7 +70,7 @@
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.8.0"
+#define PACKAGE_STRING "expat 2.8.1"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -79,13 +79,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.8.0"
+#define PACKAGE_VERSION "2.8.1"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.8.0"
+#define VERSION "2.8.1"
 
 /* whether byteorder is bigendian */
 /* #undef WORDS_BIGENDIAN */

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -1,10 +1,10 @@
 name: libexpat
-version: 2.8.0
+version: 2.8.1
 cpe: cpe:2.3:a:libexpat_project:libexpat:{}:*:*:*:*:*:*:*
 supplier: 'Organization: libexpat_project'
 description: Fast streaming XML parser written in C99
 url: https://github.com/libexpat/libexpat/
-hash: 6345e05baa634fbd60ace0134228cb6af4cfdaef
+hash: c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19
 cve-exclude-list:
-  - cve: CVE-2024-8176
-    reason: Resolved in version 2.7.0, please see https://github.com/libexpat/libexpat/pull/973
+  - cve: CVE-2026-45186
+    reason: Resolved in version 2.8.1, please see https://github.com/libexpat/libexpat/pull/1216


### PR DESCRIPTION
# Change description
This PR updates libexpat to v2.8.1 which fixes

1. [CVE-2026-45186](https://nvd.nist.gov/vuln/detail/CVE-2026-45186)
