### PR TITLE
fix(libsodium): fix build failure with platformio (IEC-543)

### DIFF
--- a/libsodium/CMakeLists.txt
+++ b/libsodium/CMakeLists.txt
@@ -209,8 +209,8 @@ target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-unused-function)
 
 if(CONFIG_LIBSODIUM_USE_MBEDTLS_SHA)
     target_compile_options(${COMPONENT_LIB} PRIVATE
-        "$<$<COMPILE_LANGUAGE:C>:SHELL:-include ${CMAKE_CURRENT_SOURCE_DIR}/port_include/sodium/crypto_hash_sha256.h>"
-        "$<$<COMPILE_LANGUAGE:C>:SHELL:-include ${CMAKE_CURRENT_SOURCE_DIR}/port_include/sodium/crypto_hash_sha512.h>")
+        "$<$<COMPILE_LANGUAGE:C>:-include${CMAKE_CURRENT_SOURCE_DIR}/port_include/sodium/crypto_hash_sha256.h>"
+        "$<$<COMPILE_LANGUAGE:C>:-include${CMAKE_CURRENT_SOURCE_DIR}/port_include/sodium/crypto_hash_sha512.h>")
 endif()
 
 if(CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE)

--- a/libsodium/idf_component.yml
+++ b/libsodium/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.22"
+version: "1.0.22~1"
 description: libsodium port to ESP
 url: https://github.com/espressif/idf-extra-components/tree/master/libsodium
 dependencies:


### PR DESCRIPTION
# Change description
When `CONFIG_LIBSODIUM_USE_MBEDTLS_SHA` is enabled, `libsodium/CMakeLists.txt` injects two -include flags (for the sha256/sha512 port shims) via a CMake `SHELL:` generator expression. Building this component under PlatformIO fails, its build generator does not honor the `SHELL:` prefix, so the option is then re-split on whitespace and CMake deduplicates one of the two -include entries, leaving the relevant header un-included at compile time.

## Fix

Drop the `SHELL:` prefix and join `-include` to the header path so the whole flag is a single, indivisible token:
