### PR TITLE
feat: Macronix Flash memory support (updated PR) (IEC-558)

### DIFF
--- a/spi_nand_flash/CHANGELOG.md
+++ b/spi_nand_flash/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Versioning policy: see [VERSIONING.md](VERSIONING.md). From **v1.0.0** onward this component follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0]
+- feat: added support for Macronix MX35LF2GE4AD, MX35LF4GE4AD NAND flash
+
 ## [1.2.0]
 - feat: added support for Gigadevice GD5F4GM7UExxG NAND flash
 

--- a/spi_nand_flash/CMakeLists.txt
+++ b/spi_nand_flash/CMakeLists.txt
@@ -27,6 +27,7 @@ else()
                      "src/devices/nand_zetta.c"
                      "src/devices/nand_xtx.c"
                      "src/devices/nand_fm.c"
+                     "src/devices/nand_macronix.c"
                      "src/nand_impl.c"
                      "src/nand_diag_api.c"
                      "src/spi_nand_flash_test_helpers.c"

--- a/spi_nand_flash/README.md
+++ b/spi_nand_flash/README.md
@@ -73,6 +73,7 @@ At present, `spi_nand_flash` component is compatible with the chips produced by 
 * Zetta - ZD35Q1GC
 * XTX - XT26G08D
 * Fudan Microelectronics (FMSH) - FM25S005BI3
+* Macronix - MX35LF2GE4AD, MX35LF4GE4AD
 
 **GigaDevice voltage classes:** Parts ending in **UExxG** are rated for 2.7–3.6 V and are suitable for typical ESP32 3.3 V SPI designs. Parts ending in **RExxG** are rated for 1.7–2.0 V and are not recommended for direct connection to 3.3 V ESP GPIO/SPI without level shifting and a 1.8 V supply. Some `RExx` variants remain in the driver from earlier releases for backward compatibility; new additions target the 3.3 V `UExx` parts only (for example, **GD5F4GM7UExxG**, not GD5F4GM7RExxG).
 

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.2.0"
+version: "1.3.0"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/layered_architecture.md
+++ b/spi_nand_flash/layered_architecture.md
@@ -284,7 +284,8 @@ src/
     ├── nand_alliance.c         # Alliance NAND flash support
     ├── nand_micron.c           # Micron NAND flash support
     ├── nand_zetta.c            # Zetta NAND flash support
