### PR TITLE
docs(spi_nand_flash_fatfs): add NAND FAT integration guide to example README

### DIFF
--- a/spi_nand_flash/README.md
+++ b/spi_nand_flash/README.md
@@ -76,11 +76,25 @@ At present, `spi_nand_flash` component is compatible with the chips produced by 
 
 **GigaDevice voltage classes:** Parts ending in **UExxG** are rated for 2.7–3.6 V and are suitable for typical ESP32 3.3 V SPI designs. Parts ending in **RExxG** are rated for 1.7–2.0 V and are not recommended for direct connection to 3.3 V ESP GPIO/SPI without level shifting and a 1.8 V supply. Some `RExx` variants remain in the driver from earlier releases for backward compatibility; new additions target the 3.3 V `UExx` parts only (for example, **GD5F4GM7UExxG**, not GD5F4GM7RExxG).
 
+## Driver configuration
+
+Before calling `spi_nand_flash_init_device()`, your application must initialize the ESP-IDF SPI bus (`spi_bus_initialize()`, `spi_bus_add_device()`) and pass the resulting `spi_device_handle_t` in `spi_nand_flash_config_t`:
+
+| Field | Description |
+|-------|-------------|
+| `device_handle` | `spi_device_handle_t` from `spi_bus_add_device()` |
+| `io_mode` | `SPI_NAND_IO_MODE_SIO`, `DIO`, `DOUT`, `QIO`, or `QOUT` |
+| `flags` | `SPI_DEVICE_HALFDUPLEX` for half-duplex (required for DIO/DOUT); `0` for full-duplex SIO. Must match `spi_device_interface_config_t.flags` |
+| `gc_factor` | Optional wear-leveling GC tuning; `0` uses the driver default |
+
+See `spi_nand_flash_config_t` in [`include/spi_nand_flash.h`](include/spi_nand_flash.h).
+
 ## FATFS Integration
 
 For FATFS filesystem support, use the separate [`spi_nand_flash_fatfs`](../spi_nand_flash_fatfs) component:
 - Provides diskio adapters and VFS mount helpers for the **legacy** `spi_nand_flash_device_t` path only
 - **Do not enable BDL** if you use this FatFs stack on the same NAND instance (see [`spi_nand_flash_fatfs/README.md`](../spi_nand_flash_fatfs/README.md))
+- **End-to-end FAT example:** [`spi_nand_flash_fatfs/examples/nand_flash`](../spi_nand_flash_fatfs/examples/nand_flash) — integration guide in that example's README
 
 ## Troubleshooting
 

--- a/spi_nand_flash_fatfs/README.md
+++ b/spi_nand_flash_fatfs/README.md
@@ -18,35 +18,18 @@ FatFS integration layer for the SPI NAND Flash driver.
 
 ## Dependencies
 
-- `spi_nand_flash` component (driver)
+- `spi_nand_flash` component (driver; pulled in automatically)
 - ESP-IDF `fatfs` component
 - ESP-IDF `vfs` component
 
 ## Usage
 
-```c
-#include "spi_nand_flash.h"
-#include "esp_vfs_fat_nand.h"
+This component provides VFS mount helpers (`esp_vfs_fat_nand_mount()`, `esp_vfs_fat_nand_unmount()` in `esp_vfs_fat_nand.h`) on top of a `spi_nand_flash_device_t` handle from `spi_nand_flash_init_device()`.
 
-// Initialize device (CONFIG_NAND_FLASH_ENABLE_BDL must be off)
-spi_nand_flash_device_t *nand_device;
-spi_nand_flash_init_device(&config, &nand_device);
+Your application must initialize the SPI bus and NAND driver before calling the mount helpers. **For the full end-to-end flow** — dependency, CMake, headers, SPI initialization, `spi_nand_flash_config_t`, FAT mount, and file I/O — see:
 
-// Mount FATFS
-esp_vfs_fat_mount_config_t mount_config = {
-    .max_files = 4,
-    .format_if_mount_failed = true,
-};
-esp_vfs_fat_nand_mount("/nand", nand_device, &mount_config);
-
-// Use filesystem...
-FILE *f = fopen("/nand/test.txt", "w");
-// ...
-
-// Unmount
-esp_vfs_fat_nand_unmount("/nand", nand_device);
-spi_nand_flash_deinit_device(nand_device);
-```
+- [`examples/nand_flash`](examples/nand_flash) — reference source: [`main/spi_nand_flash_example_main.c`](examples/nand_flash/main/spi_nand_flash_example_main.c)
+- [`examples/nand_flash/README.md`](examples/nand_flash/README.md) — integration guide and hardware notes
 
 ## Examples
 

--- a/spi_nand_flash_fatfs/examples/nand_flash/README.md
+++ b/spi_nand_flash_fatfs/examples/nand_flash/README.md
@@ -5,6 +5,96 @@
 
 This example demonstrates how to use the SPI NAND Flash driver with FAT filesystem in ESP-IDF.
 
