### PR TITLE
Add callback for packet send function to dump the output packets.

### DIFF
--- a/esp_sysview/src/SEGGER/SEGGER_SYSVIEW.c
+++ b/esp_sysview/src/SEGGER/SEGGER_SYSVIEW.c
@@ -258,6 +258,7 @@ typedef struct {
     U32                     DisabledEvents;
     const SEGGER_SYSVIEW_OS_API  *pOSAPI;
     SEGGER_SYSVIEW_SEND_SYS_DESC_FUNC   *pfSendSysDesc;
+    SEGGER_SYSVIEW_SendPacket_Dump      *pfSendPacketCallback;
 } SEGGER_SYSVIEW_GLOBALS;
 
 /*********************************************************************
@@ -898,6 +899,10 @@ Send:
     //
     TimeStamp  = SEGGER_SYSVIEW_GET_TIMESTAMP();
     Delta = TimeStamp - _SYSVIEW_Globals.LastTxTimeStamp;
+    // Call SendPacketCallback if it is set
+    if (_SYSVIEW_Globals.pfSendPacketCallback) {
+        _SYSVIEW_Globals.pfSendPacketCallback(pStartPacket, pEndPacket, EventId, TimeStamp);
+    }
     MAKE_DELTA_32BIT(Delta);
     ENCODE_U32(pEndPacket, Delta);
 #if (SEGGER_SYSVIEW_POST_MORTEM_MODE == 1)
@@ -1471,6 +1476,7 @@ void SEGGER_SYSVIEW_Init(U32 SysFreq, U32 CPUFreq, const SEGGER_SYSVIEW_OS_API *
     _SYSVIEW_Globals.SysFreq          = SysFreq;
     _SYSVIEW_Globals.CPUFreq          = CPUFreq;
     _SYSVIEW_Globals.pfSendSysDesc    = pfSendSysDesc;
+    _SYSVIEW_Globals.pfSendPacketDumpCallback = NULL;
     _SYSVIEW_Globals.EnableState      = 0;
     _SYSVIEW_Globals.PacketCount      = 0;
 #else // (SEGGER_SYSVIEW_POST_MORTEM_MODE == 1)
@@ -1488,6 +1494,7 @@ void SEGGER_SYSVIEW_Init(U32 SysFreq, U32 CPUFreq, const SEGGER_SYSVIEW_OS_API *
     _SYSVIEW_Globals.SysFreq          = SysFreq;
     _SYSVIEW_Globals.CPUFreq          = CPUFreq;
     _SYSVIEW_Globals.pfSendSysDesc    = pfSendSysDesc;
+    _SYSVIEW_Globals.pfSendPacketCallback = NULL;
     _SYSVIEW_Globals.EnableState      = 0;
 #endif  // (SEGGER_SYSVIEW_POST_MORTEM_MODE == 1)
 }
@@ -3734,6 +3741,22 @@ int SEGGER_SYSVIEW_IsStarted(void)
     }
 #endif
     return _SYSVIEW_Globals.EnableState;
+}
+
+/*********************************************************************
+*
+*       SEGGER_SYSVIEW_SetSendPacketDumpCallback()
+*
+*  Function description
+*    Set the callback function for sending packet dump.
+*
+*  Parameters
+*    pfSendPacketDumpCallback - Pointer to the callback function.
+*/
+void SEGGER_SYSVIEW_SetSendPacketCallback(SEGGER_SYSVIEW_SendPacket_Dump *pfSendPacketCallback)
+{
+    _SYSVIEW_Globals.pfSendPacketCallback = pfSendPacketCallback;
+    return;
 }
 
 

--- a/esp_sysview/src/SEGGER/SEGGER_SYSVIEW.h
+++ b/esp_sysview/src/SEGGER/SEGGER_SYSVIEW.h
@@ -251,6 +251,22 @@ struct SEGGER_SYSVIEW_MODULE_STRUCT {
 
 typedef void (SEGGER_SYSVIEW_SEND_SYS_DESC_FUNC)(void);
 
+/*
+* The callback function for sending packets
+* @param pStartPacket: the start of the packet
+* @param pEndPacket: the end of the packet
+* @param EventId: the event id
+* @param Timestamp: the timestamp
+*/
+typedef void (SEGGER_SYSVIEW_SendPacket_Dump)(U8 *pStartPacket, U8 *pEndPacket, unsigned int EventId, U32 Timestamp);
+
+/*
+* Set the callback function for sending packets
+* Use this function to subscribe and unsubscribe from the packet sending process
+* @param pfSendPacketCallback: the callback function
+*/
+void SEGGER_SYSVIEW_SetSendPacketCallback(SEGGER_SYSVIEW_SendPacket_Dump *pfSendPacketCallback);
+
 
 /*********************************************************************
 *


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_

SystemView currently sends trace data only via RTT. This callback allows firmware to intercept raw packets—for example, to dump them to an alternate channel, integrate with QEMU, or debug without changing the main RTT output path.

Curretn PR adds an optional callback to intercept outgoing SEGGER SystemView packets before they are written to the RTT buffer. New API SEGGER_SYSVIEW_SetSendPacketCallback() lets you subscribe to packet transmission.
The callback is invoked while the packet is being formed, with access to the packet start/end, event ID, and timestamp.