-    └── nand_xtx.c              # XTX NAND flash support
+    ├── nand_xtx.c              # XTX NAND flash support
+    └── nand_macronix.c         # Macronix NAND flash support
 ```
 
 ## API Usage
@@ -724,6 +725,7 @@ else()
                      "src/devices/nand_micron.c"
                      "src/devices/nand_zetta.c"
                      "src/devices/nand_xtx.c"
+                     "src/devices/nand_macronix.c"
                      "src/nand_impl.c"
                      "src/nand_diag_api.c"
                      "src/spi_nand_flash_test_helpers.c"
@@ -743,6 +745,7 @@ The component supports NAND flash chips from multiple manufacturers:
 | Micron | `src/devices/nand_micron.c` | MT29F1G01 |
 | Zetta | `src/devices/nand_zetta.c` | ZD35Q1GA |
 | XTX | `src/devices/nand_xtx.c` | XT26G01C |
+| Macronix | `src/devices/nand_macronix.c` | MX35LF2GE4AD, MX35LF4GE4AD |
 
 Device detection is automatic based on JEDEC manufacturer and device IDs.
 

--- a/spi_nand_flash/priv_include/nand_flash_devices.h
+++ b/spi_nand_flash/priv_include/nand_flash_devices.h
@@ -25,6 +25,7 @@ extern "C" {
 #define SPI_NAND_FLASH_ZETTA_MI       0xBA
 #define SPI_NAND_FLASH_XTX_MI         0x0B
 #define SPI_NAND_FLASH_FM_MI          0xA1  // Fudan Microelectronics
+#define SPI_NAND_FLASH_MACRONIX_MI    0xC2
 
 //=============================================================================
 // DEVICE IDs
@@ -84,6 +85,10 @@ extern "C" {
 // Fudan Microelectronics
 #define FM_DI_D5                      0xD5
 
+// Macronix
+#define MACRONIX_DI_26                0x26   //MX35LF2GE4AD (2Gb)
+#define MACRONIX_DI_37                0x37   //MX35LF4GE4AD (4Gb)
+
 //=============================================================================
 // DEVICE INITIALIZATION FUNCTIONS
 //=============================================================================
@@ -122,6 +127,11 @@ esp_err_t spi_nand_xtx_init(spi_nand_flash_device_t *dev);
  * @brief Initialize Fudan Microelectronics NAND flash
  */
 esp_err_t spi_nand_fm_init(spi_nand_flash_device_t *dev);
+
+/**
+ * @brief Initialize Macronix NAND flash
+ */
+esp_err_t spi_nand_macronix_init(spi_nand_flash_device_t *dev);
 
 #ifdef __cplusplus
 }

--- a/spi_nand_flash/src/devices/nand_macronix.c
+++ b/spi_nand_flash/src/devices/nand_macronix.c
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include "esp_check.h"
+#include "nand.h"
+#include "spi_nand_oper.h"
+#include "nand_flash_devices.h"
+
+static const char *TAG = "nand_macronix";
+
+esp_err_t spi_nand_macronix_init(spi_nand_flash_device_t *dev)
+{
+    esp_err_t ret = ESP_OK;
+    uint8_t device_id = 0;
+    ESP_RETURN_ON_ERROR(spi_nand_read_device_id(dev, &device_id, sizeof(device_id)), TAG, "%s, Failed to get the device ID %d", __func__, ret);
+    dev->device_info.device_id = device_id;
+    snprintf(dev->device_info.chip_name, sizeof(dev->device_info.chip_name),
+             "macronix-0x%02" PRIx8, device_id);
+    ESP_LOGD(TAG, "%s: device_id: %x\n", __func__, device_id);
+
+
+    dev->chip.has_quad_enable_bit = 1;
+    dev->chip.quad_enable_bit_pos = 0;
+    switch (device_id) {
+    case MACRONIX_DI_26: // MX35LF2GE4AD (2Gb)
+        dev->chip.num_blocks = 2048;
+        dev->chip.log2_page_size = 11;  // 2048 bytes
+        dev->chip.log2_ppb = 6;         // 64 pages per block
+        dev->chip.read_page_delay_us = 10;
+        dev->chip.erase_block_delay_us = 6000;
+        dev->chip.program_page_delay_us = 400;
+        break;
+    case MACRONIX_DI_37: // MX35LF4GE4AD (4Gb)
+        dev->chip.num_blocks = 2048;
+        dev->chip.log2_page_size = 12;  // 4096 bytes
+        dev->chip.log2_ppb = 6;         // 64 pages per block
+        dev->chip.read_page_delay_us = 12;
+        dev->chip.erase_block_delay_us = 6000;
+        dev->chip.program_page_delay_us = 440;
+        break;
+    default:
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+    return ESP_OK;
+}

--- a/spi_nand_flash/src/nand_impl.c
+++ b/spi_nand_flash/src/nand_impl.c
@@ -41,6 +41,8 @@ static esp_err_t detect_chip(spi_nand_flash_device_t *dev)
         return spi_nand_xtx_init(dev);
     case SPI_NAND_FLASH_FM_MI: // FM
         return spi_nand_fm_init(dev);
+    case SPI_NAND_FLASH_MACRONIX_MI: // Macronix
+        return spi_nand_macronix_init(dev);
     default:
         return ESP_ERR_INVALID_RESPONSE;
     }


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
Adds support for Macronix FLASH memory. Tested with ESP-C6-MINI-N4 and MX35LF2GE4AD.

Replaces #713 (due to internal org build backwards compatibility reasons we had to create a new branch).