### PR TITLE
fix(esp_prov): fixes sec2 client possible public length truncation

### DIFF
--- a/network_provisioning/tool/esp_prov/security/srp6a.py
+++ b/network_provisioning/tool/esp_prov/security/srp6a.py
@@ -229,8 +229,19 @@ class Srp6a (object):
         self.Iu = username
         self.p = password
 
-        self.a = get_random_of_length(32)
-        self.A = pow(g, self.a, N)
+        # Re-roll 'a' until A serializes to exactly len(N) bytes. The device
+        # stores the received A verbatim and re-hashes it during proof
+        # verification, but Python re-derives via long_to_bytes(A) which
+        # strips leading zeros. A leading-zero byte in A (~1/256 chance for
+        # NG_3072) makes the two views diverge and breaks the handshake.
+        n_byte_len = (N.bit_length() + 7) // 8
+        for _ in range(10000):
+            self.a = get_random_of_length(32)
+            self.A = pow(g, self.a, N)
+            if (self.A.bit_length() + 7) // 8 == n_byte_len:
+                break
+        else:
+            raise RuntimeError('SRP6a: failed to generate A with full byte length')
 
         self.v: Optional[int] = None
         self.K: Optional[bytes] = None


### PR DESCRIPTION
# Change description
The Python client's SRP-6a ephemeral public key `A = g^a mod N` is serialized via `long_to_bytes()`, which uses `(n.bit_length() + 7) // 8` and therefore strips leading zero bytes. The device, however, requires the payload to be exactly `PUBLIC_KEY_LEN (384)` bytes for the NG_3072 group (`protocomm/src/security/security2.c`).

## Solution
Re-roll the ephemeral secret `a` in `Srp6a.__init__` until `A` serializes to exactly `len(N)` bytes (i.e. no leading zero byte). This guarantees:
  - `long_to_bytes(A)` consistently produces 384 bytes — wire length check passes
  - Both sides hash the same 384-byte representation of `A` — proofs match
  - All downstream `long_to_bytes(A)` call sites become safe by construction