+Canonical source: [`main/spi_nand_flash_example_main.c`](main/spi_nand_flash_example_main.c).
+
+## Use in your own project
+
+### 1. Add the component dependency
+
+```bash
+idf.py add-dependency "espressif/spi_nand_flash_fatfs"
+```
+
+Or add to your project's `idf_component.yml`:
+
+```yaml
+dependencies:
+  espressif/spi_nand_flash_fatfs:
+    version: "*"
+```
+
+This also resolves `espressif/spi_nand_flash` transitively.
+
+### 2. Declare the component in CMake
+
+In your main component's `CMakeLists.txt`:
+
+```cmake
+idf_component_register(SRCS "main.c"
+                       INCLUDE_DIRS "."
+                       PRIV_REQUIRES spi_nand_flash_fatfs)
+```
+
+### 3. Required headers
+
+Match the includes in [`main/spi_nand_flash_example_main.c`](main/spi_nand_flash_example_main.c):
+
+```c
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_system.h"
+#include "soc/spi_pins.h"
+#include "esp_vfs_fat_nand.h"
+```
+
+`esp_vfs_fat_nand.h` pulls in `spi_nand_flash.h` and the SPI driver headers transitively.
+
+### 4. Initialization flow
+
+Follow the same order as `example_init_nand_flash()` in [`main/spi_nand_flash_example_main.c`](main/spi_nand_flash_example_main.c):
+
+1. **SPI bus** — `spi_bus_initialize()` with `spi_bus_config_t` (MOSI, MISO, CLK, WP, HD GPIOs).
+2. **SPI device** — `spi_bus_add_device()` with `spi_device_interface_config_t` (clock, CS, mode, `flags`).
+3. **NAND driver** — fill `spi_nand_flash_config_t` and call `spi_nand_flash_init_device()`.
+4. **FAT mount** — `esp_vfs_fat_nand_mount()` with `esp_vfs_fat_mount_config_t`.
+5. **File I/O** — standard `fopen()` / `fprintf()` / `fgets()` on paths under the mount point (e.g. `/nandflash/hello.txt`).
+6. **Cleanup** — `esp_vfs_fat_nand_unmount()`, then `spi_nand_flash_deinit_device()`, `spi_bus_remove_device()`, `spi_bus_free()` (see `example_deinit_nand_flash()`).
+
+Default pin macros (`HOST_ID`, `PIN_MOSI`, etc.) are defined at the top of the example source. Adjust them for your board or use the tables in [Hardware Required](#hardware-required) below.
+
+### 5. `spi_nand_flash_config_t`
+
+Populated in `example_init_nand_flash()` before `spi_nand_flash_init_device()`:
+
+| Field | Description |
+|-------|-------------|
+| `device_handle` | `spi_device_handle_t` returned by `spi_bus_add_device()` |
+| `io_mode` | `SPI_NAND_IO_MODE_SIO` in this example; also `DIO`, `DOUT`, `QIO`, or `QOUT` |
+| `flags` | `SPI_DEVICE_HALFDUPLEX` for half-duplex (required for DIO/DOUT); `0` for full-duplex SIO. **Must match** `spi_device_interface_config_t.flags` |
+| `gc_factor` | Optional wear-leveling GC tuning; omit or set `0` for the driver default |
+
+Full struct documentation is in [`spi_nand_flash.h`](../../../spi_nand_flash/include/spi_nand_flash.h).
+
+### 6. Mount configuration
+
+```c
+esp_vfs_fat_mount_config_t config = {
+    .max_files = 4,
+    .format_if_mount_failed = false,  // or true to format on first mount failure
+    .allocation_unit_size = 16 * 1024,
+};
+esp_err_t ret = esp_vfs_fat_nand_mount("/nandflash", flash, &config);
+```
+
+In this example project, `format_if_mount_failed` is controlled by `CONFIG_EXAMPLE_FORMAT_IF_MOUNT_FAILED` in menuconfig.
+
+### 7. Prerequisites
+
+- Keep **`CONFIG_NAND_FLASH_ENABLE_BDL` disabled** (Component config → SPI NAND Flash). `spi_nand_flash_init_device()` returns `ESP_ERR_NOT_SUPPORTED` when BDL is enabled, and FatFs mount helpers require the legacy handle.
+- See also [`spi_nand_flash_fatfs` component README](../../README.md#requirements-read-first).
+
 ## Hardware Required
 
 * Any ESP board from the supported targets list above


### PR DESCRIPTION
## Summary

- Expand `spi_nand_flash_fatfs/examples/nand_flash/README.md` with an end-to-end **Use in your own project** guide: dependency, CMake, headers, init flow, `spi_nand_flash_config_t`, mount config, and BDL prerequisite
- Slim `spi_nand_flash_fatfs/README.md` to point at the example instead of duplicating full source
- Add `spi_nand_flash_config_t` driver configuration notes to `spi_nand_flash/README.md` and link to the FAT example

Addresses [IDF-15775](https://jira.espressif.com:8443/browse/IDF-15775) (DocChatbot CSAT: missing end-to-end SPI NAND + FatFS integration docs).

## Test plan

- [x] Documentation-only change; no code or build impact
- [ ] Verify example README renders correctly on GitHub
- [ ] Re-test DocChatbot question class after Component Registry re-index (follow-up)