### PR TITLE
fix(esp_cli): register VFS with context-pointer flag in test app

### DIFF
--- a/esp_cli/test_apps/main/test_esp_cli.c
+++ b/esp_cli/test_apps/main/test_esp_cli.c
@@ -18,6 +18,7 @@
 #include "esp_cli_commands.h"
 
 #include "sdkconfig.h"
+#include "esp_idf_version.h"
 #include "esp_vfs.h"
 #include "esp_vfs_common.h"
 #include "driver/esp_private/uart_vfs.h"
@@ -26,6 +27,15 @@
 #include "driver/esp_private/usb_serial_jtag_vfs.h"
 #include "driver/usb_serial_jtag_vfs.h"
 #include "driver/usb_serial_jtag.h"
+
+/* Since IDF v6.0 the tables returned by esp_vfs_uart_get_vfs() and
+ * esp_vfs_usb_serial_jtag_get_vfs() hold context-pointer function variants,
+ * so they must be registered with ESP_VFS_FLAG_CONTEXT_PTR. */
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#define TEST_VFS_REGISTER_FLAGS ESP_VFS_FLAG_CONTEXT_PTR
+#else
+#define TEST_VFS_REGISTER_FLAGS 0
+#endif
 
 static size_t s_on_enter_nb_of_calls = 0;
 static size_t s_pre_executor_nb_of_calls = 0;
@@ -130,7 +140,7 @@ static void test_uart_install(int *in_fd, int *out_fd)
 
     /* register the vfs, create a FD used to interface the UART */
     const esp_vfs_fs_ops_t *uart_vfs = esp_vfs_uart_get_vfs();
-    TEST_ASSERT_EQUAL(ESP_OK, esp_vfs_register_fs("/dev/test_uart", uart_vfs, 0, NULL));
+    TEST_ASSERT_EQUAL(ESP_OK, esp_vfs_register_fs("/dev/test_uart", uart_vfs, TEST_VFS_REGISTER_FLAGS, NULL));
     /* open in blocking mode */
     const int uart_fd = open("/dev/test_uart/0", 0);
     TEST_ASSERT(uart_fd != -1);
@@ -165,7 +175,7 @@ static void test_usj_install(int *in_fd, int *out_fd)
 
     /* register the vfs, create a FD used to interface the USJ */
     const esp_vfs_fs_ops_t *usj_vfs = esp_vfs_usb_serial_jtag_get_vfs();
-    TEST_ASSERT_EQUAL(ESP_OK, esp_vfs_register_fs("/dev/test_usj", usj_vfs, 0, NULL));
+    TEST_ASSERT_EQUAL(ESP_OK, esp_vfs_register_fs("/dev/test_usj", usj_vfs, TEST_VFS_REGISTER_FLAGS, NULL));
     /* open in blocking mode */
     const int usj_fd = open("/dev/test_usj/0", 0);
     TEST_ASSERT(usj_fd != -1);


### PR DESCRIPTION

Since IDF v6.0 (backported to release/v6.0 in ece7bf6af6c), the ops tables returned by esp_vfs_uart_get_vfs() and esp_vfs_usb_serial_jtag_get_vfs() hold context-pointer function variants. Registering them without ESP_VFS_FLAG_CONTEXT_PTR makes the VFS layer call them through the context-less union member, shifting all arguments: uart_open() then receives the open() flags (0) as its path and crashes in ROM strcmp() with a LoadProhibited panic on NULL.

Register with ESP_VFS_FLAG_CONTEXT_PTR on IDF v6.0+ and keep the context-less registration on older versions, which still return context-less ops tables.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
