### PR TITLE
feat(esp_ext_part_tables): Improve MBR generation: alignment policy, layout validation, auto-placement, etc., version bump to 0.4.0

### DIFF
--- a/esp_ext_part_tables/CMakeLists.txt
+++ b/esp_ext_part_tables/CMakeLists.txt
@@ -11,3 +11,13 @@ endif()
 idf_component_register(SRCS ${srcs}
                     INCLUDE_DIRS "include"
                     REQUIRES ${requires})
+
+# Auto-enable the LittleFS branch of esp_ext_part_match_mountable() when the LittleFS
+# component is part of the build. This component intentionally does not depend on
+# LittleFS, so its header is not on our include path and the __has_include() probe in
+# esp_mbr_utils.c cannot see it; detect the component here instead. Consumers can
+# still force it by defining ESP_EXT_PART_HAS_LITTLEFS themselves.
+idf_build_get_property(build_components BUILD_COMPONENTS)
+if("joltwallet__littlefs" IN_LIST build_components OR "littlefs" IN_LIST build_components)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE ESP_EXT_PART_HAS_LITTLEFS=1)
+endif()

--- a/esp_ext_part_tables/LICENSE
+++ b/esp_ext_part_tables/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Thesis projects
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/esp_ext_part_tables/README.md
+++ b/esp_ext_part_tables/README.md
@@ -12,6 +12,73 @@ Currently only [MBR (Master boot record)](https://en.wikipedia.org/wiki/Master_b
 - Access partition information (address, size, type, label)
 - Example projects included
 
+## Alignment and layout validation (MBR generation)
+
+When generating an MBR (`esp_mbr_generate` / `esp_ext_part_list_bdl_write`), the
+behavior is controlled through `esp_mbr_generate_extra_args_t` (a zero-initialized
+struct selects all defaults):
+
+The sector size used for all byte<->sector math comes from the partition list's
+`sector_size` field (set by `esp_mbr_parse`, or assigned directly on a freshly
+built list, e.g. `part_list.sector_size = ESP_EXT_PART_SECTOR_SIZE_4KiB;`). It can
+be overridden per call via `extra_args.sector_size`; if neither is set it defaults
+to 512 B.
+
+- `total_size`: when non-zero, partitions that extend past this many bytes are
+  rejected. The block-device write helper auto-fills this from the device geometry
+  when left `0`.
+- `alignment`: partition start alignment. `ESP_EXT_PART_ALIGN_AUTO` (the value a
+  zero-initialized struct selects) resolves to a 1 MiB default;
+  `ESP_EXT_PART_ALIGN_NONE` leaves start LBAs untouched; `ESP_EXT_PART_ALIGN_4KiB`
+  and `ESP_EXT_PART_ALIGN_1MiB` request a specific alignment.
+- `align_policy`: what happens to a partition's size when alignment moves its
+  start. `ESP_EXT_PART_ALIGN_POLICY_KEEP_SIZE` (default) keeps the requested size
+  as the length from the aligned start (matching `fdisk`/`parted`);
+  `ESP_EXT_PART_ALIGN_POLICY_REJECT` returns an error if a start was not already
+  aligned; `ESP_EXT_PART_ALIGN_POLICY_PRESERVE_END` shrinks the size so the end
+  stays at the originally requested `address + size`.
+
+Overlapping partitions are always rejected, and a list item with type
+`ESP_EXT_PART_TYPE_NONE` (which would create a gap that truncates the parsed
+table) is rejected with `ESP_ERR_INVALID_ARG`.
+
+## Automatic partition placement (MBR generation)
+
+Instead of computing every start address by hand, a partition can be placed
+automatically by setting flags on `esp_ext_part_t.flags`:
+
+- `ESP_EXT_PART_FLAG_AUTO_ADDRESS`: the library computes the partition's start,
+  placing it right after the previous partition and aligning it. `info.address` is
+  ignored. The first auto-placed partition lands on the first aligned LBA (after
+  the MBR sector).
+- `ESP_EXT_PART_FLAG_FILL` (with `AUTO_ADDRESS` and `info.size == 0`): the
+  partition is sized to fill from its computed start to the end of the disk. This
+  needs a known disk size - either `extra_args->total_size`, or (via
+  `esp_ext_part_list_bdl_write`) the block device geometry.
+
+The caller's partition list is never modified; addresses/sizes are resolved into
+internal copies during generation.
+
+```c
+// First partition: auto-placed, fixed size. Last partition: auto-placed, fills the rest.
+esp_ext_part_list_item_t p0 = {
+    .info = {
+        .size = 16 * 1024 * 1024, // 16 MiB
+        .type = ESP_EXT_PART_TYPE_FAT32,
+        .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
+    }
+};
+esp_ext_part_list_item_t p1 = {
+    .info = {
+        .size = 0, // filled to the end of the disk
+        .type = ESP_EXT_PART_TYPE_LITTLEFS,
+        .extra = 4096,
+        .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS | ESP_EXT_PART_FLAG_FILL | ESP_EXT_PART_FLAG_EXTRA,
+    }
+};
+// esp_ext_part_list_insert(&part_list, &p0/&p1); then esp_ext_part_list_bdl_write(...)
+```
+
 ## Example code
 
 ```c
@@ -35,12 +102,9 @@ esp_ext_part_list_item_t* item;
 item = esp_ext_part_list_item_head(&part_list); // Get the first partition
 
 for (int i = 0; item != NULL; i++) {
-    printf("Partition %d:\n
-        address: %" PRIu64 "\n
-        size: %" PRIu64 "\n
-        type: %" PRIu32 "\n,
-        label: %s\n",
-    i, item->info.address, item->info.size, (uint32_t) item->info.type, item->label ? item->label : ""); // item->info.type is of `esp_ext_part_type_known_t` enum type
+    printf("Partition %d:\n\taddress: %" PRIu64 "\n\tsize: %" PRIu64 "\n\ttype: %" PRIu32 "\n\tlabel: %s\n",
+           i, item->info.address, item->info.size, (uint32_t) item->info.type,
+           item->info.label ? item->info.label : ""); // item->info.type is of `esp_ext_part_type_known_t` enum type
 
     item = esp_ext_part_list_item_next(item); // Get the next partition
 }

--- a/esp_ext_part_tables/README.md
+++ b/esp_ext_part_tables/README.md
@@ -10,7 +10,77 @@ Currently only [MBR (Master boot record)](https://en.wikipedia.org/wiki/Master_b
 - Generate and manipulate partition lists in memory
 - Deep copy and de-initialize partition lists
 - Access partition information (address, size, type, label)
+- Filter partitions with a caller predicate (e.g. only mountable filesystems)
 - Example projects included
+
+## Partition selection and filtering (MBR parsing)
+
+`esp_mbr_parse` inserts **every recognized partition** into the list by default,
+regardless of whether ESP-IDF can mount it (FAT12/16/32, LittleFS, `0xDA` raw data,
+and also recognized-but-undrivable types such as exFAT/NTFS, Linux and
+GPT-protective MBR). Only truly unknown/extended type codes are skipped.
+
+To select a subset, iterate with a predicate via `esp_ext_part_list_next_matching`,
+or filter at parse time with `esp_mbr_parse_extra_args_t.match`.
+
+The usage classes are a coarse, *type-intrinsic* hint. Whether a filesystem is
+actually **mountable in a given firmware** depends on which drivers are linked in
+that build (for example LittleFS is an optional external component), which the
+library cannot decide on its own. So mountability is expressed as a predicate.
+
+The library ships a ready-made matcher, `esp_ext_part_match_mountable()`, so you
+usually do not need to write your own. It treats FAT12/16/32 as always mountable
+(FatFs is part of ESP-IDF) and LittleFS as mountable when the LittleFS component is
+visible at compile time (detected via `__has_include("esp_littlefs.h")`, or forced by
+defining `ESP_EXT_PART_HAS_LITTLEFS`):
+
+```c
+esp_ext_part_match_t matcher = esp_ext_part_match_mountable();
+for (esp_ext_part_list_item_t *it = esp_ext_part_list_next_matching(NULL, &part_list, &matcher);
+     it != NULL;
+     it = esp_ext_part_list_next_matching(it, &part_list, &matcher)) {
+    // it points to a partition this build can mount
+}
+```
+
+To decide differently - e.g. gate on a specific Kconfig option, or branch on a
+runtime field such as a LittleFS block size stored in `info->extra` - supply your own
+predicate. It receives the full partition info plus an opaque context:
+
+```c
+static bool i_can_mount(const esp_ext_part_t *info, void *ctx)
+{
+    switch (info->type) {
+    case ESP_EXT_PART_TYPE_FAT12:
+    case ESP_EXT_PART_TYPE_FAT16:
+    case ESP_EXT_PART_TYPE_FAT32:
+        return true;              // FatFs is part of ESP-IDF
+#ifdef CONFIG_LITTLEFS_PAGE_SIZE // only if THIS build links the LittleFS component
+    case ESP_EXT_PART_TYPE_LITTLEFS:
+        return true;
+#endif
+    default:
+        return false;
+    }
+}
+
+// esp_ext_part_match_t matcher = { .fn = i_can_mount };
+// ... esp_ext_part_list_next_matching(NULL, &part_list, &matcher) ...
+```
+
+The same predicate can filter **at parse time** via `esp_mbr_parse_extra_args_t`, so
+unwanted partitions are never inserted:
+
+```c
+esp_mbr_parse_extra_args_t args = { .match = esp_ext_part_match_mountable() };
+esp_mbr_parse((void*) loaded_mbr, &part_list, &args); // only mountable partitions inserted
+```
+
+Whenever the parser skips a partition (an unknown/extended type, or one rejected by
+`match`), it sets `ESP_EXT_PART_LIST_FLAG_LOSSY` on the list. When that flag is
+**unset**, every partition on the source medium was captured, so regenerating an MBR
+from the list is functionally equivalent to the source (ignoring cosmetic differences
+such as CHS values or the disk signature).
 
 ## Alignment and layout validation (MBR generation)
 

--- a/esp_ext_part_tables/examples/basic/main/example_utils.c
+++ b/esp_ext_part_tables/examples/basic/main/example_utils.c
@@ -67,7 +67,7 @@ esp_err_t load_first_sector_from_sd_card(void *mbr_buffer)
     ret = sd_pwr_ctrl_new_on_chip_ldo(&ldo_config, &pwr_ctrl_handle);
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to create a new on-chip LDO power control driver");
-        return;
+        return ret;
     }
     host.pwr_ctrl_handle = pwr_ctrl_handle;
 #endif
@@ -133,7 +133,7 @@ char *parsed_type_to_str(uint8_t type)
     case ESP_EXT_PART_TYPE_FAT12:
         return "FAT12";
     case ESP_EXT_PART_TYPE_FAT16:
-        return "FAR16";
+        return "FAT16";
     case ESP_EXT_PART_TYPE_FAT32:
         return "FAT32";
     case ESP_EXT_PART_TYPE_LITTLEFS:

--- a/esp_ext_part_tables/examples/basic/main/example_utils.c
+++ b/esp_ext_part_tables/examples/basic/main/example_utils.c
@@ -138,6 +138,14 @@ char *parsed_type_to_str(uint8_t type)
         return "FAT32";
     case ESP_EXT_PART_TYPE_LITTLEFS:
         return "LittleFS";
+    case ESP_EXT_PART_TYPE_RAW_DATA:
+        return "raw data (0xDA)";
+    case ESP_EXT_PART_TYPE_EXFAT_OR_NTFS:
+        return "exFAT/NTFS";
+    case ESP_EXT_PART_TYPE_LINUX_ANY:
+        return "Linux";
+    case ESP_EXT_PART_TYPE_GPT_PROTECTIVE_MBR:
+        return "GPT protective MBR";
     default:
         break;
     }

--- a/esp_ext_part_tables/examples/basic/main/example_utils.h
+++ b/esp_ext_part_tables/examples/basic/main/example_utils.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "esp_err.h"
+#include "esp_ext_part_tables.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/esp_ext_part_tables/examples/basic/main/main.c
+++ b/esp_ext_part_tables/examples/basic/main/main.c
@@ -22,6 +22,10 @@
 
 static const char *TAG = "esp_ext_part_tables_example_basic";
 
+// A fixed disk size used for the generation demo so that FILL and the disk-bounds
+// check have a known total to work with (16 MiB).
+#define EXAMPLE_DISK_SIZE_BYTES (16 * 1024 * 1024)
+
 void print_loaded_ext_partitions(esp_ext_part_list_item_t *head)
 {
     esp_ext_part_list_item_t *it = head;
@@ -34,6 +38,26 @@ void print_loaded_ext_partitions(esp_ext_part_list_item_t *head)
                parsed_type_to_str(it->info.type));
         i++;
     } while ((it = esp_ext_part_list_item_next(it)) != NULL);
+    fflush(stdout);
+}
+
+// List only the partitions this build can mount, using the stock mountable predicate.
+static void print_mountable_partitions(esp_ext_part_list_t *part_list)
+{
+    ESP_LOGI(TAG, "Mountable partitions (via esp_ext_part_list_next_matching):");
+    int count = 0;
+    esp_ext_part_match_t matcher = esp_ext_part_match_mountable();
+    for (esp_ext_part_list_item_t *it = esp_ext_part_list_next_matching(NULL, part_list, &matcher);
+            it != NULL;
+            it = esp_ext_part_list_next_matching(it, part_list, &matcher)) {
+        printf("\t- %s at sector %" PRIu64 "\n",
+               parsed_type_to_str(it->info.type),
+               esp_ext_part_bytes_to_sector_count(it->info.address, ESP_EXT_PART_SECTOR_SIZE_512B));
+        count++;
+    }
+    if (count == 0) {
+        printf("\t(none)\n");
+    }
     fflush(stdout);
 }
 
@@ -59,7 +83,8 @@ void esp_ext_part_tables_mbr_parse_example_task(void *pvParameters)
     }
     ESP_LOGI(TAG, "MBR loaded successfully");
 
-    // Parse the MBR to get the partition list
+    // Parse the MBR to get the partition list. With extra_args == NULL, every
+    // recognized partition is inserted (mountable or not).
     esp_ext_part_list_t part_list = {0};
     err = esp_mbr_parse((void *) mbr, &part_list, NULL);
     if (err != ESP_OK) {
@@ -70,6 +95,14 @@ void esp_ext_part_tables_mbr_parse_example_task(void *pvParameters)
     }
     free(mbr); // Free the MBR buffer after parsing as it is no longer needed
     ESP_LOGI(TAG, "MBR parsed successfully");
+
+    // If the parser skipped any partition (unknown/extended type), the list is
+    // marked LOSSY - regenerating it would not reproduce the source table.
+    if (part_list.flags & ESP_EXT_PART_LIST_FLAG_LOSSY) {
+        ESP_LOGW(TAG, "Parsed list is LOSSY: some source partitions were not captured");
+    } else {
+        ESP_LOGI(TAG, "Parsed list is complete (not LOSSY)");
+    }
 
     // Get the first partition
     esp_ext_part_list_item_t *it = esp_ext_part_list_item_head(&part_list);
@@ -101,19 +134,22 @@ void esp_ext_part_tables_mbr_generate_example_task(void *pvParameters)
     esp_err_t err;
     esp_ext_part_list_t part_list = {0};
 
+    // A zero-initialized args struct already selects sensible defaults
+    // (AUTO alignment => 1 MiB, KEEP_SIZE policy, 512 B sectors). Here we set only
+    // what the auto-placement/FILL demo needs: an explicit sector size and the
+    // total disk size (so FILL and the bounds check know where the disk ends).
     esp_mbr_generate_extra_args_t mbr_args = {
         .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
-        .alignment = ESP_EXT_PART_ALIGN_1MiB
+        .total_size = EXAMPLE_DISK_SIZE_BYTES,
+        // .alignment left 0 (ESP_EXT_PART_ALIGN_AUTO) -> resolves to 1 MiB
     };
 
-    // 2 FAT12 partitions (random parameters)
+    // Partition 1: auto-placed (library picks the aligned start), fixed 4 MiB FAT32.
     esp_ext_part_list_item_t item1 = {
         .info = {
-            // Original MBR starts at 2048, but we use 8 for testing ->
-            .address = esp_ext_part_sector_count_to_bytes(8, mbr_args.sector_size), // Should be round up to 2048 sectors (aligned to 1MiB) due to defined sector size and alignment in `esp_mbr_generate_extra_args_t args` above
-            .size = esp_ext_part_sector_count_to_bytes(7953, mbr_args.sector_size),
-            .type = ESP_EXT_PART_TYPE_FAT12,
-            .label = NULL,
+            .size = 4 * 1024 * 1024,
+            .type = ESP_EXT_PART_TYPE_FAT32,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
         }
     };
     err = esp_ext_part_list_insert(&part_list, &item1);
@@ -122,17 +158,34 @@ void esp_ext_part_tables_mbr_generate_example_task(void *pvParameters)
         goto end_task;
     }
 
+    // Partition 2: auto-placed raw-data (0xDA) partition, fixed 2 MiB. Demonstrates
+    // a non-filesystem partition the application manages itself.
     esp_ext_part_list_item_t item2 = {
         .info = {
-            .address = esp_ext_part_sector_count_to_bytes(10240, mbr_args.sector_size),
-            .size = esp_ext_part_sector_count_to_bytes(10240, mbr_args.sector_size),
-            .type = ESP_EXT_PART_TYPE_FAT12,
-            .label = NULL,
+            .size = 2 * 1024 * 1024,
+            .type = ESP_EXT_PART_TYPE_RAW_DATA,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
         }
     };
     err = esp_ext_part_list_insert(&part_list, &item2);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to insert second partition: %s", esp_err_to_name(err));
+        esp_ext_part_list_deinit(&part_list);
+        goto end_task;
+    }
+
+    // Partition 3: auto-placed and FILL - sized to consume the rest of the disk.
+    esp_ext_part_list_item_t item3 = {
+        .info = {
+            .size = 0, // filled to the end of the disk
+            .type = ESP_EXT_PART_TYPE_FAT16,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS | ESP_EXT_PART_FLAG_FILL,
+        }
+    };
+    err = esp_ext_part_list_insert(&part_list, &item3);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to insert third partition: %s", esp_err_to_name(err));
+        esp_ext_part_list_deinit(&part_list);
         goto end_task;
     }
 
@@ -142,7 +195,8 @@ void esp_ext_part_tables_mbr_generate_example_task(void *pvParameters)
         esp_ext_part_list_deinit(&part_list);
         goto end_task;
     }
-    // Generate the MBR
+    // Generate the MBR. Addresses/sizes for the AUTO_ADDRESS/FILL items are
+    // resolved internally; the caller's list is not modified.
     err = esp_mbr_generate(mbr, &part_list, &mbr_args);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to generate MBR: %s", esp_err_to_name(err));
@@ -173,8 +227,9 @@ void esp_ext_part_tables_mbr_generate_example_task(void *pvParameters)
         goto end_task;
     }
 
-    // Print the loaded partition list
+    // Print the loaded partition list, then list only the mountable ones.
     print_loaded_ext_partitions(it);
+    print_mountable_partitions(&part_list_from_gen_mbr);
 
     // Deinitialize the partition list
     esp_ext_part_list_deinit(&part_list_from_gen_mbr);

--- a/esp_ext_part_tables/examples/basic/main/main.c
+++ b/esp_ext_part_tables/examples/basic/main/main.c
@@ -130,7 +130,7 @@ void esp_ext_part_tables_mbr_generate_example_task(void *pvParameters)
             .label = NULL,
         }
     };
-    esp_ext_part_list_insert(&part_list, &item2);
+    err = esp_ext_part_list_insert(&part_list, &item2);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to insert second partition: %s", esp_err_to_name(err));
         goto end_task;

--- a/esp_ext_part_tables/idf_component.yml
+++ b/esp_ext_part_tables/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.3.0"
+version: "0.4.0"
 description: ESP External Partition Tables
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_ext_part_tables
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/esp_ext_part_tables/include/esp_ext_part_tables.h
+++ b/esp_ext_part_tables/include/esp_ext_part_tables.h
@@ -34,10 +34,20 @@ typedef enum {
 } esp_ext_part_sector_size_t;
 
 typedef enum {
-    ESP_EXT_PART_ALIGN_NONE = 0, // No alignment
+    ESP_EXT_PART_ALIGN_AUTO = 0, // Use the library default alignment (1 MiB). This is what a zero-initialized extra_args selects.
     ESP_EXT_PART_ALIGN_4KiB = 4096, // 4 KiB alignment
     ESP_EXT_PART_ALIGN_1MiB = (1024 * 1024), // 1 MiB alignment
+    ESP_EXT_PART_ALIGN_NONE = -1, // Explicitly perform no alignment (leave LBAs untouched). A representable-in-int sentinel (not a real alignment value).
 } esp_ext_part_align_t;
+
+typedef enum {
+    /*!< Default: align the partition start up, keep the requested size as the length from the aligned start (matches fdisk/parted behavior). */
+    ESP_EXT_PART_ALIGN_POLICY_KEEP_SIZE = 0,
+    /*!< Return an error if a partition start was not already aligned (do not silently relocate it). */
+    ESP_EXT_PART_ALIGN_POLICY_REJECT,
+    /*!< Align the partition start up, then shrink the size so the end stays at the originally requested address + size. Errors if alignment consumes the whole partition. */
+    ESP_EXT_PART_ALIGN_POLICY_PRESERVE_END,
+} esp_ext_part_align_policy_t;
 
 typedef enum __attribute__((packed))
 {
@@ -46,6 +56,7 @@ typedef enum __attribute__((packed))
     ESP_EXT_PART_TYPE_FAT16, /*!< FAT16 with LBA addressing */
     ESP_EXT_PART_TYPE_FAT32, /*!< FAT32 with LBA addressing */
     ESP_EXT_PART_TYPE_LITTLEFS, /*!< Possibly LittleFS (MBR CHS field => LittleFS block size hack) */
+    ESP_EXT_PART_TYPE_RAW_DATA, /*!< Non-filesystem/custom data partition (e.g. raw data, custom format, etc.) */
 // Note: The following types are not supported, but we can return a type for them
     ESP_EXT_PART_TYPE_LINUX_ANY, /*!< Linux partition (any type) */
     ESP_EXT_PART_TYPE_EXFAT_OR_NTFS, /*!< Not supported, but we can return a type for it */
@@ -56,6 +67,8 @@ typedef enum {
     ESP_EXT_PART_FLAG_NONE = 0,
     ESP_EXT_PART_FLAG_ACTIVE = 1 << 0,  /*!< Active / bootable partition */
     ESP_EXT_PART_FLAG_EXTRA = 1 << 1, /*!< Additional information stored in `extra` field (e.g. LittleFS block size stored in CHS hack) */
+    ESP_EXT_PART_FLAG_AUTO_ADDRESS = 1 << 2, /*!< During MBR generation, let the library compute the start address (placed after the previous partition, aligned). `info.address` is ignored. */
+    ESP_EXT_PART_FLAG_FILL = 1 << 3, /*!< During MBR generation, together with ESP_EXT_PART_FLAG_AUTO_ADDRESS and `info.size == 0`, size the partition to fill from its computed start to the end of the disk (requires a known total size). */
 } esp_ext_part_flags_t;
 
 typedef enum {
@@ -90,7 +103,7 @@ typedef struct {
     esp_ext_part_list_signature_t signature; /*!< Disk signature or identifier */
     SLIST_HEAD(esp_ext_part_list_head_, esp_ext_part_list_item_) head; /*!< Head of the partition list */
     esp_ext_part_list_flags_t flags; /*!< Flags for the partition list */
-    esp_ext_part_sector_size_t sector_size; /*!< Sector size (storage medium property) */
+    esp_ext_part_sector_size_t sector_size; /*!< Sector size (storage medium property). `esp_mbr_parse` sets this from the parsed medium. For a freshly built list you may set it directly (e.g. `list.sector_size = ESP_EXT_PART_SECTOR_SIZE_4KiB;`); `esp_mbr_generate` uses it as the default sector size, unless overridden by `esp_mbr_generate_extra_args_t::sector_size`. Left `ESP_EXT_PART_SECTOR_SIZE_UNKNOWN` (0) it defaults to 512 B. */
 } esp_ext_part_list_t;
 
 /**
@@ -216,7 +229,7 @@ esp_err_t esp_ext_part_list_signature_set(esp_ext_part_list_t *part_list, const 
 
 #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
 /**
- * @brief Read a aprtition table and from a block device handle and parse it.
+ * @brief Read a partition table from a block device handle and parse it.
  *
  * This function reads the partition table from the specified block device and populates the provided partition list structure.
  * The type of partition table to read is specified by the 'type' parameter.

--- a/esp_ext_part_tables/include/esp_ext_part_tables.h
+++ b/esp_ext_part_tables/include/esp_ext_part_tables.h
@@ -74,6 +74,7 @@ typedef enum {
 typedef enum {
     ESP_EXT_PART_LIST_FLAG_NONE = 0,
     ESP_EXT_PART_LIST_FLAG_READ_ONLY = 1 << 0, /*!< Read-only partition list */
+    ESP_EXT_PART_LIST_FLAG_LOSSY = 1 << 1, /*!< Set by the parser when one or more source partitions were skipped (an unknown/extended type, or one rejected by the parse `match` predicate), so a regenerated table would NOT be functionally equivalent to the source. Unset = every recognized partition was captured. */
 } esp_ext_part_list_flags_t;
 
 typedef enum {
@@ -196,6 +197,65 @@ esp_ext_part_list_item_t *esp_ext_part_list_item_head(esp_ext_part_list_t *part_
  * @return Pointer to the next partition list item, or NULL if there are no more items.
  */
 esp_ext_part_list_item_t *esp_ext_part_list_item_next(esp_ext_part_list_item_t *item);
+
+/**
+ * @brief Caller-supplied predicate deciding whether a partition matches.
+ *
+ * @param[in] info Partition info (type, address, size, flags, extra, label).
+ * @param[in] ctx  Opaque caller context passed through unchanged (may be NULL).
+ *
+ * @return true to select this partition, false to skip it.
+ */
+typedef bool (*esp_ext_part_match_fn)(const esp_ext_part_t *info, void *ctx);
+
+/**
+ * @brief A predicate together with its opaque context.
+ *
+ * Bundles `fn` and the `ctx` passed to it, so a matcher can be stored and passed
+ * around as a single value. A zero-initialized matcher (`fn == NULL`) matches
+ * nothing.
+ */
+typedef struct {
+    esp_ext_part_match_fn fn; /*!< Predicate; NULL means "match nothing". */
+    void *ctx;                /*!< Opaque context passed to `fn` (may be NULL). */
+} esp_ext_part_match_t;
+
+/**
+ * @brief Iterate partition list items matching a caller-supplied predicate.
+ *
+ * The predicate can branch on any partition field and on caller/build state - for
+ * example "mountable in THIS build", which depends on which filesystem drivers are
+ * linked and therefore cannot be decided by the library itself. Mirrors
+ * `esp_ext_part_list_item_head` / `esp_ext_part_list_item_next`, but skips items the
+ * predicate rejects. Pass NULL as `from` to search from the head, or a previously
+ * returned item to continue (e.g. to find the N-th match).
+ *
+ * @param[in] from    Current item; pass NULL to start from the head of `list`.
+ * @param[in] list    Partition list to iterate (used only when `from` is NULL).
+ * @param[in] matcher Predicate + context; if NULL, or its `fn` is NULL, nothing matches.
+ *
+ * @return Pointer to the next matching item, or NULL if there are no more.
+ */
+esp_ext_part_list_item_t *esp_ext_part_list_next_matching(esp_ext_part_list_item_t *from, const esp_ext_part_list_t *list, const esp_ext_part_match_t *matcher);
+
+/**
+ * @brief Get a stock matcher selecting partitions ESP-IDF can mount.
+ *
+ * Returns a ready-to-use `esp_ext_part_match_t` for `esp_ext_part_list_next_matching`
+ * (or `esp_mbr_parse_extra_args_t::match`) when you just want "the partitions this
+ * build can mount" without writing your own predicate.
+ *
+ * - FAT12/16/32 are always considered mountable (FatFs is part of ESP-IDF).
+ * - LittleFS is considered mountable only when the LittleFS component is available
+ *   to this library at compile time - detected via `__has_include("esp_littlefs.h")`,
+ *   or forced by defining `ESP_EXT_PART_HAS_LITTLEFS`. If neither applies, LittleFS
+ *   is reported as not mountable (a safe under-report rather than a false claim).
+ * - All other types (raw data, exFAT/NTFS, Linux, GPT-protective, none) are not
+ *   mountable.
+ *
+ * @return A matcher whose `fn` reports whether a partition is mountable in this build.
+ */
+esp_ext_part_match_t esp_ext_part_match_mountable(void);
 
 /**
  * @brief Get the signature of an external partition list.

--- a/esp_ext_part_tables/include/esp_mbr.h
+++ b/esp_ext_part_tables/include/esp_mbr.h
@@ -72,6 +72,7 @@ typedef struct {
 typedef struct {
     esp_ext_part_sector_size_t sector_size; // Sector size hint, pulled from a storage device driver query
     bool (*esp_mbr_parse_custom_supported_partition_types)(uint8_t, uint8_t *); // Custom function for parsing supported MBR partition types, optional
+    esp_ext_part_match_t match; // Optional filter: if match.fn is non-NULL, only recognized partitions for which match.fn(info, match.ctx) returns true are inserted (the rest are dropped and the list is marked ESP_EXT_PART_LIST_FLAG_LOSSY). A zero-initialized match (fn == NULL) inserts all recognized partitions.
 } esp_mbr_parse_extra_args_t;
 
 typedef struct {
@@ -91,6 +92,14 @@ typedef struct {
  * This function reads the provided MBR buffer, validates its signature, and populates
  * the given partition list structure with the partition entries found in the MBR.
  * Additional parsing options can be provided via the extra_args parameter.
+ *
+ * By default every recognized partition is inserted into the list, regardless of
+ * whether ESP-IDF can mount it. To filter at parse time, set `extra_args->match` to
+ * a predicate: only recognized partitions for which it returns true are inserted
+ * (for example `esp_ext_part_match_mountable`). After parsing, a subset can also be
+ * iterated with `esp_ext_part_list_next_matching`. When any partition is skipped (an
+ * unknown/extended type, or one rejected by `match`), the list is marked
+ * `ESP_EXT_PART_LIST_FLAG_LOSSY`.
  *
  * @note This function is not thread-safe.
  *

--- a/esp_ext_part_tables/include/esp_mbr.h
+++ b/esp_ext_part_tables/include/esp_mbr.h
@@ -75,10 +75,14 @@ typedef struct {
 } esp_mbr_parse_extra_args_t;
 
 typedef struct {
-    esp_ext_part_sector_size_t sector_size; // Sector size hint for correct LBA alignment
-    esp_ext_part_align_t alignment; // Alignment hint for correct LBA alignment
-    bool keep_signature; // If true, the disk signature will be preserved in the generated MBR and not overwritten with a random value
+    // Members are ordered to minimize struct padding (8-byte fields, then 4-byte
+    // enums, then bools). Zero-initialization ({0}) still selects all defaults.
+    uint64_t total_size; // Total device size in bytes for the "fits within disk" check; 0 disables the check. The BDL write helper auto-fills this from the device geometry when left 0.
     uint8_t (*esp_mbr_generate_custom_supported_partition_types)(uint8_t); // Custom function for generating supported MBR partition types, optional
+    esp_ext_part_sector_size_t sector_size; // Sector size for correct LBA alignment. Overrides the list's `sector_size` for this call; 0 (UNKNOWN) falls back to the list's value, then to 512 B.
+    esp_ext_part_align_t alignment; // Partition start alignment. 0 (ESP_EXT_PART_ALIGN_AUTO, the default) resolves to 1 MiB; ESP_EXT_PART_ALIGN_NONE leaves LBAs untouched; ESP_EXT_PART_ALIGN_4KiB / ESP_EXT_PART_ALIGN_1MiB request a specific alignment.
+    esp_ext_part_align_policy_t align_policy; // Policy applied when alignment moves a partition start (default 0 = KEEP_SIZE)
+    bool keep_signature; // If true, the disk signature will be preserved in the generated MBR and not overwritten with a random value
 } esp_mbr_generate_extra_args_t;
 
 /**
@@ -113,16 +117,47 @@ esp_err_t esp_mbr_parse(void *mbr_buf,
  * options such as sector size, alignment, and signature preservation can be specified
  * via the extra_args parameter.
  *
+ * After all partition entries are written, the generated layout is validated:
+ * overlapping partitions are rejected, and if `extra_args->total_size` is
+ * non-zero, partitions that run past the end of the disk are rejected.
+ *
+ * Alignment behavior:
+ *   - `extra_args->alignment == ESP_EXT_PART_ALIGN_AUTO` (the default when a
+ *     zero-initialized `extra_args` is used) resolves to a 1 MiB alignment.
+ *   - `ESP_EXT_PART_ALIGN_NONE` leaves partition start LBAs untouched.
+ *   - When alignment moves a partition start, `extra_args->align_policy` decides
+ *     what happens to the size (see `esp_ext_part_align_policy_t`).
+ *
+ * Automatic placement:
+ *   - A partition item with `ESP_EXT_PART_FLAG_AUTO_ADDRESS` has its start address
+ *     computed by this function (placed after the previous entry, aligned); its
+ *     `info.address` is ignored. The first such partition is placed at the first
+ *     aligned LBA (after the MBR sector).
+ *   - With `ESP_EXT_PART_FLAG_FILL` and `info.size == 0`, the partition is sized to
+ *     fill from its computed start to the end of the disk; this requires
+ *     `extra_args->total_size` (or, via `esp_ext_part_list_bdl_write`, the device
+ *     geometry).
+ *   - Auto-placement is honored only here (and through `esp_ext_part_list_bdl_write`);
+ *     `esp_mbr_partition_set` does not support it. The caller's partition list is not
+ *     modified.
+ *
+ * Empty list items:
+ *   - A list item with `type == ESP_EXT_PART_TYPE_NONE` cannot be encoded as a
+ *     partition entry without leaving a gap in the table (which truncates the parsed
+ *     result and disturbs auto-placement). Such an item is rejected with
+ *     `ESP_ERR_INVALID_ARG`.
+ *
  * @note This function is not thread-safe.
  *
  * @param[out] mbr         Pointer to the blank MBR structure to be filled (must already be allocated and be at least `MBR_SIZE` bytes).
  * @param[in]  part_list   Pointer to the partition list structure containing partition entries to encode.
- * @param[in]  extra_args  Optional extra arguments for generation (can be NULL for defaults).
+ * @param[in]  extra_args  Optional extra arguments for generation (can be NULL for defaults: 1 MiB alignment, KEEP_SIZE policy, no disk-bounds check).
  *
  * @return
  *     - ESP_OK:                Generation was successful.
- *     - ESP_ERR_INVALID_ARG:   Invalid arguments were provided.
- *     - ESP_ERR_INVALID_STATE: Error filling partition entry.
+ *     - ESP_ERR_INVALID_ARG:   Invalid arguments were provided, a partition start was not aligned while `align_policy` is `ESP_EXT_PART_ALIGN_POLICY_REJECT`, an AUTO_ADDRESS partition has size 0 without the FILL flag, or a list item has type `ESP_EXT_PART_TYPE_NONE`.
+ *     - ESP_ERR_INVALID_STATE: Error filling a partition entry, or two partitions overlap.
+ *     - ESP_ERR_INVALID_SIZE:  Alignment consumed a whole partition (PRESERVE_END policy), a partition runs past `total_size`, or a FILL partition cannot be sized (no/insufficient total size).
  *     - ESP_ERR_NOT_SUPPORTED: Partition address or size (sector count) exceeds 32-bit limit of MBR.
  *     - Other error codes from `esp_ext_part_list_signature_get` or `esp_mbr_partition_set`.
  */
@@ -137,6 +172,14 @@ esp_err_t esp_mbr_generate(mbr_t *mbr,
  * with the information from the given partition list item. Additional arguments for
  * partition generation must be supplied via the extra_args parameter.
  *
+ * When alignment moves the partition start, `extra_args->align_policy` decides how
+ * the size is treated (keep it, reject, or shrink to preserve the end; see
+ * `esp_ext_part_align_policy_t`). This low-level function does NOT resolve
+ * `ESP_EXT_PART_ALIGN_AUTO` to a default alignment - callers that want the 1 MiB
+ * default should either go through `esp_mbr_generate` or pass a concrete alignment
+ * value. It also does NOT perform overlap or disk-bounds validation (that is done
+ * by `esp_mbr_generate`).
+ *
  * @note This function is not thread-safe.
  *
  * @warning If the partition entry is empty (i.e., `item->info.type` is `ESP_EXT_PART_TYPE_NONE`), it will be cleared in the MBR.
@@ -150,8 +193,9 @@ esp_err_t esp_mbr_generate(mbr_t *mbr,
  *
  * @return
  *     - ESP_OK:                Success.
- *     - ESP_ERR_INVALID_ARG:   Invalid arguments were provided.
+ *     - ESP_ERR_INVALID_ARG:   Invalid arguments were provided, or the start was not aligned while `align_policy` is `ESP_EXT_PART_ALIGN_POLICY_REJECT`.
  *     - ESP_ERR_INVALID_STATE: Error filling partition entry.
+ *     - ESP_ERR_INVALID_SIZE:  Alignment consumed the whole partition (PRESERVE_END policy).
  *     - ESP_ERR_NOT_SUPPORTED: Partition address or size (sector count) exceeds 32-bit limit of MBR.
  */
 esp_err_t esp_mbr_partition_set(mbr_t *mbr, uint8_t partition_index, esp_ext_part_list_item_t *item, esp_mbr_generate_extra_args_t *extra_args);

--- a/esp_ext_part_tables/include/esp_mbr_utils.h
+++ b/esp_ext_part_tables/include/esp_mbr_utils.h
@@ -46,7 +46,12 @@ uint32_t esp_mbr_chs_arr_val_get(const uint8_t chs[3]);
 void esp_mbr_lba_to_chs_arr(uint8_t chs[3], uint32_t lba);
 
 /**
- * @brief Align an LBA value according to sector size and alignment requirements.
+ * @brief Align an LBA value up according to sector size and alignment requirements.
+ *
+ * Rounds @p lba up to the next multiple of `alignment / sector_size` sectors. Any
+ * ratio is supported (it does not have to be a power of two). An alignment of
+ * `ESP_EXT_PART_ALIGN_NONE`, a zero alignment, or a zero sector size leaves the LBA
+ * untouched, as does an alignment that is at most one sector.
  *
  * @param[in] lba         Logical Block Address to align.
  * @param[in] sector_size Sector size enumeration.
@@ -58,7 +63,7 @@ uint32_t esp_mbr_lba_align(uint32_t lba, esp_ext_part_sector_size_t sector_size,
 /**
  * @brief Generate default supported MBR partition types for a given internal type.
  *
- * @param[in] type Internal artition type to generate supported types from internal `esp_ext_part_type_known_t` enum.
+ * @param[in] type Internal partition type to generate supported types from internal `esp_ext_part_type_known_t` enum.
  * @return MBR partition type code.
  */
 uint8_t esp_mbr_generate_default_supported_partition_types(uint8_t type);

--- a/esp_ext_part_tables/src/esp_ext_part_tables.c
+++ b/esp_ext_part_tables/src/esp_ext_part_tables.c
@@ -205,13 +205,24 @@ esp_err_t esp_ext_part_list_bdl_write(esp_blockdev_handle_t handle, esp_ext_part
     uint8_t *buf = NULL;
 
     switch (type) {
-    case ESP_EXT_PART_LIST_SIGNATURE_MBR:
+    case ESP_EXT_PART_LIST_SIGNATURE_MBR: {
         buf = calloc(1, MBR_SIZE);
         if (buf == NULL) {
             return ESP_ERR_NO_MEM;
         }
 
-        err = esp_mbr_generate((mbr_t *) buf, part_list, (esp_mbr_generate_extra_args_t *) extra_args);
+        // Auto-fill the "fits within disk" bound from the device geometry when the
+        // caller did not provide one. This is a pure arithmetic check inside
+        // esp_mbr_generate - it does not allocate a buffer of `total_size`.
+        esp_mbr_generate_extra_args_t local_args = {0};
+        if (extra_args != NULL) {
+            local_args = *(esp_mbr_generate_extra_args_t *) extra_args; // Caller's choices take precedence
+        }
+        if (local_args.total_size == 0 && handle->geometry.disk_size > 0) {
+            local_args.total_size = handle->geometry.disk_size;
+        }
+
+        err = esp_mbr_generate((mbr_t *) buf, part_list, &local_args);
         if (err != ESP_OK) {
             free(buf);
             return err;
@@ -220,6 +231,7 @@ esp_err_t esp_ext_part_list_bdl_write(esp_blockdev_handle_t handle, esp_ext_part
         err = handle->ops->write(handle, buf, 0, MBR_SIZE);
         free(buf);
         break;
+    }
 
     default:
         err = ESP_ERR_NOT_SUPPORTED; // Unsupported signature type

--- a/esp_ext_part_tables/src/esp_ext_part_tables.c
+++ b/esp_ext_part_tables/src/esp_ext_part_tables.c
@@ -125,6 +125,28 @@ esp_ext_part_list_item_t *esp_ext_part_list_item_next(esp_ext_part_list_item_t *
     return SLIST_NEXT(item, next);
 }
 
+esp_ext_part_list_item_t *esp_ext_part_list_next_matching(esp_ext_part_list_item_t *from, const esp_ext_part_list_t *list, const esp_ext_part_match_t *matcher)
+{
+    if (matcher == NULL || matcher->fn == NULL) {
+        return NULL;
+    }
+    esp_ext_part_list_item_t *it;
+    if (from != NULL) {
+        it = SLIST_NEXT(from, next);
+    } else if (list != NULL) {
+        it = SLIST_FIRST(&list->head);
+    } else {
+        return NULL;
+    }
+
+    for (; it != NULL; it = SLIST_NEXT(it, next)) {
+        if (matcher->fn(&it->info, matcher->ctx)) {
+            return it;
+        }
+    }
+    return NULL;
+}
+
 esp_err_t esp_ext_part_list_signature_get(esp_ext_part_list_t *part_list, void *signature)
 {
     if (part_list == NULL || signature == NULL) {

--- a/esp_ext_part_tables/src/esp_mbr.c
+++ b/esp_ext_part_tables/src/esp_mbr.c
@@ -50,6 +50,7 @@ esp_err_t esp_mbr_parse(void *mbr_buf,
     // Set defaults
     part_list->sector_size = ESP_EXT_PART_SECTOR_SIZE_512B; // Default sector size
     bool (*f_parse_supported_partition_types)(uint8_t, uint8_t *) = esp_mbr_parse_default_supported_partition_types;
+    const esp_ext_part_match_t *matcher = NULL; // Optional parse-time filter (NULL / NULL fn = keep all)
 
     // Load extra arguments if provided
     if (extra_args) {
@@ -59,6 +60,7 @@ esp_err_t esp_mbr_parse(void *mbr_buf,
         if (extra_args->esp_mbr_parse_custom_supported_partition_types) {
             f_parse_supported_partition_types = extra_args->esp_mbr_parse_custom_supported_partition_types; // Use a custom function for supported partition types
         }
+        matcher = &extra_args->match; // .fn == NULL keeps all recognized partitions
     }
 
     esp_err_t err = ESP_OK;
@@ -81,10 +83,14 @@ esp_err_t esp_mbr_parse(void *mbr_buf,
             break; // No more partitions, exit the loop (MBR partition table cannot have holes in it)
         }
 
-        // If the partition entry is not supported, skip it as well
+        // Resolve the partition type. The bool return is not used to gate insertion;
+        // filtering is done by the optional `match` predicate below.
         uint8_t parsed_type = ESP_EXT_PART_TYPE_NONE;
-        bool is_supported = f_parse_supported_partition_types(partition->type, &parsed_type);
-        if (!is_supported) {
+        (void) f_parse_supported_partition_types(partition->type, &parsed_type);
+        if (parsed_type == ESP_EXT_PART_TYPE_NONE) {
+            // Unknown/extended type: cannot be represented, so a regenerated table
+            // would differ from the source.
+            part_list->flags |= ESP_EXT_PART_LIST_FLAG_LOSSY;
             continue;
         }
 
@@ -106,6 +112,13 @@ esp_err_t esp_mbr_parse(void *mbr_buf,
 
         // Set the flags or extra field based on the partition type or do any extra actions needed
         ext_part_list_item_do_extra(&item, partition);
+
+        // Apply the optional parse-time filter on the fully-populated info. A rejected
+        // partition is dropped, which makes a regenerated table differ from the source.
+        if (matcher != NULL && matcher->fn != NULL && !matcher->fn(&item.info, matcher->ctx)) {
+            part_list->flags |= ESP_EXT_PART_LIST_FLAG_LOSSY;
+            continue;
+        }
 
         // Add the partition info to the output table
         err = esp_ext_part_list_insert(part_list, &item);

--- a/esp_ext_part_tables/src/esp_mbr.c
+++ b/esp_ext_part_tables/src/esp_mbr.c
@@ -5,6 +5,7 @@
  */
 
 #include <stdint.h>
+#include <inttypes.h>
 #include <string.h>
 #include "esp_err.h"
 #include "esp_log.h"
@@ -183,7 +184,48 @@ esp_err_t esp_mbr_partition_set(mbr_t *mbr, uint8_t partition_index, esp_ext_par
     if (item->info.flags & ESP_EXT_PART_FLAG_ACTIVE) {
         partition->status = MBR_PARTITION_STATUS_ACTIVE;
     }
-    partition->lba_start = esp_mbr_lba_align((uint32_t) first_sector_address, extra_args->sector_size, extra_args->alignment);
+
+    uint32_t aligned_start = esp_mbr_lba_align((uint32_t) first_sector_address, extra_args->sector_size, extra_args->alignment);
+
+    if (aligned_start != (uint32_t) first_sector_address) {
+        // Alignment moved the partition start; apply the configured policy.
+        switch (extra_args->align_policy) {
+        case ESP_EXT_PART_ALIGN_POLICY_KEEP_SIZE:
+            // Default: keep the requested size as the length from the aligned start (matches fdisk/parted).
+            break;
+        case ESP_EXT_PART_ALIGN_POLICY_REJECT:
+            ESP_LOGE(TAG, "Partition %u start (sector %" PRIu32 ") is not aligned and align_policy is REJECT",
+                     partition_index, (uint32_t) first_sector_address);
+            return ESP_ERR_INVALID_ARG;
+        case ESP_EXT_PART_ALIGN_POLICY_PRESERVE_END: {
+            // Shrink the size so the end stays at the originally requested address + size.
+            uint64_t orig_end = first_sector_address + sector_count; // exclusive end, in sectors
+            if ((uint64_t) aligned_start >= orig_end) {
+                ESP_LOGE(TAG, "Alignment consumed the whole partition %u (aligned start %" PRIu32 " >= end %" PRIu64 ")",
+                         partition_index, aligned_start, orig_end);
+                return ESP_ERR_INVALID_SIZE;
+            }
+            sector_count = orig_end - (uint64_t) aligned_start;
+            break;
+        }
+        default:
+            ESP_LOGE(TAG, "Unknown align_policy %d", (int) extra_args->align_policy);
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+
+    // The exclusive end LBA (start + count) must also fit in the 32-bit MBR fields.
+    // Checking start and count individually (above) is not enough - their sum can
+    // still exceed UINT32_MAX. Compute it in 64-bit and reject if it overflows;
+    // this also prevents the auto-placement cursor (lba_start + sector_count) from
+    // wrapping in esp_mbr_generate.
+    if ((uint64_t) aligned_start + sector_count > (uint64_t) UINT32_MAX) {
+        ESP_LOGE(TAG, "Partition end (sector %" PRIu64 ") exceeds 32-bit limit of MBR",
+                 (uint64_t) aligned_start + sector_count);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    partition->lba_start = aligned_start;
     partition->sector_count = (uint32_t) sector_count;
     partition->type = f_generate_supported_partition_types(item->info.type);
 
@@ -204,9 +246,12 @@ esp_err_t esp_mbr_generate(mbr_t *mbr,
     esp_err_t err = ESP_OK;
 
     // Set default arguments for MBR generation
+    // (initializer follows the struct's member order)
     esp_mbr_generate_extra_args_t args = {
+        .total_size = 0, // Default: no "fits within disk" check
         .sector_size = part_list->sector_size != ESP_EXT_PART_SECTOR_SIZE_UNKNOWN ? part_list->sector_size : ESP_EXT_PART_SECTOR_SIZE_512B, // Default sector size
-        .alignment = ESP_EXT_PART_ALIGN_1MiB, // Default alignment
+        .alignment = ESP_EXT_PART_ALIGN_AUTO, // Resolved to the default (1 MiB) below unless overridden
+        .align_policy = ESP_EXT_PART_ALIGN_POLICY_KEEP_SIZE, // Default: keep the requested size (current behavior)
         .keep_signature = false, // Default is to generate a new disk signature
     };
 
@@ -215,13 +260,21 @@ esp_err_t esp_mbr_generate(mbr_t *mbr,
         if (extra_args->sector_size != ESP_EXT_PART_SECTOR_SIZE_UNKNOWN) {
             args.sector_size = extra_args->sector_size;
         }
-        if (extra_args->alignment != ESP_EXT_PART_ALIGN_NONE) {
+        if (extra_args->alignment != ESP_EXT_PART_ALIGN_AUTO) {
+            // Honor an explicit alignment, including ESP_EXT_PART_ALIGN_NONE
             args.alignment = extra_args->alignment;
         }
         args.keep_signature = extra_args->keep_signature;
         if (extra_args->esp_mbr_generate_custom_supported_partition_types) {
             args.esp_mbr_generate_custom_supported_partition_types = extra_args->esp_mbr_generate_custom_supported_partition_types;
         }
+        args.align_policy = extra_args->align_policy;
+        args.total_size = extra_args->total_size;
+    }
+
+    // Resolve ESP_EXT_PART_ALIGN_AUTO to the library default alignment (1 MiB)
+    if (args.alignment == ESP_EXT_PART_ALIGN_AUTO) {
+        args.alignment = ESP_EXT_PART_ALIGN_1MiB;
     }
 
     mbr->boot_signature = MBR_SIGNATURE;
@@ -240,19 +293,118 @@ esp_err_t esp_mbr_generate(mbr_t *mbr,
         mbr->copy_protected = MBR_COPY_PROTECTED;
     }
 
+    // Total disk size in sectors (used both for auto-fill/FILL and the bounds check).
+    // Use FLOOR division here: this is a device capacity, so a trailing partial sector
+    // (when total_size is not a whole multiple of sector_size) is not usable and must
+    // not be counted - otherwise a FILL/bounds check could place a partition up to one
+    // sector past the real end of the disk.
+    uint64_t total_sectors = 0;
+    if (args.total_size != 0 && args.sector_size != ESP_EXT_PART_SECTOR_SIZE_UNKNOWN) {
+        total_sectors = args.total_size / (uint64_t) args.sector_size;
+    }
+
     esp_ext_part_list_item_t *it = NULL;
     int i = 0;
+    // Running cursor for automatic placement (in sectors). Starts at 1 so the first
+    // auto-placed partition begins after the MBR sector (sector 0) and, once aligned,
+    // lands on the first aligned LBA (e.g. sector 2048 for 1 MiB / 512 B).
+    uint32_t next_free_lba = 1;
     SLIST_FOREACH(it, &part_list->head, next) {
         if (i >= MBR_MAX_PARTITION_COUNT) {
             ESP_LOGW(TAG, "More than %d partitions in the list, only the first %d will be added to the MBR", MBR_MAX_PARTITION_COUNT, MBR_MAX_PARTITION_COUNT);
             break; // MBR can only hold 4 partitions
         }
-        err = esp_mbr_partition_set(mbr, i, it, &args);
+
+        // An empty (ESP_EXT_PART_TYPE_NONE) item cannot be written as a partition entry:
+        // it would leave a zeroed slot in the middle of the table, which esp_mbr_parse
+        // stops at (silently dropping later partitions). Reject it.
+        if (it->info.type == ESP_EXT_PART_TYPE_NONE) {
+            ESP_LOGE(TAG, "Empty partition (ESP_EXT_PART_TYPE_NONE) in list would create a gap in the MBR partition table");
+            return ESP_ERR_INVALID_ARG;
+        }
+
+        // FILL without AUTO_ADDRESS has no effect (FILL is only resolved inside the
+        // AUTO_ADDRESS block). Reject the case where size is also 0; that combination
+        // would silently produce a zero-sector entry.
+        if ((it->info.flags & ESP_EXT_PART_FLAG_FILL) && !(it->info.flags & ESP_EXT_PART_FLAG_AUTO_ADDRESS)) {
+            if (it->info.size == 0) {
+                ESP_LOGE(TAG, "Partition %d has FILL flag without AUTO_ADDRESS and size 0; this would write a zero-size partition", i);
+                return ESP_ERR_INVALID_ARG;
+            }
+            ESP_LOGW(TAG, "Partition %d has FILL flag without AUTO_ADDRESS; FILL has no effect", i);
+        }
+
+        // Work on a shallow copy so the caller's list items are never mutated.
+        esp_ext_part_list_item_t local = *it;
+
+        if (it->info.flags & ESP_EXT_PART_FLAG_AUTO_ADDRESS) {
+            // Compute an aligned start placed after the previous entry.
+            uint32_t start_lba = esp_mbr_lba_align(next_free_lba, args.sector_size, args.alignment);
+
+            uint64_t size_sectors;
+            if (it->info.size == 0) {
+                if (!(it->info.flags & ESP_EXT_PART_FLAG_FILL)) {
+                    ESP_LOGE(TAG, "Partition %d has AUTO_ADDRESS and size 0 but no FILL flag", i);
+                    return ESP_ERR_INVALID_ARG;
+                }
+                if (total_sectors == 0 || (uint64_t) start_lba >= total_sectors) {
+                    ESP_LOGE(TAG, "Partition %d FILL cannot size to disk end (total sectors %" PRIu64 ", start %" PRIu32 ")",
+                             i, total_sectors, start_lba);
+                    return ESP_ERR_INVALID_SIZE;
+                }
+                size_sectors = total_sectors - (uint64_t) start_lba;
+            } else {
+                size_sectors = esp_ext_part_bytes_to_sector_count(it->info.size, args.sector_size);
+            }
+
+            // Feed a concrete, already-aligned address/size to esp_mbr_partition_set.
+            local.info.address = esp_ext_part_sector_count_to_bytes(start_lba, args.sector_size);
+            local.info.size = esp_ext_part_sector_count_to_bytes(size_sectors, args.sector_size);
+            local.info.flags &= ~(esp_ext_part_flags_t) ESP_EXT_PART_FLAG_AUTO_ADDRESS; // Now concrete
+        }
+
+        err = esp_mbr_partition_set(mbr, i, &local, &args);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "Failed to set partition %d: %s", i, esp_err_to_name(err));
             return err; // Error setting partition
         }
+
+        // Advance the cursor from the entry actually written (post-alignment).
+        next_free_lba = mbr->partition_table[i].lba_start + mbr->partition_table[i].sector_count;
         i += 1;
+    }
+    int partition_count = i; // Number of partition entries actually written
+
+    // Validate the generated layout (using the final post-alignment LBA values).
+    for (int a = 0; a < partition_count; a++) {
+        mbr_partition_t *pa = &mbr->partition_table[a];
+        if (pa->type == 0x00) {
+            continue; // Empty entry, nothing to validate
+        }
+        uint64_t a_start = pa->lba_start;
+        uint64_t a_end = a_start + pa->sector_count; // exclusive
+
+        // "Fits within disk" check (only when a total size was provided/auto-filled).
+        if (total_sectors != 0 && a_end > total_sectors) {
+            ESP_LOGE(TAG, "Partition %d (sectors %" PRIu64 "..%" PRIu64 ") runs past the disk (%" PRIu64 " sectors)",
+                     a, a_start, a_end, total_sectors);
+            return ESP_ERR_INVALID_SIZE;
+        }
+
+        // Overlap check against previously placed partitions.
+        for (int b = 0; b < a; b++) {
+            mbr_partition_t *pb = &mbr->partition_table[b];
+            if (pb->type == 0x00) {
+                continue;
+            }
+            uint64_t b_start = pb->lba_start;
+            uint64_t b_end = b_start + pb->sector_count; // exclusive
+            if (a_start < b_end && b_start < a_end) {
+                ESP_LOGE(TAG, "Partition %d (sectors %" PRIu64 "..%" PRIu64 ") overlaps partition %d (sectors %" PRIu64 "..%" PRIu64 ")",
+                         a, a_start, a_end, b, b_start, b_end);
+                return ESP_ERR_INVALID_STATE;
+            }
+        }
     }
 
     return ESP_OK;

--- a/esp_ext_part_tables/src/esp_mbr_utils.c
+++ b/esp_ext_part_tables/src/esp_mbr_utils.c
@@ -86,10 +86,14 @@ uint32_t esp_mbr_lba_align(uint32_t lba, esp_ext_part_sector_size_t sector_size,
 
 static bool default_known_supported_partition_types(uint8_t type, esp_ext_part_type_known_t *out_type_parsed)
 {
+    // `supported` reports whether ESP-IDF has a driver for the type (i.e. it is
+    // mountable). It no longer gates whether the parser inserts the partition;
+    // insertion is driven by the type mapping and the optional parse `match`
+    // predicate. The return value is kept for the public callback contract.
     bool supported = true;
     esp_ext_part_type_known_t parsed_type = ESP_EXT_PART_TYPE_NONE;
     switch (type) {
-    // Supported types:
+    // Mountable types (known filesystem with an ESP-IDF driver):
     case 0x01: // FAT12
         parsed_type = ESP_EXT_PART_TYPE_FAT12;
         break;
@@ -109,18 +113,18 @@ static bool default_known_supported_partition_types(uint8_t type, esp_ext_part_t
         parsed_type = ESP_EXT_PART_TYPE_RAW_DATA;
         break;
 
-    // Unsupported types:
+    // Recognized but not mountable (no ESP-IDF driver):
     case 0x07: // exFAT or NTFS
         parsed_type = ESP_EXT_PART_TYPE_EXFAT_OR_NTFS;
-        supported = false; // Not supported
+        supported = false; // Not mountable
         break;
     case 0x83: // Linux partition (any type)
         parsed_type = ESP_EXT_PART_TYPE_LINUX_ANY;
-        supported = false; // Not supported
+        supported = false; // Not mountable
         break;
     case 0xEE: // GPT protective MBR
         parsed_type = ESP_EXT_PART_TYPE_GPT_PROTECTIVE_MBR;
-        supported = false; // Not supported
+        supported = false; // Not mountable
         break;
     case 0x05: __attribute__((fallthrough)); // Extended partition with CHS addressing
     case 0x0F: __attribute__((fallthrough)); // Extended partition with LBA addressing
@@ -133,7 +137,7 @@ static bool default_known_supported_partition_types(uint8_t type, esp_ext_part_t
         *out_type_parsed = parsed_type;
     }
     if (supported == false) {
-        ESP_LOGD(TAG, "Unknown or unsupported partition type: 0x%02X", type);
+        ESP_LOGD(TAG, "Unknown or not-mountable partition type: 0x%02X", type);
     }
     return supported;
 }
@@ -183,4 +187,35 @@ uint8_t esp_mbr_generate_default_supported_partition_types(uint8_t type)
     default:
         return 0x00; // Unknown type
     }
+}
+
+static bool match_mountable_fn(const esp_ext_part_t *info, void *ctx)
+{
+    (void) ctx;
+    if (info == NULL) {
+        return false;
+    }
+    switch ((esp_ext_part_type_known_t) info->type) {
+    case ESP_EXT_PART_TYPE_FAT12:
+    case ESP_EXT_PART_TYPE_FAT16:
+    case ESP_EXT_PART_TYPE_FAT32:
+        return true; // FatFs is part of ESP-IDF
+    case ESP_EXT_PART_TYPE_LITTLEFS:
+        // Mountable only if the LittleFS component is available to this library at
+        // compile time (its header is visible), or explicitly forced by the consumer.
+#if defined(ESP_EXT_PART_HAS_LITTLEFS) || (defined(__has_include) && __has_include("esp_littlefs.h"))
+        return true;
+#else
+        return false;
+#endif
+    default:
+        return false;
+    }
+}
+
+esp_ext_part_match_t esp_ext_part_match_mountable(void)
+{
+    return (esp_ext_part_match_t) {
+        .fn = match_mountable_fn, .ctx = NULL
+    };
 }

--- a/esp_ext_part_tables/src/esp_mbr_utils.c
+++ b/esp_ext_part_tables/src/esp_mbr_utils.c
@@ -61,11 +61,27 @@ void esp_mbr_lba_to_chs_arr(uint8_t chs[3], uint32_t lba)
 
 uint32_t esp_mbr_lba_align(uint32_t lba, esp_ext_part_sector_size_t sector_size, esp_ext_part_align_t alignment)
 {
-    if (sector_size == 0 || alignment == 0) {
+    // ESP_EXT_PART_ALIGN_NONE (and a 0/unset alignment or sector size) means "leave the LBA untouched".
+    if (sector_size == 0 || alignment == 0 || alignment == ESP_EXT_PART_ALIGN_NONE) {
         return lba; // No alignment
     }
-    uint32_t alignment_sectors = alignment / sector_size;
-    return (lba + alignment_sectors - 1) & ~(alignment_sectors - 1);
+    uint32_t alignment_sectors = (uint32_t) alignment / (uint32_t) sector_size;
+    if (alignment_sectors <= 1) {
+        return lba; // Alignment is at most one sector, nothing to round.
+    }
+    // Round up to the next multiple of alignment_sectors. Use modulo rather than a
+    // power-of-two bitmask so non-power-of-two alignment/sector_size ratios work.
+    uint32_t remainder = lba % alignment_sectors;
+    if (remainder == 0) {
+        return lba; // Already aligned
+    }
+    uint32_t to_add = alignment_sectors - remainder;
+    // Guard against uint32_t overflow at the very top of the MBR address space.
+    // Saturate to UINT32_MAX; the caller's bounds check will reject this as needed.
+    if (lba > UINT32_MAX - to_add) {
+        return UINT32_MAX;
+    }
+    return lba + to_add;
 }
 
 static bool default_known_supported_partition_types(uint8_t type, esp_ext_part_type_known_t *out_type_parsed)
@@ -88,6 +104,9 @@ static bool default_known_supported_partition_types(uint8_t type, esp_ext_part_t
         break;
     case 0xC3: // Possibly LittleFS (MBR CHS field => LittleFS block size hack)
         parsed_type = ESP_EXT_PART_TYPE_LITTLEFS;
+        break;
+    case 0xDA: // Non-filesystem/custom data partition (e.g. raw data, custom format, etc.)
+        parsed_type = ESP_EXT_PART_TYPE_RAW_DATA;
         break;
 
     // Unsupported types:
@@ -153,6 +172,8 @@ uint8_t esp_mbr_generate_default_supported_partition_types(uint8_t type)
     */
     case ESP_EXT_PART_TYPE_LITTLEFS:
         return 0xC3; // Possibly LittleFS (MBR CHS field => LittleFS block size hack)
+    case ESP_EXT_PART_TYPE_RAW_DATA:
+        return 0xDA; // Non-filesystem/custom data partition (e.g. raw data, custom format, etc.)
     case ESP_EXT_PART_TYPE_EXFAT_OR_NTFS: // Not supported, but we can return a type for it
         return 0x07; // exFAT or NTFS
     case ESP_EXT_PART_TYPE_LINUX_ANY: // Not supported, but we can return a type for it

--- a/esp_ext_part_tables/test_apps/CMakeLists.txt
+++ b/esp_ext_part_tables/test_apps/CMakeLists.txt
@@ -3,3 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(COMPONENTS main)
 project(esp_ext_part_tables_parse_test)
+
+# Force the LittleFS branch of esp_ext_part_match_mountable on for tests, so the
+# host test can verify LittleFS-is-mountable without linking the LittleFS component.
+idf_build_set_property(COMPILE_DEFINITIONS "ESP_EXT_PART_HAS_LITTLEFS=1" APPEND)

--- a/esp_ext_part_tables/test_apps/main/test_esp_ext_part.c
+++ b/esp_ext_part_tables/test_apps/main/test_esp_ext_part.c
@@ -976,6 +976,352 @@ TEST_CASE("Test empty partition in list is rejected", "[esp_ext_part_table]")
     TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
 }
 
+// ---------------------------------------------------------------------------
+// Parse-time filtering (esp_mbr_parse_extra_args_t.match) and the LOSSY flag
+// ---------------------------------------------------------------------------
+
+// Build an MBR with one FAT32, one exFAT/NTFS and one raw-data (0xDA) partition, so
+// parse-time filtering behavior can be exercised.
+static void generate_mixed_usage_mbr(mbr_t *mbr)
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    esp_ext_part_list_t part_list = {0};
+
+    esp_ext_part_list_item_t fat = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT32,
+        }
+    };
+    esp_ext_part_list_item_t exfat = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(6144, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_EXFAT_OR_NTFS,
+        }
+    };
+    esp_ext_part_list_item_t raw = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(10240, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_RAW_DATA,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &fat));
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &exfat));
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &raw));
+    TEST_ESP_OK(esp_mbr_generate(mbr, &part_list, &args));
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+}
+
+static int count_list_items(esp_ext_part_list_t *list)
+{
+    int count = 0;
+    for (esp_ext_part_list_item_t *it = esp_ext_part_list_item_head(list); it != NULL; it = esp_ext_part_list_item_next(it)) {
+        count++;
+    }
+    return count;
+}
+
+// Parse-filter predicates.
+static bool keep_only_fat32(const esp_ext_part_t *info, void *ctx)
+{
+    (void) ctx;
+    return info->type == ESP_EXT_PART_TYPE_FAT32;
+}
+
+static bool keep_fat32_or_raw(const esp_ext_part_t *info, void *ctx)
+{
+    (void) ctx;
+    return info->type == ESP_EXT_PART_TYPE_FAT32 || info->type == ESP_EXT_PART_TYPE_RAW_DATA;
+}
+
+// By default (match == NULL) every recognized partition is inserted, including the
+// exFAT one; nothing is dropped, so LOSSY must NOT be set.
+TEST_CASE("Test parse inserts all recognized types by default (not lossy)", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    generate_mixed_usage_mbr(mbr);
+
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, NULL));
+
+    TEST_ASSERT_EQUAL(3, count_list_items(&parsed));
+    TEST_ASSERT_EQUAL(0, parsed.flags & ESP_EXT_PART_LIST_FLAG_LOSSY);
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
+// With a match predicate that keeps only FAT32, the exFAT and raw partitions are
+// dropped at parse time, so LOSSY must be set.
+TEST_CASE("Test parse match predicate inserts only matching partitions and marks lossy", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    generate_mixed_usage_mbr(mbr);
+
+    esp_mbr_parse_extra_args_t args = {
+        .match = { .fn = keep_only_fat32 },
+    };
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, &args));
+
+    TEST_ASSERT_EQUAL(1, count_list_items(&parsed));
+    esp_ext_part_list_item_t *it = esp_ext_part_list_item_head(&parsed);
+    TEST_ASSERT_NOT_NULL(it);
+    TEST_ASSERT_EQUAL(ESP_EXT_PART_TYPE_FAT32, it->info.type);
+    TEST_ASSERT_NOT_EQUAL(0, parsed.flags & ESP_EXT_PART_LIST_FLAG_LOSSY);
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
+// A match predicate keeping FAT32 + raw drops only the exFAT partition (still lossy).
+TEST_CASE("Test parse match predicate keeps multiple types", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    generate_mixed_usage_mbr(mbr);
+
+    esp_mbr_parse_extra_args_t args = {
+        .match = { .fn = keep_fat32_or_raw },
+    };
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, &args));
+
+    TEST_ASSERT_EQUAL(2, count_list_items(&parsed));
+    TEST_ASSERT_NOT_EQUAL(0, parsed.flags & ESP_EXT_PART_LIST_FLAG_LOSSY);
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
+// A partition with an unknown/extended type (0x05) has no esp_ext_part_type_known_t
+// mapping; it is skipped during parse and the list is marked LOSSY.
+TEST_CASE("Test parse skips unknown type and marks lossy", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    mbr->boot_signature = MBR_SIGNATURE;
+    // Slot 0: a valid FAT32 (0x0C) partition.
+    mbr->partition_table[0].type = 0x0C;
+    mbr->partition_table[0].lba_start = 2048;
+    mbr->partition_table[0].sector_count = 2048;
+    // Slot 1: extended partition (0x05) - unknown to this component.
+    mbr->partition_table[1].type = 0x05;
+    mbr->partition_table[1].lba_start = 4096;
+    mbr->partition_table[1].sector_count = 2048;
+
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, NULL));
+
+    // Only the FAT32 partition made it into the list.
+    TEST_ASSERT_EQUAL(1, count_list_items(&parsed));
+    TEST_ASSERT_NOT_EQUAL(0, parsed.flags & ESP_EXT_PART_LIST_FLAG_LOSSY);
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
+// --- Predicate-based iteration (esp_ext_part_list_next_matching) ---
+
+// Predicate: match a single fixed type (ignores ctx).
+static bool match_is_fat32(const esp_ext_part_t *info, void *ctx)
+{
+    (void) ctx;
+    return info->type == ESP_EXT_PART_TYPE_FAT32;
+}
+
+// Predicate: match any type contained in a caller-provided set passed via ctx.
+typedef struct {
+    const uint8_t *types;
+    size_t count;
+} type_set_t;
+
+static bool match_type_in_set(const esp_ext_part_t *info, void *ctx)
+{
+    const type_set_t *set = (const type_set_t *) ctx;
+    for (size_t i = 0; i < set->count; i++) {
+        if (info->type == set->types[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Predicate: match on a runtime field (size at least the threshold passed via ctx).
+static bool match_size_at_least(const esp_ext_part_t *info, void *ctx)
+{
+    uint64_t threshold = *(const uint64_t *) ctx;
+    return info->size >= threshold;
+}
+
+TEST_CASE("Test esp_ext_part_list_next_matching with a type predicate", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    generate_mixed_usage_mbr(mbr); // FAT32 + exFAT + 0xDA
+
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, NULL));
+
+    // First (and only) FAT32 is found, then NULL.
+    esp_ext_part_match_t matcher = { .fn = match_is_fat32 };
+    esp_ext_part_list_item_t *it = esp_ext_part_list_next_matching(NULL, &parsed, &matcher);
+    TEST_ASSERT_NOT_NULL(it);
+    TEST_ASSERT_EQUAL(ESP_EXT_PART_TYPE_FAT32, it->info.type);
+    TEST_ASSERT_NULL(esp_ext_part_list_next_matching(it, &parsed, &matcher));
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
+TEST_CASE("Test esp_ext_part_list_next_matching with a ctx set predicate", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    generate_mixed_usage_mbr(mbr); // FAT32 + exFAT + 0xDA
+
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, NULL));
+
+    // "Types I can handle in this build" = FAT32 + raw data. Should match 2 items.
+    uint8_t wanted[] = { ESP_EXT_PART_TYPE_FAT32, ESP_EXT_PART_TYPE_RAW_DATA };
+    type_set_t set = { .types = wanted, .count = 2 };
+    esp_ext_part_match_t matcher = { .fn = match_type_in_set, .ctx = &set };
+
+    int matches = 0;
+    for (esp_ext_part_list_item_t *it = esp_ext_part_list_next_matching(NULL, &parsed, &matcher);
+            it != NULL;
+            it = esp_ext_part_list_next_matching(it, &parsed, &matcher)) {
+        matches++;
+    }
+    TEST_ASSERT_EQUAL(2, matches);
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
+TEST_CASE("Test esp_ext_part_list_next_matching branches on a runtime field", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    generate_mixed_usage_mbr(mbr); // all three partitions are 2048 sectors == 1 MiB
+
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, NULL));
+
+    // Threshold above every partition's size -> no match.
+    uint64_t big = esp_ext_part_sector_count_to_bytes(4096, ESP_EXT_PART_SECTOR_SIZE_512B);
+    esp_ext_part_match_t big_matcher = { .fn = match_size_at_least, .ctx = &big };
+    TEST_ASSERT_NULL(esp_ext_part_list_next_matching(NULL, &parsed, &big_matcher));
+
+    // Threshold at or below every partition's size -> all three match.
+    uint64_t small = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B);
+    esp_ext_part_match_t small_matcher = { .fn = match_size_at_least, .ctx = &small };
+    int matches = 0;
+    for (esp_ext_part_list_item_t *it = esp_ext_part_list_next_matching(NULL, &parsed, &small_matcher);
+            it != NULL;
+            it = esp_ext_part_list_next_matching(it, &parsed, &small_matcher)) {
+        matches++;
+    }
+    TEST_ASSERT_EQUAL(3, matches);
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
+TEST_CASE("Test esp_ext_part_list_next_matching handles NULL predicate and list", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    generate_mixed_usage_mbr(mbr);
+
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, NULL));
+
+    // NULL matcher pointer -> nothing matches.
+    TEST_ASSERT_NULL(esp_ext_part_list_next_matching(NULL, &parsed, NULL));
+    // Matcher with NULL fn -> nothing matches.
+    esp_ext_part_match_t empty = {0};
+    TEST_ASSERT_NULL(esp_ext_part_list_next_matching(NULL, &parsed, &empty));
+    // NULL list with NULL from -> NULL.
+    esp_ext_part_match_t matcher = { .fn = match_is_fat32 };
+    TEST_ASSERT_NULL(esp_ext_part_list_next_matching(NULL, NULL, &matcher));
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
+// The stock esp_ext_part_match_mountable predicate: FAT* always mountable, the
+// non-filesystem / undrivable types never, and LittleFS mountable here because the
+// test build defines ESP_EXT_PART_HAS_LITTLEFS.
+TEST_CASE("Test esp_ext_part_match_mountable classifies types", "[esp_ext_part_table]")
+{
+    esp_ext_part_match_t matcher = esp_ext_part_match_mountable();
+    TEST_ASSERT_NOT_NULL(matcher.fn);
+    esp_ext_part_t info = {0};
+
+    info.type = ESP_EXT_PART_TYPE_FAT12;
+    TEST_ASSERT_TRUE(matcher.fn(&info, matcher.ctx));
+    info.type = ESP_EXT_PART_TYPE_FAT16;
+    TEST_ASSERT_TRUE(matcher.fn(&info, matcher.ctx));
+    info.type = ESP_EXT_PART_TYPE_FAT32;
+    TEST_ASSERT_TRUE(matcher.fn(&info, matcher.ctx));
+
+    // LittleFS: mountable because ESP_EXT_PART_HAS_LITTLEFS is defined for this build.
+    info.type = ESP_EXT_PART_TYPE_LITTLEFS;
+    TEST_ASSERT_TRUE(matcher.fn(&info, matcher.ctx));
+
+    // Not mountable: raw data, exFAT/NTFS, Linux, GPT-protective, none.
+    info.type = ESP_EXT_PART_TYPE_RAW_DATA;
+    TEST_ASSERT_FALSE(matcher.fn(&info, matcher.ctx));
+    info.type = ESP_EXT_PART_TYPE_EXFAT_OR_NTFS;
+    TEST_ASSERT_FALSE(matcher.fn(&info, matcher.ctx));
+    info.type = ESP_EXT_PART_TYPE_LINUX_ANY;
+    TEST_ASSERT_FALSE(matcher.fn(&info, matcher.ctx));
+    info.type = ESP_EXT_PART_TYPE_GPT_PROTECTIVE_MBR;
+    TEST_ASSERT_FALSE(matcher.fn(&info, matcher.ctx));
+    info.type = ESP_EXT_PART_TYPE_NONE;
+    TEST_ASSERT_FALSE(matcher.fn(&info, matcher.ctx));
+}
+
+// The stock predicate composes with the iterator: on a FAT32 + exFAT + 0xDA disk,
+// only the FAT32 partition is mountable.
+TEST_CASE("Test esp_ext_part_match_mountable via next_matching", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    generate_mixed_usage_mbr(mbr); // FAT32 (mountable) + exFAT + 0xDA (not)
+
+    esp_ext_part_list_t parsed = {0};
+    TEST_ESP_OK(esp_mbr_parse((void *) mbr, &parsed, NULL));
+
+    int matches = 0;
+    esp_ext_part_list_item_t *first = NULL;
+    esp_ext_part_match_t matcher = esp_ext_part_match_mountable();
+    for (esp_ext_part_list_item_t *it = esp_ext_part_list_next_matching(NULL, &parsed, &matcher);
+            it != NULL;
+            it = esp_ext_part_list_next_matching(it, &parsed, &matcher)) {
+        if (first == NULL) {
+            first = it;
+        }
+        matches++;
+    }
+    TEST_ASSERT_EQUAL(1, matches);
+    TEST_ASSERT_NOT_NULL(first);
+    TEST_ASSERT_EQUAL(ESP_EXT_PART_TYPE_FAT32, first->info.type);
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&parsed));
+    free(mbr);
+}
+
 #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
 #include "esp_blockdev.h"
 

--- a/esp_ext_part_tables/test_apps/main/test_esp_ext_part.c
+++ b/esp_ext_part_tables/test_apps/main/test_esp_ext_part.c
@@ -23,6 +23,7 @@
 
 #include "esp_ext_part_tables.h"
 #include "esp_mbr.h"
+#include "esp_mbr_utils.h"
 
 void setUp(void)
 {
@@ -212,7 +213,11 @@ TEST_CASE("Test esp_mbr_generate with esp_mbr_parse", "[esp_ext_part_table]")
     };
     esp_ext_part_list_item_t item2 = {
         .info = {
-            .address = 10000, // Should be round up to 10240 (aligned to 1MiB) due to defined sector size and alignment in `esp_mbr_generate_extra_args_t args` below
+            // 10000 sectors -> aligned up to 10240 (1 MiB). Note this is expressed in
+            // sectors (converted to bytes); using a raw byte value like 10000 here
+            // would be only ~20 sectors and would align back to 2048, overlapping
+            // item1 - which the generator's overlap validation now rejects.
+            .address = esp_ext_part_sector_count_to_bytes(10000, mbr_args.sector_size),
             .size = esp_ext_part_sector_count_to_bytes(2 * 10240, mbr_args.sector_size),
             .type = ESP_EXT_PART_TYPE_LITTLEFS,
             .label = NULL,
@@ -357,6 +362,618 @@ TEST_CASE("Test esp_mbr_partition_set and esp_mbr_remove_gaps_between_partiton_e
 
     // Deinitialize the part list
     TEST_ESP_OK(esp_ext_part_list_deinit(&part_list_from_mbr_correct));
+}
+
+// ---------------------------------------------------------------------------
+// Alignment policy, alignment sentinels, and layout validation tests
+// ---------------------------------------------------------------------------
+
+// Helper: generate a single-partition MBR and return the raw partition entry 0.
+static esp_err_t gen_single_partition(mbr_t *mbr,
+                                      uint64_t address_bytes,
+                                      uint64_t size_bytes,
+                                      esp_ext_part_type_known_t type,
+                                      esp_mbr_generate_extra_args_t *args)
+{
+    esp_ext_part_list_t part_list = {0};
+    esp_ext_part_list_item_t item = {
+        .info = {
+            .address = address_bytes,
+            .size = size_bytes,
+            .type = type,
+            .label = NULL,
+        }
+    };
+    esp_err_t err = esp_ext_part_list_insert(&part_list, &item);
+    if (err != ESP_OK) {
+        esp_ext_part_list_deinit(&part_list);
+        return err;
+    }
+    err = esp_mbr_generate(mbr, &part_list, args);
+    esp_ext_part_list_deinit(&part_list);
+    return err;
+}
+
+// Test 5: KEEP_SIZE (default) - unaligned start is aligned up, size (sector_count) stays unchanged.
+TEST_CASE("Test align policy KEEP_SIZE keeps size when start is aligned up", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+        .align_policy = ESP_EXT_PART_ALIGN_POLICY_KEEP_SIZE,
+    };
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // Start at sector 8 (=> aligned up to 2048), size 7953 sectors.
+    TEST_ESP_OK(gen_single_partition(mbr,
+                                     esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(7953, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args));
+
+    TEST_ASSERT_EQUAL_UINT32(2048, mbr->partition_table[0].lba_start);
+    TEST_ASSERT_EQUAL_UINT32(7953, mbr->partition_table[0].sector_count); // size unchanged
+    free(mbr);
+}
+
+// Test 1: PRESERVE_END (opt-in) - start aligned up, size shrunk so end == original end.
+TEST_CASE("Test align policy PRESERVE_END shrinks size to keep the end", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+        .align_policy = ESP_EXT_PART_ALIGN_POLICY_PRESERVE_END,
+    };
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // Start at sector 8 => aligned to 2048. Original end (exclusive) = 8 + 7953 = 7961.
+    // New sector_count should be 7961 - 2048 = 5913.
+    TEST_ESP_OK(gen_single_partition(mbr,
+                                     esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(7953, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args));
+
+    TEST_ASSERT_EQUAL_UINT32(2048, mbr->partition_table[0].lba_start);
+    TEST_ASSERT_EQUAL_UINT32(5913, mbr->partition_table[0].sector_count);
+    // End preserved:
+    TEST_ASSERT_EQUAL_UINT32(7961, mbr->partition_table[0].lba_start + mbr->partition_table[0].sector_count);
+    free(mbr);
+}
+
+// Test 2: PRESERVE_END - alignment consumes the whole partition -> error.
+TEST_CASE("Test align policy PRESERVE_END errors when alignment eats the partition", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+        .align_policy = ESP_EXT_PART_ALIGN_POLICY_PRESERVE_END,
+    };
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // Start at sector 8 => aligned up to 2048, but size is only 10 sectors (end = 18 < 2048).
+    esp_err_t err = gen_single_partition(mbr,
+                                         esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                         esp_ext_part_sector_count_to_bytes(10, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                         ESP_EXT_PART_TYPE_FAT12, &args);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_SIZE, err);
+    free(mbr);
+}
+
+// Test 3 & 4: REJECT policy.
+TEST_CASE("Test align policy REJECT errors on unaligned start, ok when aligned", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+        .align_policy = ESP_EXT_PART_ALIGN_POLICY_REJECT,
+    };
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // Unaligned start (sector 8) -> error.
+    esp_err_t err = gen_single_partition(mbr,
+                                         esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                         esp_ext_part_sector_count_to_bytes(7953, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                         ESP_EXT_PART_TYPE_FAT12, &args);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, err);
+
+    // Pre-aligned start (sector 2048) -> ok, unchanged.
+    memset(mbr, 0, sizeof(mbr_t));
+    TEST_ESP_OK(gen_single_partition(mbr,
+                                     esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(7953, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args));
+    TEST_ASSERT_EQUAL_UINT32(2048, mbr->partition_table[0].lba_start);
+    TEST_ASSERT_EQUAL_UINT32(7953, mbr->partition_table[0].sector_count);
+    free(mbr);
+}
+
+// Test 6: ALIGN_NONE performs no relocation.
+TEST_CASE("Test ALIGN_NONE leaves the start untouched", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_NONE,
+    };
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // Start at sector 8, no alignment -> lba_start stays 8.
+    TEST_ESP_OK(gen_single_partition(mbr,
+                                     esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args));
+    TEST_ASSERT_EQUAL_UINT32(8, mbr->partition_table[0].lba_start);
+    TEST_ASSERT_EQUAL_UINT32(100, mbr->partition_table[0].sector_count);
+    free(mbr);
+}
+
+// Test 7: ALIGN_AUTO (and zero-initialized alignment) applies the 1 MiB default.
+TEST_CASE("Test ALIGN_AUTO applies the 1MiB default alignment", "[esp_ext_part_table]")
+{
+    // Explicit AUTO
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_AUTO,
+    };
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    TEST_ESP_OK(gen_single_partition(mbr,
+                                     esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args));
+    TEST_ASSERT_EQUAL_UINT32(2048, mbr->partition_table[0].lba_start); // aligned to 1 MiB
+    free(mbr);
+
+    // Zero-initialized alignment field must also select AUTO (=> 1 MiB), not NONE.
+    esp_mbr_generate_extra_args_t args0 = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+    };
+    mbr_t *mbr2 = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr2);
+    TEST_ESP_OK(gen_single_partition(mbr2,
+                                     esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args0));
+    TEST_ASSERT_EQUAL_UINT32(2048, mbr2->partition_table[0].lba_start);
+    free(mbr2);
+}
+
+// Test 8: overlap detection (always on).
+TEST_CASE("Test overlapping partitions are rejected", "[esp_ext_part_table]")
+{
+    esp_ext_part_list_t part_list = {0};
+    // Two partitions that overlap: p0 = [2048, 2048+4096), p1 starts at 4096 (< 6144) with NONE alignment.
+    esp_ext_part_list_item_t item1 = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = esp_ext_part_sector_count_to_bytes(4096, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+        }
+    };
+    esp_ext_part_list_item_t item2 = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(4096, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = esp_ext_part_sector_count_to_bytes(4096, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &item1));
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &item2));
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // With NONE alignment the two partitions overlap -> overlap error.
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_NONE,
+    };
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, esp_mbr_generate(mbr, &part_list, &args));
+
+    free(mbr);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+}
+
+// Test 10 & 11: disk-bounds (total_size) check.
+TEST_CASE("Test total_size bounds check rejects off-disk partitions", "[esp_ext_part_table]")
+{
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // Partition ends at sector 2048+100 = 2148 (= 1099776 bytes). Set total_size just below that.
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+        .total_size = esp_ext_part_sector_count_to_bytes(2000, ESP_EXT_PART_SECTOR_SIZE_512B), // too small
+    };
+    esp_err_t err = gen_single_partition(mbr,
+                                         esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                         esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                         ESP_EXT_PART_TYPE_FAT12, &args);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_SIZE, err);
+
+    // total_size large enough -> ok.
+    memset(mbr, 0, sizeof(mbr_t));
+    args.total_size = esp_ext_part_sector_count_to_bytes(4096, ESP_EXT_PART_SECTOR_SIZE_512B);
+    TEST_ESP_OK(gen_single_partition(mbr,
+                                     esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args));
+
+    // total_size == 0 -> check skipped even for a huge partition.
+    memset(mbr, 0, sizeof(mbr_t));
+    args.total_size = 0;
+    TEST_ESP_OK(gen_single_partition(mbr,
+                                     esp_ext_part_sector_count_to_bytes(8, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args));
+    free(mbr);
+}
+
+// total_size that is NOT a whole multiple of the sector size must be floored, not
+// ceiled: a trailing partial sector is not usable capacity. A partition that ends on
+// the last WHOLE sector is accepted; one that ends on the (non-existent) partial
+// sector beyond it must be rejected. With the old ceiling behavior the latter was
+// wrongly accepted (off-disk by up to one sector).
+TEST_CASE("Test total_size is floored to whole sectors", "[esp_ext_part_table]")
+{
+    // 100 whole 512 B sectors + 100 extra bytes -> floor = 100 sectors (usable),
+    // ceiling would have been 101.
+    const uint64_t total = (uint64_t) 100 * 512 + 100;
+
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_NONE, // keep the exact start, no rounding
+        .total_size = total,
+    };
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // Ends exactly at sector 100 (start 50 + 50): within the floored capacity -> OK.
+    TEST_ESP_OK(gen_single_partition(mbr,
+                                     esp_ext_part_sector_count_to_bytes(50, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     esp_ext_part_sector_count_to_bytes(50, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                     ESP_EXT_PART_TYPE_FAT12, &args));
+    TEST_ASSERT_EQUAL_UINT32(100, mbr->partition_table[0].lba_start + mbr->partition_table[0].sector_count);
+
+    // Ends at sector 101 (start 50 + 51): past the floored capacity of 100 -> rejected.
+    // (Ceiling would have made total_sectors 101 and wrongly accepted this.)
+    memset(mbr, 0, sizeof(mbr_t));
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_SIZE,
+                      gen_single_partition(mbr,
+                                           esp_ext_part_sector_count_to_bytes(50, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                           esp_ext_part_sector_count_to_bytes(51, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                           ESP_EXT_PART_TYPE_FAT12, &args));
+    free(mbr);
+}
+
+// A partition whose start and count each fit in 32 bits but whose END (start + count)
+// exceeds UINT32_MAX must be rejected: the sum would overflow the 32-bit MBR fields
+// and wrap the auto-placement cursor. Use ALIGN_NONE so the start is not rounded.
+TEST_CASE("Test partition whose end exceeds the 32-bit MBR range is rejected", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_NONE,
+    };
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+
+    // start = UINT32_MAX - 10 sectors, count = 20 sectors -> end = UINT32_MAX + 10 (overflow).
+    // Both start and count individually fit in 32 bits, but the end does not.
+    TEST_ASSERT_EQUAL(ESP_ERR_NOT_SUPPORTED,
+                      gen_single_partition(mbr,
+                                           esp_ext_part_sector_count_to_bytes((uint64_t) UINT32_MAX - 10, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                           esp_ext_part_sector_count_to_bytes(20, ESP_EXT_PART_SECTOR_SIZE_512B),
+                                           ESP_EXT_PART_TYPE_FAT12, &args));
+    free(mbr);
+}
+
+// esp_mbr_lba_align must round up correctly even when alignment / sector_size is
+// not a power of two. The defined enum values all happen to yield a power-of-two
+// number of sectors, but a caller may cast a custom alignment value, so the
+// rounding must not rely on the power-of-two bitmask idiom.
+TEST_CASE("Test esp_mbr_lba_align rounds up for non-power-of-two alignment", "[esp_ext_part_table]")
+{
+    // alignment = 1536 bytes, sector_size = 512 => alignment_sectors = 3 (not a power of two).
+    esp_ext_part_align_t align3 = (esp_ext_part_align_t) 1536;
+
+    // Already-aligned values stay put.
+    TEST_ASSERT_EQUAL_UINT32(0, esp_mbr_lba_align(0, ESP_EXT_PART_SECTOR_SIZE_512B, align3));
+    TEST_ASSERT_EQUAL_UINT32(3, esp_mbr_lba_align(3, ESP_EXT_PART_SECTOR_SIZE_512B, align3));
+    TEST_ASSERT_EQUAL_UINT32(6, esp_mbr_lba_align(6, ESP_EXT_PART_SECTOR_SIZE_512B, align3));
+
+    // Unaligned values round UP to the next multiple of 3.
+    TEST_ASSERT_EQUAL_UINT32(3, esp_mbr_lba_align(1, ESP_EXT_PART_SECTOR_SIZE_512B, align3));
+    TEST_ASSERT_EQUAL_UINT32(6, esp_mbr_lba_align(4, ESP_EXT_PART_SECTOR_SIZE_512B, align3));
+    TEST_ASSERT_EQUAL_UINT32(6, esp_mbr_lba_align(5, ESP_EXT_PART_SECTOR_SIZE_512B, align3));
+    TEST_ASSERT_EQUAL_UINT32(9, esp_mbr_lba_align(7, ESP_EXT_PART_SECTOR_SIZE_512B, align3));
+
+    // Sanity: a power-of-two combo (1 MiB / 512 = 2048) still works.
+    TEST_ASSERT_EQUAL_UINT32(2048, esp_mbr_lba_align(8, ESP_EXT_PART_SECTOR_SIZE_512B, ESP_EXT_PART_ALIGN_1MiB));
+    TEST_ASSERT_EQUAL_UINT32(2048, esp_mbr_lba_align(2048, ESP_EXT_PART_SECTOR_SIZE_512B, ESP_EXT_PART_ALIGN_1MiB));
+
+    // ESP_EXT_PART_ALIGN_NONE and a zero alignment leave the LBA untouched.
+    TEST_ASSERT_EQUAL_UINT32(7, esp_mbr_lba_align(7, ESP_EXT_PART_SECTOR_SIZE_512B, ESP_EXT_PART_ALIGN_NONE));
+    TEST_ASSERT_EQUAL_UINT32(7, esp_mbr_lba_align(7, ESP_EXT_PART_SECTOR_SIZE_512B, (esp_ext_part_align_t) 0));
+
+    // Overflow guard: aligning an LBA that is already within one alignment_sectors
+    // of UINT32_MAX must not wrap; the saturated result is UINT32_MAX.
+    // alignment_sectors = 2048 (1 MiB / 512 B); last aligned LBA below UINT32_MAX is
+    // 0xFFFFF800 (= 4294965248). The next LBA after that would overflow, so
+    // esp_mbr_lba_align must return UINT32_MAX instead.
+    TEST_ASSERT_EQUAL_UINT32(UINT32_MAX, esp_mbr_lba_align(0xFFFFF801, ESP_EXT_PART_SECTOR_SIZE_512B, ESP_EXT_PART_ALIGN_1MiB));
+    TEST_ASSERT_EQUAL_UINT32(UINT32_MAX, esp_mbr_lba_align(UINT32_MAX,  ESP_EXT_PART_SECTOR_SIZE_512B, ESP_EXT_PART_ALIGN_1MiB));
+}
+
+// ---------------------------------------------------------------------------
+// Automatic partition placement (ESP_EXT_PART_FLAG_AUTO_ADDRESS / _FILL) tests
+// ---------------------------------------------------------------------------
+
+// Test 1: a single AUTO_ADDRESS partition (first in the list) lands at the first aligned LBA.
+TEST_CASE("Test auto-placement: first partition placed at first aligned LBA", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    esp_ext_part_list_t part_list = {0};
+    esp_ext_part_list_item_t item = {
+        .info = {
+            .size = esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &item));
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    TEST_ESP_OK(esp_mbr_generate(mbr, &part_list, &args));
+
+    TEST_ASSERT_EQUAL_UINT32(2048, mbr->partition_table[0].lba_start); // first 1 MiB-aligned LBA
+    TEST_ASSERT_EQUAL_UINT32(100, mbr->partition_table[0].sector_count);
+    free(mbr);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+}
+
+// Test 2 & 3: AUTO partitions chain contiguously after their predecessor (aligned).
+TEST_CASE("Test auto-placement: partitions chain after the previous one", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    esp_ext_part_list_t part_list = {0};
+
+    // p0 explicit at sector 2048, size 3000 sectors -> ends at 5048.
+    esp_ext_part_list_item_t p0 = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = esp_ext_part_sector_count_to_bytes(3000, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+        }
+    };
+    // p1 AUTO, size 1000 -> placed at align_up(5048) = 6144.
+    esp_ext_part_list_item_t p1 = {
+        .info = {
+            .size = esp_ext_part_sector_count_to_bytes(1000, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
+        }
+    };
+    // p2 AUTO, size 500 -> placed at align_up(6144+1000=7144) = 8192.
+    esp_ext_part_list_item_t p2 = {
+        .info = {
+            .size = esp_ext_part_sector_count_to_bytes(500, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &p0));
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &p1));
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &p2));
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    TEST_ESP_OK(esp_mbr_generate(mbr, &part_list, &args));
+
+    TEST_ASSERT_EQUAL_UINT32(2048, mbr->partition_table[0].lba_start);
+    TEST_ASSERT_EQUAL_UINT32(6144, mbr->partition_table[1].lba_start);
+    TEST_ASSERT_EQUAL_UINT32(1000, mbr->partition_table[1].sector_count);
+    TEST_ASSERT_EQUAL_UINT32(8192, mbr->partition_table[2].lba_start);
+    TEST_ASSERT_EQUAL_UINT32(500, mbr->partition_table[2].sector_count);
+    free(mbr);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+}
+
+// Test 5: AUTO + size==0 without FILL -> error.
+TEST_CASE("Test auto-placement: size 0 without FILL is rejected", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    esp_ext_part_list_t part_list = {0};
+    esp_ext_part_list_item_t item = {
+        .info = {
+            .size = 0,
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &item));
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, esp_mbr_generate(mbr, &part_list, &args));
+    free(mbr);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+}
+
+// Test 6 & 7: FILL behavior.
+TEST_CASE("Test auto-placement: FILL sizes to the end of the disk", "[esp_ext_part_table]")
+{
+    esp_ext_part_list_t part_list = {0};
+    // p0 AUTO explicit-size 100 -> [2048, 2148). p1 AUTO + FILL -> [align_up(2148)=4096, total).
+    esp_ext_part_list_item_t p0 = {
+        .info = {
+            .size = esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
+        }
+    };
+    esp_ext_part_list_item_t p1 = {
+        .info = {
+            .size = 0,
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS | ESP_EXT_PART_FLAG_FILL,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &p0));
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &p1));
+
+    // total_size = 20000 sectors.
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+        .total_size = esp_ext_part_sector_count_to_bytes(20000, ESP_EXT_PART_SECTOR_SIZE_512B),
+    };
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    TEST_ESP_OK(esp_mbr_generate(mbr, &part_list, &args));
+
+    TEST_ASSERT_EQUAL_UINT32(4096, mbr->partition_table[1].lba_start);
+    // Fills to disk end: start + count == total_sectors (20000).
+    TEST_ASSERT_EQUAL_UINT32(20000, mbr->partition_table[1].lba_start + mbr->partition_table[1].sector_count);
+    free(mbr);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+
+    // Test 7: FILL with no total_size -> error.
+    esp_ext_part_list_t pl2 = {0};
+    TEST_ESP_OK(esp_ext_part_list_insert(&pl2, &p1));
+    esp_mbr_generate_extra_args_t args_no_total = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    mbr_t *mbr2 = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr2);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_SIZE, esp_mbr_generate(mbr2, &pl2, &args_no_total));
+    free(mbr2);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&pl2));
+}
+
+// Test 9: the caller's partition items are not mutated by generation.
+TEST_CASE("Test auto-placement: caller items are not mutated", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    esp_ext_part_list_t part_list = {0};
+    esp_ext_part_list_item_t item = {
+        .info = {
+            .address = 0,
+            .size = esp_ext_part_sector_count_to_bytes(100, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &item));
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    TEST_ESP_OK(esp_mbr_generate(mbr, &part_list, &args));
+
+    // The list item must still have its original address (0) and AUTO flag set.
+    esp_ext_part_list_item_t *stored = esp_ext_part_list_item_head(&part_list);
+    TEST_ASSERT_NOT_NULL(stored);
+    TEST_ASSERT_EQUAL_UINT64(0, stored->info.address);
+    TEST_ASSERT_TRUE(stored->info.flags & ESP_EXT_PART_FLAG_AUTO_ADDRESS);
+    free(mbr);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+}
+
+// FILL without AUTO_ADDRESS + size 0 must be rejected (it would silently produce a
+// zero-sector entry). FILL without AUTO_ADDRESS + non-zero size is allowed (with a
+// warning) since the non-zero size still produces a valid entry.
+TEST_CASE("Test FILL without AUTO_ADDRESS: size 0 is rejected", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    esp_ext_part_list_t part_list = {0};
+    esp_ext_part_list_item_t item = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = 0, // size 0 + FILL but no AUTO_ADDRESS -> error
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_FILL,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &item));
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, esp_mbr_generate(mbr, &part_list, &args));
+    free(mbr);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+}
+
+// ---------------------------------------------------------------------------
+// Empty (ESP_EXT_PART_TYPE_NONE) list-item handling in esp_mbr_generate
+// ---------------------------------------------------------------------------
+
+// A ESP_EXT_PART_TYPE_NONE item in the middle of the list would, if written as a
+// zeroed slot, create a gap that esp_mbr_parse silently truncates at (data loss)
+// and that misplaces auto-placed partitions. esp_mbr_generate must reject such an
+// item instead of producing a bad MBR.
+TEST_CASE("Test empty partition in list is rejected", "[esp_ext_part_table]")
+{
+    esp_mbr_generate_extra_args_t args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    esp_ext_part_list_t part_list = {0};
+
+    esp_ext_part_list_item_t p0 = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(2048, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = esp_ext_part_sector_count_to_bytes(1000, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+        }
+    };
+    esp_ext_part_list_item_t empty = {
+        .info = {
+            .type = ESP_EXT_PART_TYPE_NONE, // gap
+        }
+    };
+    esp_ext_part_list_item_t p2 = {
+        .info = {
+            .address = esp_ext_part_sector_count_to_bytes(6144, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .size = esp_ext_part_sector_count_to_bytes(1000, ESP_EXT_PART_SECTOR_SIZE_512B),
+            .type = ESP_EXT_PART_TYPE_FAT12,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &p0));
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &empty));
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &p2));
+
+    mbr_t *mbr = (mbr_t *) calloc(1, sizeof(mbr_t));
+    TEST_ASSERT_NOT_NULL(mbr);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, esp_mbr_generate(mbr, &part_list, &args));
+    free(mbr);
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
 }
 
 #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
@@ -504,6 +1121,13 @@ TEST_CASE("Test with BDL (simulated in RAM) - MBR related", "[esp_ext_part_table
     TEST_ESP_OK(err);
     TEST_ASSERT_NOT_NULL(handle);
 
+    // The backing buffer is intentionally tiny (one MBR sector) to stay within
+    // limited on-target RAM, but the MBR we write declares partitions at high LBAs.
+    // Report a realistic disk size so those partitions are within-bounds for the
+    // new bdl_write disk-bounds validation. Only the MBR sector (offset 0) is ever
+    // actually read/written, so the small backing buffer is never over-indexed.
+    handle->geometry.disk_size = 40 * 1024 * 1024; // 40 MiB (reported only, no allocation)
+
     err = handle->ops->write(handle, mbr_bin, 0, mbr_bin_len);
     TEST_ESP_OK(err);
 
@@ -552,7 +1176,74 @@ TEST_CASE("Test with BDL (simulated in RAM) - MBR related", "[esp_ext_part_table
     print_esp_ext_part_list_items(it);
     fflush(stdout);
 
+    // Negative case: prove the disk-bounds validation fires through the BDL write
+    // path. bdl_write auto-fills total_size from handle->geometry.disk_size (40 MiB
+    // reported above) when the caller leaves it 0, so a partition placed past the
+    // end of the (reported) disk must be rejected with ESP_ERR_INVALID_SIZE.
+    // This is a pure arithmetic check - it does not allocate a 40 MiB buffer.
+    esp_ext_part_list_item_t off_disk_partition = {
+        .info = {
+            .address = 50 * 1024 * 1024, // 50 MiB offset - beyond the 40 MiB reported disk
+            .size = 1 * 1024 * 1024,
+            .type = ESP_EXT_PART_TYPE_FAT12,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &off_disk_partition));
+    err = esp_ext_part_list_bdl_write(handle, &part_list, ESP_EXT_PART_LIST_SIGNATURE_MBR, (void *) &mbr_gen_args);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_SIZE, err);
+
     TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+}
+
+// Test 10: AUTO_ADDRESS + FILL through the BDL write path, with total_size
+// auto-filled from the device geometry (no explicit total_size passed).
+TEST_CASE("Test auto-placement: FILL via BDL uses device geometry", "[esp_ext_part_table]")
+{
+    const uint32_t sector_size = 512;
+    const uint64_t disk_sectors = 30000; // reported disk size in sectors
+
+    size_t buffer_size = 512; // tiny backing buffer; only the MBR sector is touched
+    uint8_t *buffer = (uint8_t *) malloc(buffer_size);
+    TEST_ASSERT_NOT_NULL(buffer);
+    esp_blockdev_handle_t handle = NULL;
+    TEST_ESP_OK(bdl_simulated_get_blockdev(buffer, buffer_size, &handle));
+    TEST_ASSERT_NOT_NULL(handle);
+    handle->geometry.disk_size = disk_sectors * sector_size; // realistic reported size
+
+    esp_ext_part_list_t part_list = {0};
+    esp_ext_part_list_item_t fill_part = {
+        .info = {
+            .size = 0,
+            .type = ESP_EXT_PART_TYPE_FAT12,
+            .flags = ESP_EXT_PART_FLAG_AUTO_ADDRESS | ESP_EXT_PART_FLAG_FILL,
+        }
+    };
+    TEST_ESP_OK(esp_ext_part_list_insert(&part_list, &fill_part));
+
+    // No total_size in args -> bdl_write auto-fills it from handle->geometry.disk_size.
+    esp_mbr_generate_extra_args_t mbr_gen_args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B,
+        .alignment = ESP_EXT_PART_ALIGN_1MiB,
+    };
+    TEST_ESP_OK(esp_ext_part_list_bdl_write(handle, &part_list, ESP_EXT_PART_LIST_SIGNATURE_MBR, (void *) &mbr_gen_args));
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+
+    // Read the MBR back and confirm the FILL partition reaches the disk end.
+    esp_mbr_parse_extra_args_t mbr_parse_args = {
+        .sector_size = ESP_EXT_PART_SECTOR_SIZE_512B
+    };
+    TEST_ESP_OK(esp_ext_part_list_bdl_read(handle, &part_list, ESP_EXT_PART_LIST_SIGNATURE_MBR, (void *) &mbr_parse_args));
+    esp_ext_part_list_item_t *it = esp_ext_part_list_item_head(&part_list);
+    TEST_ASSERT_NOT_NULL(it);
+
+    uint64_t start_sec = esp_ext_part_bytes_to_sector_count(it->info.address, ESP_EXT_PART_SECTOR_SIZE_512B);
+    uint64_t count_sec = esp_ext_part_bytes_to_sector_count(it->info.size, ESP_EXT_PART_SECTOR_SIZE_512B);
+    TEST_ASSERT_EQUAL_UINT32(2048, start_sec); // first aligned LBA
+    TEST_ASSERT_EQUAL_UINT64(disk_sectors, start_sec + count_sec); // fills to disk end
+
+    TEST_ESP_OK(esp_ext_part_list_deinit(&part_list));
+    handle->ops->release(handle);
+    free(buffer);
 }
 #endif // (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0))
 


### PR DESCRIPTION
Overhauls `esp_ext_part_tables` so `esp_mbr_generate` produces valid, verifiable
MBRs (instead of silently-broken ones) and `esp_mbr_parse` reports every recognized
partition, with predicate-based selection for filtering.

## MBR generation

- **Layout validation** - overlapping partitions and partitions running past the end
  of the disk are always rejected. `total_size` bounds the disk; it is auto-filled
  from the block-device geometry in `esp_ext_part_list_bdl_write`.
- **`align_policy`** - `KEEP_SIZE` (default), `REJECT`, `PRESERVE_END` control how a
  partition's size is handled when alignment shifts its start.
- **Automatic placement** - `ESP_EXT_PART_FLAG_AUTO_ADDRESS` computes aligned start
  offsets and `ESP_EXT_PART_FLAG_FILL` sizes the last partition to the disk end.
  Resolved on internal copies, so the caller's list is never mutated.
- **Empty list items** - a `ESP_EXT_PART_TYPE_NONE` item can't be encoded without
  leaving a gap that truncates the parsed table and misplaces auto-partitions, so it
  is now rejected (`ESP_ERR_INVALID_ARG`).
- **Alignment ergonomics** - `ESP_EXT_PART_ALIGN_AUTO` (default -> 1 MiB) and
  `ESP_EXT_PART_ALIGN_NONE` make "default" and "no alignment" explicit;
  `esp_mbr_lba_align` now handles any alignment/sector-size ratio (not just powers of
  two).

## MBR parsing & partition selection

- **All recognized partitions are parsed** - the old binary "supported/unsupported"
  drop behavior is gone. exFAT/NTFS, Linux and GPT-protective partitions are no
  longer silently dropped; only truly unknown/extended type codes are skipped.
- **New type `ESP_EXT_PART_TYPE_RAW_DATA` (0xDA)** for non-filesystem/custom-data
  partitions the application manages itself.
- **Predicate-based selection** - `esp_ext_part_match_t { fn; ctx; }` bundles a
  caller predicate with its context. `esp_ext_part_list_next_matching()` iterates the
  items a predicate accepts, and `esp_mbr_parse_extra_args_t.match` filters at parse
  time (a zero-initialized `match` inserts everything). Mountability depends on which
  filesystem drivers are linked into the firmware, so it is a caller decision rather
  than a fixed library classification.
- **Stock matcher** - `esp_ext_part_match_mountable()` returns a ready-to-use matcher:
  FAT12/16/32 are always mountable; LittleFS is mountable when its component is part
  of the build (auto-detected in CMake, or forced via `ESP_EXT_PART_HAS_LITTLEFS`),
  otherwise reported not-mountable (a safe under-report).
- **`ESP_EXT_PART_LIST_FLAG_LOSSY`** is set when any partition is skipped (unknown/
  extended type, or rejected by the parse `match` predicate), signaling that a
  regenerated MBR would not be functionally equivalent to the source.

## Other

- Reordered `esp_mbr_generate_extra_args_t` to minimize padding; a zero-initialized
  struct still selects all defaults.
- Fixed enum portability and a potential LBA overflow at the top of the address space.
- Upgraded the basic example to showcase auto-placement, `FILL`, the `0xDA` type,
  the mountable matcher, and the `LOSSY` flag.
- Minor example/README/license fixes.

Covered by host-side unit tests (linux target). Version bumped to 0.4.0.

**ABI note (pre-1.0):** `esp_mbr_generate_extra_args_t` and
`esp_mbr_parse_extra_args_t` changed shape; source-compatible via designated
initializers. Behavior change: `esp_mbr_parse` now returns exFAT/NTFS, Linux and
GPT-protective partitions as list items instead of dropping them - filter with a
predicate via `esp_mbr_parse_extra_args_t.match` /
`esp_ext_part_list_next_matching()` (e.g. `esp_ext_part_match_mountable()`).

# Checklist

- [x] CI passing