### PR TITLE
feat(nghttp2): update version to v1.69.0

### DIFF
--- a/nghttp/idf_component.yml
+++ b/nghttp/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.68.1"
+version: "1.69.0"
 description: "nghttp2 - HTTP/2 C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/nghttp
 dependencies:

--- a/nghttp/port/include/nghttp2/nghttp2ver.h
+++ b/nghttp/port/include/nghttp2/nghttp2ver.h
@@ -29,7 +29,7 @@
  * @macro
  * Version number of the nghttp2 library release
  */
-#define NGHTTP2_VERSION "1.68.1"
+#define NGHTTP2_VERSION "1.69.0"
 
 /**
  * @macro
@@ -37,6 +37,6 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define NGHTTP2_VERSION_NUM 0x014400
+#define NGHTTP2_VERSION_NUM 0x014500
 
 #endif /* NGHTTP2VER_H */

--- a/nghttp/sbom_nghttp2.yml
+++ b/nghttp/sbom_nghttp2.yml
@@ -1,10 +1,10 @@
 name: nghttp2
-version: 1.68.1
+version: 1.69.0
 cpe: cpe:2.3:a:nghttp2:nghttp2:{}:*:*:*:*:*:*:*
 supplier: 'Organization: nghttp2 <https://nghttp2.org/'
 description: nghttp2 - HTTP/2 C Library and tools
 url: https://github.com/nghttp2/nghttp2
-hash: f769990597670f3ea8d2440d1e18a3f9a0df9bc0
+hash: 68cb6900fde14c77f0cd7add0e094a862960eb99
 cve-exclude-list:
-  - cve: CVE-2026-27135
-    reason: Fixed in v1.68.1. See https://github.com/nghttp2/nghttp2/commit/310c239817118dc0b6be0c2184a7b6c39f751a45
+  - cve: CVE-2026-58055
+    reason: Fixed in v1.69.0. See https://github.com/nghttp2/nghttp2/commit/ab28105c4a0197da24f8bfc414bc116055249e1e


### PR DESCRIPTION
# Change description
This MR updates nghttp2 to v1.69.0 which fixes
1. [CVE-2026-58055](https://nvd.nist.gov/vuln/detail/CVE-2026-58055)
