### PR TITLE
fix(libjpeg-turbo): wire SBOM manifest and correct CPE

### DIFF
--- a/libjpeg-turbo/idf_component.yml
+++ b/libjpeg-turbo/idf_component.yml
@@ -1,6 +1,10 @@
 
-version: "3.1.1~1"
+version: "3.1.1~2"
 description: Jpeg-turbo port to ESP
 url: https://github.com/espressif/idf-extra-components/tree/master/libjpeg-turbo
 dependencies:
   idf: ">=5.0.0"
+sbom:
+  manifests:
+    - path: sbom_libjpeg.yml
+      dest: libjpeg-turbo

--- a/libjpeg-turbo/sbom_libjpeg.yml
+++ b/libjpeg-turbo/sbom_libjpeg.yml
@@ -1,6 +1,8 @@
 name: libjpeg-turbo
 version: 3.1.1
-cpe: cpe:3.1.1:a:libjpeg:libjpeg:{}:*:*:*:*:*:*:*
+cpe:
+  - cpe:2.3:a:libjpeg-turbo:libjpeg-turbo:{}:*:*:*:*:*:*:*
+  - cpe:2.3:a:d.r.commander:libjpeg-turbo:{}:*:*:*:*:*:*:*
 supplier: 'Organization: libjpeg-turbo'
 description: libjpeg-turbo is a JPEG image codec library
 url: https://github.com/libjpeg-turbo/libjpeg-turbo


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] CI passing

> Note: this is a fix to the **existing** `libjpeg-turbo` component, not a new component.

# Change description

`libjpeg-turbo/sbom_libjpeg.yml` was never referenced from `libjpeg-turbo/idf_component.yml`. `esp-idf-sbom` only treats a file as a manifest if it is wired through one of its recognized entry points (`sbom.yml`, `idf_component.yml`, `.gitmodules`), so the unreferenced `sbom_libjpeg.yml` was invisible to it. As a result `libjpeg-turbo` was excluded from SBOM generation and CVE scanning, and its manifest was never validated by the `test_sbom` CI job.

This PR:

- **Wires in the manifest** — adds the `sbom:` section to `idf_component.yml` (matching every other component here), so `sbom_libjpeg.yml` is discovered.
- **Fixes the CPE**, which was both:
  - *malformed* — the CPE-spec-version field read `3.1.1` instead of `2.3`, so the value was not a well-formed CPE 2.3 binding and never matched NVD; and
  - *pointing at the wrong product* — `libjpeg:libjpeg` is IJG libjpeg, not libjpeg-turbo. Replaced with the two products NVD assigns to libjpeg-turbo CVEs: `libjpeg-turbo:libjpeg-turbo` and `d.r.commander:libjpeg-turbo` (both, since NVD splits libjpeg-turbo CVEs across the two vendors).
- **Bumps the component revision** to `3.1.1~2`.

With the manifest wired in, `esp-idf-sbom manifest validate` discovers and validates it (exit 0).
