### PR TITLE
feat(expat): Update to v2.8.2

### DIFF
--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.8.1"
+version: "2.8.2"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:

--- a/expat/port/include/expat_config.h
+++ b/expat/port/include/expat_config.h
@@ -70,7 +70,7 @@
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.8.1"
+#define PACKAGE_STRING "expat 2.8.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -79,13 +79,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.8.1"
+#define PACKAGE_VERSION "2.8.2"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.8.1"
+#define VERSION "2.8.2"
 
 /* whether byteorder is bigendian */
 /* #undef WORDS_BIGENDIAN */

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -1,10 +1,7 @@
 name: libexpat
-version: 2.8.1
+version: 2.8.2
 cpe: cpe:2.3:a:libexpat_project:libexpat:{}:*:*:*:*:*:*:*
 supplier: 'Organization: libexpat_project'
 description: Fast streaming XML parser written in C99
 url: https://github.com/libexpat/libexpat/
-hash: c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19
-cve-exclude-list:
-  - cve: CVE-2026-45186
-    reason: Resolved in version 2.8.1, please see https://github.com/libexpat/libexpat/pull/1216
+hash: c61098da494eea1cbd091118118dcee417faacea


### PR DESCRIPTION
# Change description

This PR updates libexpat to v2.8.1 which fixes

1. [CVE-2026-56132](https://nvd.nist.gov/vuln/detail/CVE-2026-56132)
2. [CVE-2026-56403](https://nvd.nist.gov/vuln/detail/CVE-2026-56403)
3. [CVE-2026-56404](https://nvd.nist.gov/vuln/detail/CVE-2026-56404)
4. [CVE-2026-56405](https://nvd.nist.gov/vuln/detail/CVE-2026-56405)
5. [CVE-2026-56406](https://nvd.nist.gov/vuln/detail/CVE-2026-56406)
6. [CVE-2026-56407](https://nvd.nist.gov/vuln/detail/CVE-2026-56407)
7. [CVE-2026-56408](https://nvd.nist.gov/vuln/detail/CVE-2026-56408)
8. [CVE-2026-56410](https://nvd.nist.gov/vuln/detail/CVE-2026-56410)
9. [CVE-2026-56411](https://nvd.nist.gov/vuln/detail/CVE-2026-56411)
10. [CVE-2026-56409](https://nvd.nist.gov/vuln/detail/CVE-2026-56409)
11. [CVE-2026-50219](https://nvd.nist.gov/vuln/detail/CVE-2026-50219)
12. [CVE-2026-56131](https://nvd.nist.gov/vuln/detail/CVE-2026-56131)
13. [CVE-2026-56412](https://nvd.nist.gov/vuln/detail/CVE-2026-56412)
