### PR TITLE
fix(esp_ext_part_tables): Use calloc instead of malloc when allocating memory for MBR

### DIFF
--- a/esp_ext_part_tables/idf_component.yml
+++ b/esp_ext_part_tables/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.3.0"
 description: ESP External Partition Tables
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_ext_part_tables
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/esp_ext_part_tables/src/esp_ext_part_tables.c
+++ b/esp_ext_part_tables/src/esp_ext_part_tables.c
@@ -206,7 +206,7 @@ esp_err_t esp_ext_part_list_bdl_write(esp_blockdev_handle_t handle, esp_ext_part
 
     switch (type) {
     case ESP_EXT_PART_LIST_SIGNATURE_MBR:
-        buf = malloc(MBR_SIZE);
+        buf = calloc(1, MBR_SIZE);
         if (buf == NULL) {
             return ESP_ERR_NO_MEM;
         }


### PR DESCRIPTION
Unused MBR fields for partition table would have garbage values in them if the memory is not zeroed and thus when the  MBR was written to an SD card and put into a computer (tested on MacOS), it would say the card / the device is corrupted and needs a repair. This fixes the issue.

# Checklist
- [x] CI passing
