### PR TITLE
适配 idf.py v6 对扩展的要求 (IEC-557)

### DIFF
--- a/unit-test-app/examples/unit-test-app/idf_ext.py
+++ b/unit-test-app/examples/unit-test-app/idf_ext.py
@@ -185,6 +185,7 @@ def action_extensions(base_actions, project_path=os.getcwd()):
 
     # Add global options
     extensions = {
+        'version': '1.0',
         'global_options': [{
             'names': ['-T', '--test-components'],
             'help': 'Specify the components to test.',


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] CI passing

# Change description
当前针对 idf.py 进行的 extension 扩展对 idf v5.x 是合适的, 但升级到 v6 后要求存在 version 的字段, 添加这个做了兼容.

有部分组件代码还是使用 unit-test-app 的机制编写的测试, 还需要这个能力在 idf v6 能够运行进行过渡.