### PR TITLE
fix(esp_schedule): correct date engine and timer overflow (IEC-563)

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -44,6 +44,11 @@ esp_schedule/examples/get_started:
     - if: ((IDF_VERSION_MAJOR == 5 and IDF_VERSION_MINOR >= 1) or (IDF_VERSION_MAJOR > 5)) and SOC_WIFI_SUPPORTED == 1
       reason: Network provisioning component has dependencies IDF >= 5.1; example only supports Wi-Fi enabled targets
 
+esp_schedule/test_app:
+  disable:
+    - if: IDF_VERSION_MAJOR < 5
+      reason: Example relies on WHOLE_ARCHIVE component property which was introduced in IDF v5.0
+
 catch2/examples/catch2-test:
   enable:
     - if: INCLUDE_DEFAULT == 1 or IDF_TARGET == "linux"

--- a/esp_schedule/README.md
+++ b/esp_schedule/README.md
@@ -26,3 +26,139 @@ See the comprehensive example in [`examples/get_started/`](examples/get_started/
 - **Schedule Management** - Create, edit, enable, and disable schedules
 
 The example includes detailed documentation, build instructions, and demonstrates all schedule types with practical use cases.
+
+## Trigger Usage
+
+> **Full specification:** see [`docs/trigger_rules.md`](docs/trigger_rules.md) for the date engine's exact behavior, the day-match / one-shot rules, DST handling, and a comprehensive scenario table for every field combination.
+
+**Each trigger type reads only the fields it owns.** Setting a field the type does not read is a configuration error, not an ignored value: `esp_schedule_create()` returns `NULL` and `esp_schedule_edit()` returns `ESP_ERR_INVALID_ARG`, with the offending field logged. See §4.7 of [`docs/trigger_rules.md`](docs/trigger_rules.md) for the full rule list.
+
+| Type | Time of day | Day selection |
+|------|-------------|---------------|
+| `DAYS_OF_WEEK` | `hours`:`minutes` | `day.repeat_days` only |
+| `DATE` | `hours`:`minutes` | `date.*` only — no weekday mask |
+| `SUNRISE` / `SUNSET` | sunrise/sunset + `solar.offset_minutes` | `day.repeat_days` **or** `date.*`, never both |
+| `RELATIVE` | `relative_seconds` | — |
+
+### Day-of-week triggers (ESP_SCHEDULE_TYPE_DAYS_OF_WEEK)
+
+```c
+// 05:00 every Monday and Wednesday
+esp_schedule_trigger_t t0 = {
+    .type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK,
+    .hours = 5, .minutes = 0,
+};
+t0.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY | ESP_SCHEDULE_DAY_WEDNESDAY;
+
+// 05:00 daily
+esp_schedule_trigger_t t1 = {
+    .type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK,
+    .hours = 5, .minutes = 0,
+};
+t1.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+
+// (one-shot) 05:00 at the next occurrence of that time, then done
+esp_schedule_trigger_t t2 = {
+    .type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK,
+    .hours = 5, .minutes = 0,
+};
+t2.day.repeat_days = ESP_SCHEDULE_DAY_ONCE;
+```
+
+### Date-based triggers (ESP_SCHEDULE_TYPE_DATE)
+
+Date-based triggers express calendar patterns using:
+
+- **Time of day**: `hours` and `minutes` (24-hour format)
+- **Day-of-month**: `date.day` (1–31)
+- **Months-of-year mask**: `date.repeat_months` using `esp_schedule_months_t`
+- **Specific year**: `date.year` (4-digit), **or** `date.repeat_every_year` — not both
+
+`date.repeat_months` is what makes a date trigger recur — **without a months mask the trigger fires exactly once**, whatever `date.year` says. With a mask, `date.year` / `date.repeat_every_year` decide how far it recurs:
+
+| `date.year` | `date.repeat_every_year` | Recurs until |
+|-------------|--------------------------|--------------|
+| `0` | `true` | never ends |
+| `N` | `false` | end of year `N` |
+| `0` | `false` | end of the **current** year — re-resolved on every arm, so a reboot in the next calendar year starts it again for that year |
+
+```c
+// 19:30 on the 20th of every month, forever
+esp_schedule_trigger_t t3 = {
+    .type = ESP_SCHEDULE_TYPE_DATE,
+    .hours = 19, .minutes = 30,
+};
+t3.date.day = 20;                                  // 20th
+t3.date.repeat_months = ESP_SCHEDULE_MONTH_ALL;    // every month
+t3.date.repeat_every_year = true;                  // <-- recurs over those months
+
+// 14:03 on the 14th of Jan..Apr, every year
+esp_schedule_trigger_t t4 = {
+    .type = ESP_SCHEDULE_TYPE_DATE,
+    .hours = 14, .minutes = 3,
+};
+t4.date.day = 14;
+t4.date.repeat_months = ESP_SCHEDULE_MONTH_JANUARY | ESP_SCHEDULE_MONTH_FEBRUARY |
+                        ESP_SCHEDULE_MONTH_MARCH | ESP_SCHEDULE_MONTH_APRIL;
+t4.date.repeat_every_year = true;
+
+// 07:00 on the 15th of Jun and Jul 2026, then the schedule expires
+esp_schedule_trigger_t t5 = {
+    .type = ESP_SCHEDULE_TYPE_DATE,
+    .hours = 7, .minutes = 0,
+};
+t5.date.day = 15;
+t5.date.repeat_months = ESP_SCHEDULE_MONTH_JUNE | ESP_SCHEDULE_MONTH_JULY;
+t5.date.year = 2026;              // bounds it to 2026 (do not also set repeat_every_year)
+
+// (one-shot) 00:00 on the next 9 August, in 2035
+esp_schedule_trigger_t t6 = {
+    .type = ESP_SCHEDULE_TYPE_DATE,
+    .hours = 0, .minutes = 0,
+};
+t6.date.day = 9;
+t6.date.repeat_months = ESP_SCHEDULE_MONTH_AUGUST;
+t6.date.year = 2035;
+```
+
+Rejected on purpose: a weekday mask on a `DATE` trigger, `date.repeat_months` without `date.day`, `date.year` together with `date.repeat_every_year`, and `date.repeat_every_year` without a months mask.
+
+> Tip: Prefer using the `esp_schedule_days_t` and `esp_schedule_months_t` constants instead of raw bit values. This keeps code readable and portable.
+
+### Solar triggers
+
+Solar triggers (`ESP_SCHEDULE_TYPE_SUNRISE` / `ESP_SCHEDULE_TYPE_SUNSET`) reuse the day selection above — either a weekday mask **or** a date pattern, never both — and replace the time of day with the computed sunrise/sunset instant:
+
+- Provide `solar.latitude`, `solar.longitude`, and an optional `solar.offset_minutes` to shift from the exact sunrise/sunset time.
+
+```c
+// Sunset every single day, at the exact sunset time.
+esp_schedule_trigger_t s0 = { .type = ESP_SCHEDULE_TYPE_SUNSET };
+s0.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;  // <-- the weekday arm repeats forever
+s0.solar.latitude = 37.7749;
+s0.solar.longitude = -122.4194;
+s0.solar.offset_minutes = 0;      // exactly at sunset
+
+// Sunrise every Monday and Wednesday, 15 minutes before the event
+esp_schedule_trigger_t s1 = { .type = ESP_SCHEDULE_TYPE_SUNRISE };
+s1.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY | ESP_SCHEDULE_DAY_WEDNESDAY;
+s1.solar.latitude = 37.7749;
+s1.solar.longitude = -122.4194;
+s1.solar.offset_minutes = -15;
+
+// Sunset on the 15th of Feb and Nov, every year, 10 minutes after the event
+esp_schedule_trigger_t s2 = { .type = ESP_SCHEDULE_TYPE_SUNSET };
+s2.date.day = 15;          // date arm, so no day.repeat_days
+s2.date.repeat_months = ESP_SCHEDULE_MONTH_FEBRUARY | ESP_SCHEDULE_MONTH_NOVEMBER;
+s2.date.repeat_every_year = true;
+s2.solar.latitude = 52.5200;
+s2.solar.longitude = 13.4050;
+s2.solar.offset_minutes = 10;
+
+// (one-shot) the next sunrise, then done
+esp_schedule_trigger_t s3 = { .type = ESP_SCHEDULE_TYPE_SUNRISE };
+s3.solar.latitude = 37.7749;
+s3.solar.longitude = -122.4194;
+```
+
+The day is selected first, then the actual sunrise/sunset instant for that day is computed for your location. Days with no solar event (polar night/day) are skipped.

--- a/esp_schedule/docs/trigger_rules.md
+++ b/esp_schedule/docs/trigger_rules.md
@@ -1,0 +1,425 @@
+# ESP Schedule — Date Engine & Trigger Rules
+
+This document explains, in detail, how `esp_schedule` decides *when* a trigger
+fires. It covers:
+
+1. The core date engine (`esp_schedule_get_next_date_time`).
+2. How each public trigger type feeds the engine.
+3. The "fired-and-done" one-shot rule that decides whether a trigger repeats.
+4. A comprehensive table of scenarios showing exactly what each field
+   combination does, including the combinations that are **rejected**.
+5. The footguns worth knowing before writing a trigger.
+
+The scenario tables in §4 carry a **Unit test** column naming the case in
+`test_app/main/test_esp_schedule.c` that verifies each row; `N/A` marks behavior
+that follows from the same engine logic but is not yet covered by a dedicated
+test. All cases run on target through `test_app/pytest_esp_schedule.py`.
+
+Every scenario row also carries a stable **ID** for quick reference in reviews,
+bug reports, and test names:
+
+| ID prefix | Section | Covers                                                  |
+|-----------|---------|---------------------------------------------------------|
+| `DOW-n`   | §4.1    | `TYPE_DAYS_OF_WEEK` scenarios                           |
+| `DATE-n`  | §4.2    | date-arm scenarios — `TYPE_DATE`, and solar's date arm   |
+| `SOL-n`   | §4.3    | solar-specific scenarios (`TYPE_SUNRISE` / `TYPE_SUNSET`)|
+| `REC-n`   | §4.4    | Common recipes                                          |
+| `REL-n`   | §4.5    | `TYPE_RELATIVE` scenarios                               |
+| `VAL-n`   | §4.6    | Validity-window scenarios (all types)                   |
+| `V1`..`V7`| §4.7    | Rejected configurations (validation rules)              |
+
+---
+
+## 1. The core date engine
+
+Every non-relative trigger ultimately calls one function:
+
+```c
+bool esp_schedule_get_next_date_time(time_t now,
+                                     uint16_t minutes_since_midnight,
+                                     uint8_t  days_of_week_mask,   // Mon=bit0 .. Sun=bit6
+                                     uint8_t  day_of_month,        // 1..31
+                                     uint16_t months_of_year_mask, // Jan=bit0 .. Dec=bit11
+                                     uint16_t year,                // 4-digit, e.g. 2026
+                                     const esp_schedule_validity_t *validity,
+                                     time_t *next_time);
+```
+
+It returns the **next instant at or after `now`** whose local wall-clock date
+matches every constraint, at the requested time of day. Each of the four date
+fields uses `0` as a wildcard meaning **"any"**.
+
+### 1.1 Field wildcard semantics
+
+| Field                 | `0` means         | non-zero means                          |
+|-----------------------|-------------------|-----------------------------------------|
+| `days_of_week_mask`   | any weekday       | day-of-week must be in the mask         |
+| `day_of_month`        | any day           | `tm_mday` must equal this value          |
+| `months_of_year_mask` | any month         | month must be in the mask               |
+| `year`                | any year          | bounded to exactly this year            |
+
+The engine matches a day if *either* day arm matches (`days_of_week_mask` OR
+`day_of_month`). No trigger can reach that union: validation (§4.7, rule `V2`)
+rejects a configuration that sets both arms, so exactly one of the two is ever
+non-zero. The union is engine-internal and is covered only by engine-level tests.
+
+### 1.2 What it does (broad steps)
+
+1. **Anchor the search.** Start from `now`; if the validity window opens in the
+   future, jump the origin to `start_time` instead.
+2. **Skip today if the time already passed.** If today's `HH:MM` is behind us,
+   the earliest candidate is tomorrow (unless a future window forces today).
+3. **Honor the year.** A year already in the past → no match. A future year →
+   jump forward to Jan 1 of that year.
+4. **Walk forward, month by month then day by day.** Skip whole months not in
+   the months mask; within a month, test each day against the day-match rule
+   (§1.1).
+5. **First matching day wins.** Build the exact instant at `HH:MM`
+   (DST-resolved), check it against the year bound and the validity window, and
+   return it. If it falls before the window start, keep searching.
+6. **Give up** if nothing matches within the search horizon.
+   Months outside the mask do not count against it, so the horizon covers the
+   worst satisfiable case, `Feb 29` across the 8-year leap gap (e.g., 2096 -> 2104).
+   That worst case is asserted by `date feb29 non leap` (64-bit `time_t` only).
+
+### 1.3 Why it is built this way (implementation notes)
+
+- **Day advance uses `tm_mday++` + `mktime`, never `+86400s`.** Adding a fixed
+  86400 seconds across a DST transition skips or repeats a day. Re-normalizing
+  the broken-down time is DST-safe.
+- **`tm_isdst = -1` before every `mktime`.** This lets libc resolve the correct
+  UTC instant for a local wall-clock time. No manual `±3600` correction is
+  applied (doing so would double-correct).
+- **Validity-start jump (§1.2 step 1).** Without it, a far-future `start_time`
+  would exhaust the month-attempt budget before ever reaching the window, and the
+  schedule would silently never fire.
+- **Day-31 / Feb-29 safety.** Because each candidate is normalized by `mktime`,
+  a `day_of_month = 31` in a 30-day month never matches a normalized "1st of
+  next month"; it lands on the next month that actually *has* a 31st. `Feb 29`
+  correctly skips non-leap years to the next leap year.
+
+### 1.4 DST wall-clock behavior
+
+Schedules fire on **local wall-clock** time (compliant with [RainMaker specification](https://legacy.rainmaker.espressif.com/docs/scheduling/#managing-daylight-saving-time-dst)):
+
+- **Spring forward:** a local time that does not exist (e.g. `02:30` when clocks
+  jump `02:00 -> 03:00`) is delayed and fires at `03:30` on the switch day — it
+  does **not** skip to the next day.
+- **Fall back:** a local time that occurs twice (e.g. `01:30`) fires **once**
+  (the first occurrence) and then advances a full day; it does not fire again at
+  the repeated hour.
+
+---
+
+## 2. How each trigger type feeds the engine
+
+**Each type reads only the fields it owns.** A field the type does not read is
+not silently ignored — the configuration is rejected (§4.7). There is no encoding
+for "field not set", so an all-zero date arm is the *wildcard*, not "absent".
+
+| Trigger type            | Time of day             | Day selection                                   | Ignored          |
+|-------------------------|-------------------------|-------------------------------------------------|------------------|
+| `DAYS_OF_WEEK`          | `hours`:`minutes`       | `day.repeat_days`                                | `solar.*`        |
+| `DATE`                  | `hours`:`minutes`       | `date.*`                                         | `solar.*`        |
+| `SUNRISE` / `SUNSET`    | solar event + `solar.offset_minutes` | `day.repeat_days` **xor** `date.*` (§2.1) | `hours`, `minutes` |
+| `RELATIVE`              | `relative_seconds` from the base time | — (engine not used)                | all date fields, `solar.*` |
+
+Values passed to the engine:
+
+| Trigger type            | `dow_mask`         | `day_of_month`   | `months_mask`         | `year`         |
+|-------------------------|--------------------|------------------|-----------------------|----------------|
+| `DAYS_OF_WEEK`          | `day.repeat_days`  | `0`              | `0`                   | `0`            |
+| `DATE`                  | `0`                | `date.day`       | `date.repeat_months`  | `date.year`    |
+| `SUNRISE` / `SUNSET`    | `day.repeat_days`  | `date.day`       | `date.repeat_months`  | `date.year`    |
+
+`date.year` is passed straight through: rule `V5` guarantees it is already `0`
+whenever `date.repeat_every_year` is set, so `repeat_every_year` never needs to
+mask it out.
+
+### 2.1 Solar picks one day arm
+
+`SUNRISE` / `SUNSET` select their day arm from whichever is populated:
+
+| `day.repeat_days` | any of `date.day` / `repeat_months` / `year` / `repeat_every_year` | Arm         | Outcome                    |
+|-------------------|---------------------------------------------------------------------|-------------|----------------------------|
+| `> 0`             | none                                                                | day-of-week | `SOL-0` — forever          |
+| `0`               | some                                                                | date        | the `DATE-n` rows of §4.2  |
+| `> 0`             | some                                                                | —           | **rejected** (rule `V2`)   |
+| `0`               | none                                                                | date, all wildcard | `DATE-0`            |
+
+The two arms are never unioned and never intersected. "Weekdays in June" is not
+expressible; the nearest option is two separate schedules, or a wider `dow`
+schedule bounded by `validity`.
+
+> ### Solar = a date/weekday pattern with a solar time-of-day
+>
+> Apart from the day-of-week arm above, solar day selection and lifetime rules are
+> **identical to `DATE`**. The only difference is the time of day: instead of
+> `hours:minutes`, the fire instant is the computed sunrise/sunset for the
+> selected day, shifted by `solar.offset_minutes`. Every `DATE-n` row in §4.2
+> therefore applies to solar with "at `HH:MM`" replaced by "at sunrise/sunset ±
+> offset".
+
+> ### `DATE` has no weekday arm
+>
+> `ESP_SCHEDULE_TYPE_DATE` reads `date.*` only. Setting `day.repeat_days` on a
+> `DATE` trigger is a configuration error (rule `V2`), not an additional filter.
+> For a weekday pattern use `ESP_SCHEDULE_TYPE_DAYS_OF_WEEK`; for a weekday
+> pattern at sunrise/sunset use a solar trigger with `day.repeat_days` and an
+> empty date arm (`SOL-0`).
+
+---
+
+## 3. The one-shot "fired-and-done" rule
+
+After a trigger fires (its `next_scheduled_time_utc` is in the past), the code
+asks `esp_schedule_trigger_fired_and_done()` whether to recompute a future
+occurrence or leave it dead. This is what separates "fire once" from "repeat".
+
+| Type            | Repeats when…                                                                    |
+|-----------------|----------------------------------------------------------------------------------|
+| `RELATIVE`      | never — fires exactly once                                                        |
+| `DAYS_OF_WEEK`  | `repeat_days != ESP_SCHEDULE_DAY_ONCE` (i.e. any weekday bit set)                  |
+| `SUNRISE`, `SUNSET` | `day.repeat_days != 0` (the day-of-week arm), else the date-arm rule below     |
+| `DATE`, solar date arm | `repeat_months != 0` — how far it recurs then depends on `year` / `repeat_every_year` (§3.1) |
+
+> ### `repeat_months` gates all date-arm recurrence
+>
+> A recurrence must name what it recurs *over*, and for the date arm that is the
+> month set. With `repeat_months == 0` there is nothing to iterate and the trigger
+> fires exactly once, whatever `year` says. This is why:
+>
+> - `repeat_every_year` with **no** month mask is rejected outright (rule `V6`) —
+>   it would be inert. Write it as `repeat_months = ESP_SCHEDULE_MONTH_ALL`.
+> - `year` with no month mask is **valid but one-shot** (`DATE-2`): unlike
+>   `repeat_every_year`, `year` still constrains *when* the single fire happens.
+> - a non-zero `repeat_months` always recurs, including with neither `year` nor
+>   `repeat_every_year` (`DATE-3`).
+
+### 3.1 How far a masked date arm recurs — the year constraint
+
+`repeat_months` says *that* the arm recurs; `year` / `repeat_every_year` say *how
+far*. The three spellings map to the `year` the arm passes to the engine:
+
+| `year` | `rep_yr` | Year passed to the engine | Ends                                | Shape    |
+|--------|----------|---------------------------|-------------------------------------|----------|
+| `0`    | `true`   | `0` — unconstrained       | never                               | `DATE-4` |
+| `N`    | `false`  | `N`                       | after the last masked month of `N`  | `DATE-5` |
+| `0`    | `false`  | **the current year**      | after the last masked month of the current year | `DATE-3` |
+
+In every case the end is enforced by the engine, not by a separate expiry check:
+once the bound year is exhausted there is no further match, and the arm path
+disarms and deletes the schedule.
+
+> **`DATE-3`'s bound is not persistent.** With `year = 0` nothing is stored, so
+> the bound is re-resolved from the current time on every arm. A device that
+> reboots in a later calendar year re-bounds the schedule to *that* year and fires
+> it again. Use `year = N` when the end date must survive a reboot, or
+> `repeat_every_year` when it should never end.
+
+---
+
+## 4. Comprehensive scenario tables
+
+`HH:MM` = the configured time of day. "Now" is arbitrary unless stated.
+`dow` = `day.repeat_days`, `day` = `date.day`, `months` = `date.repeat_months`,
+`year`/`rep_yr` = `date.year` / `date.repeat_every_year`.
+
+### 4.1 `ESP_SCHEDULE_TYPE_DAYS_OF_WEEK`
+
+Only `repeat_days` is read. Any `date.*` field set is rejected (rule `V1`).
+
+| ID      | `repeat_days`            | Lifetime | Behavior                                    | Unit test |
+|---------|--------------------------|----------|---------------------------------------------|-----------|
+| `DOW-0` | `DAY_ONCE` (`0`)         | one-shot | Fires **once** at the next `HH:MM` (today if not yet passed, else tomorrow), then done. | `one-shot fired and done`, `trigger validation truth table` |
+| `DOW-1` | `THURSDAY`               | forever  | Every Thursday at `HH:MM`.                  | `day of week`, `knife edge now equals target` |
+| `DOW-2` | `MONDAY \| WEDNESDAY`    | forever  | Every Mon **and** Wed at `HH:MM`.           | `sequence dow mon wed` |
+| `DOW-3` | `DAY_EVERYDAY` (`0x7F`)  | forever  | Daily at `HH:MM`. **This is the daily recipe.** | `dst daily across spring forward` |
+| `DOW-4` | any mask, `HH:MM` = non-existent local time (spring forward) | forever | Delayed within the switch day (`02:30` → `03:30`); no day skipped (§1.4). | `dst rainmaker spring forward delayed one hour`, `dst skipped local time` |
+| `DOW-5` | any mask, `HH:MM` = repeated local time (fall back) | forever | Fires **once** (first occurrence), then advances a full day (§1.4). | `dst rainmaker fall back fires once`, `dst daily across fall back` |
+| `DOW-6` | mask near midnight, next-day rollover | forever | Next matching weekday resolved correctly across a DST-affected midnight. | `dst next dow near midnight` |
+
+### 4.2 The date arm — `ESP_SCHEDULE_TYPE_DATE`, and solar's date arm
+
+`dow` is `0` throughout (a weekday mask here is rejected by `V2`). These six
+shapes are the **complete** set of accepted date-arm configurations; every other
+combination of the four date fields is rejected (§4.7).
+
+| ID       | `day` | `months`        | `year`/`rep_yr` | Lifetime           | Behavior                                                              | Unit test |
+|----------|-------|-----------------|-----------------|--------------------|-----------------------------------------------------------------------|-----------|
+| `DATE-0` | `0`   | `0`             | `0`/`false`     | one-shot           | All wildcards → fires **once** at the next `HH:MM`.                    | `one-shot fired and done`, `date wildcard and daily` |
+| `DATE-1` | `15`  | `0`             | `0`/`false`     | one-shot           | Fires **once** on the next 15th.                                       | `one-shot fired and done`, `date wildcard and daily` |
+| `DATE-2` | `15`  | `0`             | `2026`/`false`  | one-shot           | Fires **once**, on the next 15th **in 2026**. Dropped if 2026 is past.  | `one-shot fired and done`, `date one shot vs recurring month mask` |
+| `DATE-3` | `15`  | `Jun\|Jul`      | `0`/`false`     | expires after the current year | 15th of each masked month **of the current year**, then dead. ⚠️ The bound is re-resolved on every arm, so it is not reboot-safe (§3.1). | `date months mask year scoping`, `one-shot fired and done` |
+| `DATE-4` | `15`  | `Jun\|Jul`      | `0`/`true`      | forever            | 15th of each masked month, **every year**. With `months = MONTH_ALL`, "the 15th of every month". | `date months mask recurs over month set` |
+| `DATE-5` | `15`  | `Jun\|Jul`      | `2026`/`false`  | expires after 2026 | 15th of each masked month **in 2026**, then dead.                       | `date one shot vs recurring month mask`, `date months year bounded expires` |
+| `DATE-6` | `31`  | `Apr\|May`      | `0`/`true`      | forever            | Skips 30-day April's non-existent 31st → lands on **May 31**.            | `date permutations more` |
+| `DATE-7` | `29`  | `Feb`           | `0`/`true`      | forever            | **Feb 29 skips non-leap years** to the next leap Feb 29 (up to the 8-year gap, §1.2 step 6). | `date feb29 non leap` |
+| `DATE-8` | `1`   | `Nov\|Dec\|Jan` | `0`/`true`      | forever            | 1st of Nov/Dec/Jan, across the year boundary.                           | `date permutations more` |
+
+`DATE-6`..`DATE-8` are `DATE-4` with awkward day/month combinations; they are
+listed separately because the engine's day-normalization behavior is the point.
+
+`DATE-2` vs `DATE-5` is the pair that shows what `repeat_months` does: identical
+`day` and `year`, identical *first* fire, but one fire versus one fire per masked
+month. `date one shot vs recurring month mask` is the regression guard for it.
+`DATE-3` vs `DATE-4` vs `DATE-5` then differ only in how far that recurrence
+reaches (§3.1), which `date months mask year scoping` pins down.
+
+Patterns with no finite match — `day = 30` masked to February, `day = 31` masked
+to only 30-day months, `Feb 29` bounded to a non-leap `year` — exhaust the search
+horizon and never fire (`date no finite match`).
+
+### 4.3 `ESP_SCHEDULE_TYPE_SUNRISE` / `ESP_SCHEDULE_TYPE_SUNSET`
+
+Requires `CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT`. `off` = `solar.offset_minutes`;
+the fire instant is the solar event for the selected day, plus `off`.
+
+Solar's date arm is §4.2 verbatim, so only the solar-specific rows are listed
+here.
+
+| ID      | `dow`          | date arm | `off` | Lifetime | Behavior                                                                | Unit test |
+|---------|----------------|----------|-------|----------|-------------------------------------------------------------------------|-----------|
+| `SOL-0` | `Mon..Fri`     | empty    | `0`   | forever  | Solar event on every set weekday, indefinitely. **The weekday recipe.**   | `solar with dow`, `solar variants` |
+| `SOL-1` | `DAY_EVERYDAY` | empty    | `0`   | forever  | Solar event **every day**. Selects the same first day as `DATE-0`, but repeats. **The daily recipe.** | `solar variants` |
+| `SOL-2` | `EVERYDAY`     | empty    | `-30`/`+15` | forever | Fires 30 min before / 15 min after the solar event.                  | `solar variants` |
+| `SOL-3` | any            | any      | any   | as above | Polar night/day: days with **no solar event** are skipped, search advances up to ~370 days; no event in window → no schedule. | N/A (location-dependent) |
+| `SOL-4` | any repeating  | any      | any   | forever  | Consecutive fire instants stay strictly increasing as solar times drift day to day. | `solar sequence monotonic` |
+
+Solar-specific notes:
+- `offset_minutes` may be negative (before) or positive (after). Solar times are
+  computed in UTC; the calendar date is taken from the selected day's local date.
+- The day is selected by the same date engine (evaluated at 23:59 so selection is
+  date-only), then the actual sunrise/sunset instant for that day is computed.
+- `SUNRISE` vs `SUNSET` only changes which event is used; day selection is
+  identical.
+- A solar **weekday** pattern cannot be year-bounded (rule `V2` — `year` belongs
+  to the date arm). Use `validity.end_time` instead.
+
+### 4.4 Common recipes
+
+| ID      | Goal                                          | Type          | Fields                                                        | Shape    |
+|---------|-----------------------------------------------|---------------|---------------------------------------------------------------|----------|
+| `REC-0` | Once, at the next `HH:MM`                     | `DAYS_OF_WEEK`| `repeat_days = DAY_ONCE`                                       | `DOW-0`  |
+| `REC-1` | Daily at `HH:MM`                              | `DAYS_OF_WEEK`| `repeat_days = DAY_EVERYDAY`                                   | `DOW-3`  |
+| `REC-2` | Every Mon/Wed/Fri at `HH:MM`                  | `DAYS_OF_WEEK`| `repeat_days = MON\|WED\|FRI`                                   | `DOW-2`  |
+| `REC-3` | Once, on the next 15th                        | `DATE`        | `day = 15`                                                     | `DATE-1` |
+| `REC-4` | Once, on the next 15th in 2026                | `DATE`        | `day = 15`, `year = 2026`                                      | `DATE-2` |
+| `REC-5` | 15th of every month, forever                  | `DATE`        | `day = 15`, `months = MONTH_ALL`, `rep_yr = true`                | `DATE-4` |
+| `REC-6` | 15th of Jun/Jul/Aug, every year               | `DATE`        | `day = 15`, `months = Jun\|Jul\|Aug`, `rep_yr = true`            | `DATE-4` |
+| `REC-7` | 15th of every month in 2026, then stop        | `DATE`        | `day = 15`, `months = MONTH_ALL`, `year = 2026`                  | `DATE-5` |
+| `REC-8` | Once, at the next sunrise                     | `SUNRISE`     | lat/lon/offset only                                             | `DATE-0` |
+| `REC-9` | Every day at sunrise                          | `SUNRISE`     | `repeat_days = DAY_EVERYDAY`                                    | `SOL-1`  |
+| `REC-10`| Weekdays, 30 min before sunset                | `SUNSET`      | `repeat_days = MON..FRI`, `offset_minutes = -30`                 | `SOL-0`  |
+| `REC-11`| Sunset on the 1st of every month              | `SUNSET`      | `day = 1`, `months = MONTH_ALL`, `rep_yr = true`                  | `DATE-4` |
+| `REC-12`| Sunrise on the 15th of Jun/Jul 2026, then stop| `SUNRISE`     | `day = 15`, `months = Jun\|Jul`, `year = 2026`                    | `DATE-5` |
+| `REC-13`| Once, N seconds from now                      | `RELATIVE`    | `relative_seconds = N`                                          | `REL-0`  |
+
+Not expressible by design, with the nearest alternative:
+
+| Not expressible                                        | Reason | Nearest                                    |
+|--------------------------------------------------------|--------|--------------------------------------------|
+| Every day of a month range                             | `V3`   | `DAYS_OF_WEEK` + `EVERYDAY` (not month-scoped) |
+| Weekday **union** a date pattern                       | `V2`   | two separate schedules                     |
+| Weekday **intersected** with a date pattern ("weekdays in June") | `V2` | none                              |
+| Masked months recurring with neither `year` nor `rep_yr`| `DATE-3` is one-shot | `DATE-4` (forever) or `DATE-5` (bounded) |
+| `rep_yr` without a month mask                          | `V6`   | add `months = MONTH_ALL` (`DATE-4`)        |
+| A solar weekday pattern bounded to one year            | `V2`   | `validity.end_time`                        |
+
+### 4.5 `ESP_SCHEDULE_TYPE_RELATIVE`
+
+`relative_seconds` from the base time (`now`, or `validity.start_time` if that is
+in the future). Fires exactly **once**. Not recomputed after firing. Date fields
+are ignored — the engine is not used, and no date field can invalidate the
+configuration. `relative_seconds` itself must be **> 0** (rule `V7`).
+
+| ID      | `relative_seconds` | `validity.start_time` | Lifetime | Behavior                                                    | Unit test |
+|---------|--------------------|-----------------------|----------|-------------------------------------------------------------|-----------|
+| `REL-0` | `N`                | `0` / past            | one-shot | Fires once at `now + N`, then done.                          | `one-shot fired and done` |
+| `REL-1` | `N`                | future                | one-shot | Base jumps to `start_time`; fires once at `start_time + N`.   | N/A |
+| `REL-2` | `N`                | `end_time < base + N` | expired  | Occurrence past `end_time` → no match, schedule expires (`VAL-1`). | N/A |
+| `REL-3` | `0` or negative    | any                   | —        | **Rejected** (`V7`): the target would be at or before the base time, so there is nothing to fire. | `trigger validation truth table`, `create and edit reject invalid config` |
+
+### 4.6 Validity window (`esp_schedule_validity_t`) — applies to all types
+
+| ID      | Situation                                   | Behavior                                                        | Unit test |
+|---------|---------------------------------------------|----------------------------------------------------------------|-----------|
+| `VAL-0` | `start_time` in the future                  | Search origin jumps to `start_time`; result is `>= start_time`. | `validity respected`, `validity start skips earlier match` |
+| `VAL-1` | Next occurrence would be after `end_time`   | Returns no match → schedule expires.                           | `sequence validity cutoff` |
+| `VAL-2` | Callback dispatch delayed past `end_time`   | Trigger is suppressed at fire time (re-check in the timer callback). | N/A (runtime timer path, not unit-testable without a live timer) |
+| `VAL-3` | `start_time == 0` / `end_time == 0` (or NULL) | That bound is disabled (open-ended).                        | `validity respected` |
+| `VAL-4` | First match falls before `start_time`       | Search continues past it instead of returning it (§1.2 step 5). | `validity start skips earlier match` |
+
+### 4.7 Rejected configurations
+
+A configuration that sets a field its type does not read, or that combines fields
+with no coherent reading, is **rejected** rather than partly ignored.
+`esp_schedule_create()` returns `NULL`, `esp_schedule_edit()` returns
+`ESP_ERR_INVALID_ARG`, and a configuration restored from NVS is deleted instead
+of armed. The offending field is logged.
+
+Rules are evaluated in order; the first match is the reported cause.
+
+| Rule | Condition                                                                          | Applies to | Why |
+|------|------------------------------------------------------------------------------------|------------|-----|
+| `V1` | any of `date.day`, `date.repeat_months`, `date.year`, `date.repeat_every_year` set  | `DAYS_OF_WEEK` | The type reads only `day.repeat_days`. |
+| `V2` | `day.repeat_days != 0`                                                             | `DATE` always; solar only when the date arm is also populated | The weekday and date arms are exclusive (§2.1). |
+| `V3` | `date.day == 0` and `repeat_months != 0`                                            | date arm | Would mean *every day* of the masked months — never an intended schedule. |
+| `V4` | `date.day == 0` and `repeat_months == 0` and (`year != 0` or `repeat_every_year`)    | date arm | A recurrence or a year bound with no date pattern to apply it to. |
+| `V5` | `year != 0` and `repeat_every_year`                                                 | date arm | Contradictory intent: "only year N" vs "every year". |
+| `V6` | `repeat_every_year` and `repeat_months == 0`                                         | date arm | `repeat_every_year` recurs over the month set (§3); with no mask it would be inert. |
+| `V7` | `relative_seconds <= 0`                                                             | `RELATIVE` | The target would be at or before the base time; the schedule could never fire. |
+
+Counting over `dow × day × months × year × rep_yr` with each field reduced to
+zero / non-zero — 32 combinations per type:
+
+| Type                 | Accepted        | Repeating, unbounded | Repeating, year-bounded |
+|----------------------|-----------------|----------------------|-------------------------|
+| `DAYS_OF_WEEK`       | 2 (`DOW-0`, `DOW-1`) | `DOW-1`          | —                       |
+| `DATE`               | 6 (`DATE-0`..`DATE-5`) | `DATE-4`       | `DATE-3` (current year), `DATE-5` (named year) |
+| `SUNRISE` / `SUNSET` | 7 (`DATE-0`..`DATE-5`, `SOL-0`) | `DATE-4`, `SOL-0` | `DATE-3`, `DATE-5` |
+| `RELATIVE`           | all 32 (no date field is read; `relative_seconds > 0` is the only requirement) | — | — |
+
+`DAYS_OF_WEEK` reaches only 2 because `V1` rejects all 30 combinations with any
+date field set. The full 32-combination table for every type is asserted by
+`trigger validation truth table`, and `create and edit reject invalid config`
+covers one rejected shape per rule through the public API.
+
+Range validation is separate and unchanged: `hours < 24 && minutes < 60`, checked
+by `create()` / `edit()` and by the engine itself
+(`minutes_since_midnight < 24*60`); `RELATIVE` reads neither field, so no range
+applies to it. `time of day range validation` covers all three paths. No range
+check is applied to `latitude` / `longitude` / `offset_minutes`; a zeroed-out
+solar config computes sunrise/sunset for 0°N 0°E, which is a valid location.
+
+---
+
+## 5. Footguns
+
+1. **`repeat_months` is what makes a date arm recur.** `day = 15` alone
+   (`DATE-1`) and `day = 15` with a `year` (`DATE-2`) fire exactly **once** — the
+   `year` narrows the single fire, it does not repeat it. For "the 15th of every
+   month" set `months = MONTH_ALL` *and* `rep_yr = true` (`DATE-4`).
+2. **A months mask with no `year` and no `rep_yr` stops at the end of the current
+   year** (`DATE-3`), and because nothing is stored, a reboot in the next calendar
+   year starts it again for that year (§3.1). Say what you mean: `rep_yr = true`
+   for never-ending, `year = N` for a persistent end date.
+3. **`repeat_every_year` alone is rejected**, not helpful — it has no month set
+   to recur over (`V6`). Add `months = MONTH_ALL`.
+4. **`year` and `repeat_every_year` together are rejected** (`V5`). Pick one:
+   `year` bounds the schedule to that year, `repeat_every_year` never expires.
+5. **A weekday mask on a `DATE` trigger is rejected** (`V2`), and so is a
+   weekday mask plus any date field on a solar trigger. Daily is
+   `DAYS_OF_WEEK` + `EVERYDAY` (`DOW-3`), or a solar trigger with
+   `repeat_days = EVERYDAY` and an empty date arm (`SOL-1`).
+6. **A months mask needs a `date.day`** (`V3`). There is no "every day of June"
+   date shape; the nearest is `DAYS_OF_WEEK` + `EVERYDAY`, which is not
+   month-scoped.
+7. **A zero field is a wildcard, not "unset".** There is no encoding for
+   "absent", so an all-zero date arm means "any day, any month, any year" — that
+   is `DATE-0`, a one-shot at the next `HH:MM`, and a zeroed solar config
+   computes sunrise/sunset for 0°N 0°E.
+8. **Setting a field the type does not read is an error**, not a no-op: the
+   schedule is refused at `create()` / `edit()` and deleted on NVS restore
+   (§4.7). Only `RELATIVE` ignores date fields — but its own
+   `relative_seconds` must be `> 0` (`V7`).

--- a/esp_schedule/examples/get_started/main/idf_component.yml
+++ b/esp_schedule/examples/get_started/main/idf_component.yml
@@ -3,7 +3,7 @@ dependencies:
   idf:
     version: ">=5.1"
   espressif/esp_schedule:
-    version: "~1.3.1"
+    version: "~1.4.0"
     override_path: "../../../."
   espressif/network_provisioning:
     version: "~1.2.0"

--- a/esp_schedule/idf_component.yml
+++ b/esp_schedule/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.3.3"
+version: "1.4.0"
 description: Task scheduling based on periodic and one-time events
 url: https://github.com/espressif/idf-extra-components/tree/master/components/esp_schedule
 repository: https://github.com/espressif/idf-extra-components.git

--- a/esp_schedule/src/esp_schedule.c
+++ b/esp_schedule/src/esp_schedule.c
@@ -1,9 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <time.h>
 #include <inttypes.h>
 #include "esp_log.h"
 #include "esp_sntp.h"
@@ -13,539 +16,663 @@
 static const char *TAG = "esp_schedule";
 
 #define SECONDS_TILL_2020 ((2020 - 1970) * 365 * 24 * 3600)
-#define SECONDS_IN_DAY (60 * 60 * 24)
+#define MINUTES_IN_DAY (60 * 24)
+
+/* Longest gap between two leap years, in years. Normally 4, but a century that
+ * is not a leap year stretches it to 8: 2096 and 2104 are leap, 2100 is not. */
+#define MAX_LEAP_YEAR_GAP 8
+
+/*
+ * Search horizon of the date engine in esp_schedule_get_next_date_time(),
+ * counted in *masked* months - months outside months_of_year_mask are skipped
+ * without spending one, so the budget only covers months actually walked day by
+ * day.
+ *
+ * This is the exact bound required, not a padded one:
+ *
+ *     1  the starting month, which may be partially elapsed (the engine can skip
+ *        today when the target time of day has already passed)
+ *   + N  the longest run of consecutive masked months in which day_of_month does
+ *        not exist
+ *   + 1  the month that finally matches
+ *
+ * Only day_of_month can be missing from a month; a days_of_week_mask always
+ * matches, since every month contains all seven weekdays. So N is maximized by
+ * the narrowest mask over the rarest day:
+ *
+ *   day <= 28, or any dow mask   N = 0   present in every month
+ *   day 31, no months mask       N = 1   Feb, Apr, Jun, Sep and Nov all lack a
+ *                                       31st, but none of them are adjacent
+ *   day 29, mask = Feb only      N = 7   <-- worst satisfiable case
+ *
+ * N = 7 is the run of non-leap Februaries inside the longest leap gap, hence
+ * N = MAX_LEAP_YEAR_GAP - 1 and a bound of 9. Worked example, starting late on
+ * 29 Feb 2096 with the target time already past: attempt 0 skips today, attempts
+ * 1..7 walk Feb 2097..2103, attempt 8 matches 29 Feb 2104. (A 32-bit time_t
+ * cannot reach 2096, capping the gap at 4 years there, so this is the 64-bit
+ * worst case.)
+ *
+ * Patterns that can never match - day 30 masked to February, day 31 masked to
+ * only 30-day months - have no finite N. They exhaust the horizon and fail
+ * regardless of its value, so it merely caps their wasted work.
+ *
+ * This holds for the current day rule (dow mask OR day_of_month). Adding an
+ * "nth weekday of month" rule would need N re-derived, as such a day can be
+ * absent from several consecutive months - that calls for a new term in the sum,
+ * not a larger MAX_LEAP_YEAR_GAP.
+ */
+#define MAX_MASKED_MONTH_ATTEMPTS (1 + (MAX_LEAP_YEAR_GAP - 1) + 1)
 
 static bool init_done = false;
 
-static int esp_schedule_get_no_of_days(esp_schedule_trigger_t *trigger, struct tm *current_time, struct tm *schedule_time)
+// Forward declarations for static functions
+static void esp_schedule_common_timer_cb(TimerHandle_t timer);
+
+/*
+ * Unified date-based next occurrence calculation.
+ * Returns true and sets *next_time to the next valid time that matches all provided constraints.
+ * - now: current time
+ * - minutes_since_midnight: target minutes in day [0, 24*60)
+ * - days_of_week_mask: bitmask Monday=bit0 .. Sunday=bit6; 0 => any day
+ * - day_of_month: 1..31; 0 => any day
+ * - months_of_year_mask: bitmask January=bit0 .. December=bit11; 0 => any month
+ * - year: 4-digit year (e.g., 2025); 0 => any year
+ * - validity: optional window [start,end]; if provided, the returned time will be within this window
+ */
+bool esp_schedule_get_next_date_time(time_t now,
+                                     uint16_t minutes_since_midnight,
+                                     uint8_t days_of_week_mask,
+                                     uint8_t day_of_month,
+                                     uint16_t months_of_year_mask,
+                                     uint16_t year,
+                                     const esp_schedule_validity_t *validity,
+                                     time_t *next_time)
 {
-    /* for day, monday = 0, sunday = 6. */
-    int next_day = 0;
-    /* struct tm has tm_wday with sunday as 0. Whereas we have monday as 0. Converting struct tm to our format */
-    int today = ((current_time->tm_wday + 7 - 1) % 7);
+    if (next_time == NULL) {
+        return false;
+    }
+    /* Reject an out-of-range time-of-day instead of letting mktime() normalize it.
+     * With minutes_since_midnight >= 24*60 the candidate would roll into the
+     * following day, so the returned instant could land on a day that violates
+     * the day/month mask this engine just matched. */
+    if (minutes_since_midnight >= MINUTES_IN_DAY) {
+        *next_time = 0;
+        return false;
+    }
+    /* If the validity window opens in the future, start the search there rather
+     * than walking day-by-day from now. The month-attempt cap below would
+     * otherwise be exhausted before reaching a far-future start_time, causing the
+     * schedule to silently never fire. We evaluate the first candidate day
+     * unconditionally (force_include_first) and let the exact-instant
+     * ">= start_time" validity check below decide whether it qualifies. That
+     * avoids seeding need_next_occurrence from a wall-clock-of-day comparison,
+     * which could skip the first valid day across a DST transition at the
+     * window boundary. */
+    bool force_include_first = false;
+    if (validity != NULL && validity->start_time > now) {
+        now = validity->start_time;
+        force_include_first = true;
+    }
+    struct tm current_tm = {0};
+    localtime_r(&now, &current_tm);
+    struct tm candidate_tm = current_tm;
 
-    esp_schedule_days_t today_bit = 1 << today;
-    uint8_t repeat_days = trigger->day.repeat_days;
-    int current_seconds = (current_time->tm_hour * 60 + current_time->tm_min) * 60 + current_time->tm_sec;
-    int schedule_seconds = (schedule_time->tm_hour * 60 + schedule_time->tm_min) * 60;
+    uint32_t current_seconds_since_midnight = (uint32_t)(current_tm.tm_hour * 3600 + current_tm.tm_min * 60 + current_tm.tm_sec);
+    uint32_t target_seconds_since_midnight = (uint32_t)minutes_since_midnight * 60U;
 
-    /* Handling for one time schedule */
-    if (repeat_days == ESP_SCHEDULE_DAY_ONCE) {
-        if (schedule_seconds > current_seconds) {
-            /* The schedule is today and is yet to go off */
-            return 0;
-        } else {
-            /* The schedule is tomorrow */
-            return 1;
+    bool need_next_occurrence = (current_seconds_since_midnight >= target_seconds_since_midnight);
+    if (force_include_first) {
+        /* Do not skip the window-open day; the ">= start_time" check gates it. */
+        need_next_occurrence = false;
+    }
+
+    if (year != 0) {
+        int target_year = (int)year - 1900;
+        if (current_tm.tm_year > target_year) {
+            *next_time = 0;
+            return false;
+        } else if (current_tm.tm_year < target_year) {
+            candidate_tm.tm_year = target_year;
+            candidate_tm.tm_mon = 0;
+            candidate_tm.tm_mday = 1;
+            need_next_occurrence = false;
         }
     }
 
-    /* Handling for repeating schedules */
-    /* Check if it is today */
-    if ((repeat_days & today_bit)) {
-        if (schedule_seconds > current_seconds) {
-            /* The schedule is today and is yet to go off. */
-            return 0;
+    candidate_tm.tm_isdst = -1;
+    time_t candidate_time = mktime(&candidate_tm);
+    localtime_r(&candidate_time, &candidate_tm);
+
+    /* One attempt == one *masked* month, searched day by day below. A month
+     * outside months_of_year_mask is skipped by the inner do-while without
+     * consuming an attempt, so the horizon is spent only on months actually
+     * walked. See MAX_MASKED_MONTH_ATTEMPTS for why that horizon is exact. */
+    for (int month_attempts = 0; month_attempts < MAX_MASKED_MONTH_ATTEMPTS; month_attempts++) {
+        bool month_valid = true;
+        if (months_of_year_mask != 0) {
+            uint16_t month_bit = (uint16_t)(1U << candidate_tm.tm_mon);
+            month_valid = (month_bit & months_of_year_mask) != 0;
         }
-    }
-    /* Check if it is this week or next week */
-    if ((repeat_days & (today_bit ^ 0xFF)) > today_bit) {
-        /* Next schedule is yet to come in this week */
-        next_day = ffs(repeat_days & (0xFF << (today + 1))) - 1;
-        return (next_day - today);
-    } else {
-        /* First scheduled day of the next week */
-        next_day = ffs(repeat_days) - 1;
-        if (next_day == today) {
-            /* Same day, next week */
-            return 7;
+
+        if (!month_valid) {
+            do {
+                candidate_tm.tm_mon++;
+                if (candidate_tm.tm_mon >= 12) {
+                    candidate_tm.tm_mon = 0;
+                    candidate_tm.tm_year++;
+                }
+                if (year != 0 && candidate_tm.tm_year > ((int)year - 1900)) {
+                    *next_time = 0;
+                    return false;
+                }
+                uint16_t month_bit = (uint16_t)(1U << candidate_tm.tm_mon);
+                month_valid = (month_bit & months_of_year_mask) != 0;
+            } while (!month_valid);
+
+            candidate_tm.tm_mday = 1;
+            candidate_tm.tm_isdst = -1;
+            candidate_time = mktime(&candidate_tm);
+            localtime_r(&candidate_time, &candidate_tm);
+            need_next_occurrence = false;
         }
-        return (7 - today + next_day);
+
+        int days_in_month = 31; /* bounded by normalization */
+        for (int day_attempts = 0; day_attempts < days_in_month; day_attempts++) {
+            bool day_matches = true;
+            if (days_of_week_mask != 0 || day_of_month != 0) {
+                day_matches = false;
+                if (days_of_week_mask != 0) {
+                    uint8_t day_of_week_index = (uint8_t)((candidate_tm.tm_wday + 6) % 7); /* Sunday=0 -> Monday=0 */
+                    uint8_t day_bit = (uint8_t)(1U << day_of_week_index);
+                    if ((day_bit & days_of_week_mask) != 0) {
+                        day_matches = true;
+                    }
+                }
+                if (!day_matches && day_of_month != 0) {
+                    if (candidate_tm.tm_mday == day_of_month) {
+                        day_matches = true;
+                    }
+                }
+            }
+
+            if (day_matches) {
+                if (month_attempts == 0 && day_attempts == 0 && need_next_occurrence) {
+                    /* skip today due to time passed */
+                } else {
+                    candidate_tm.tm_hour = (int)(minutes_since_midnight / 60U);
+                    candidate_tm.tm_min = (int)(minutes_since_midnight % 60U);
+                    candidate_tm.tm_sec = 0;
+                    /* Let mktime resolve DST for the target local time. It uses
+                     * tm_isdst to pick the correct epoch, so no manual +/-3600
+                     * correction is needed (and applying one double-corrects). */
+                    candidate_tm.tm_isdst = -1;
+                    time_t result_time = mktime(&candidate_tm);
+
+                    if (year != 0) {
+                        struct tm check_tm;
+                        localtime_r(&result_time, &check_tm);
+                        if (check_tm.tm_year != ((int)year - 1900)) {
+                            *next_time = 0;
+                            return false;
+                        }
+                    }
+
+                    if (validity && validity->end_time != 0 && result_time > validity->end_time) {
+                        *next_time = 0;
+                        return false;
+                    }
+                    if (!validity || validity->start_time == 0 || result_time >= validity->start_time) {
+                        *next_time = result_time;
+                        return true;
+                    }
+                    /* else fall through to search next valid day */
+                }
+            }
+
+            /* Advance to the next calendar day. Incrementing tm_mday and
+             * re-normalizing via mktime is DST-safe; adding a fixed 86400
+             * seconds skips or repeats a day across DST transitions. */
+            int prev_mon = candidate_tm.tm_mon;
+            candidate_tm.tm_mday++;
+            candidate_tm.tm_isdst = -1;
+            candidate_time = mktime(&candidate_tm);
+            localtime_r(&candidate_time, &candidate_tm);
+            need_next_occurrence = false;
+            if (candidate_tm.tm_mon != prev_mon) {
+                break;
+            }
+            if (year != 0 && candidate_tm.tm_year > ((int)year - 1900)) {
+                *next_time = 0;
+                return false;
+            }
+        }
     }
 
-    ESP_LOGE(TAG, "No of days could not be found. This should not happen.");
-    return 0;
+    *next_time = 0;
+    return false;
 }
 
-static uint8_t esp_schedule_get_next_month(esp_schedule_trigger_t *trigger, struct tm *current_time, struct tm *schedule_time)
+/*
+ * Year constraint the date arm passes to the C engine. This is where the three
+ * recurrence spellings differ:
+ *
+ *   repeat_every_year  the pattern recurs in every year        -> unconstrained
+ *   year = N           bounded to that year                    -> N
+ *   neither, with a
+ *   months mask        bounded to the *current* year           -> this year
+ *
+ * The last row is why a months mask alone is not a one-shot: it fires each masked
+ * month of the current year and then finds no further match. Because nothing is
+ * stored, the bound is re-resolved from `now` on every arm, so a reboot in a
+ * later calendar year re-bounds it to that year. Use `year = N` when the end must
+ * survive a reboot, or `repeat_every_year` when it should never end.
+ *
+ * With no months mask there is nothing to iterate, so the trigger fires once and
+ * the year is left unconstrained (it may land in the next year).
+ */
+uint16_t esp_schedule_date_arm_match_year(const esp_schedule_trigger_t *trigger, time_t now)
 {
-    int current_seconds = (current_time->tm_hour * 60 + current_time->tm_min) * 60 + current_time->tm_sec;
-    int schedule_seconds = (schedule_time->tm_hour * 60 + schedule_time->tm_min) * 60;
-    /* +1 is because struct tm has months starting from 0, whereas we have them starting from 1 */
-    uint8_t current_month = current_time->tm_mon + 1;
-    /* -1 because month_bit starts from 0b1. So for January, it should be 1 << 0. And current_month starts from 1. */
-    uint16_t current_month_bit = 1 << (current_month - 1);
-    uint8_t next_schedule_month = 0;
-    uint16_t repeat_months = trigger->date.repeat_months;
-
-    /* Check if month is not specified */
-    if (repeat_months == ESP_SCHEDULE_MONTH_ONCE) {
-        if (trigger->date.day == current_time->tm_mday) {
-            /* The schedule day is same. Check if time has already passed */
-            if (schedule_seconds > current_seconds) {
-                /* The schedule is today and is yet to go off */
-                return current_month;
-            } else {
-                /* Today's time has passed */
-                return (current_month + 1);
-            }
-        } else if (trigger->date.day > current_time->tm_mday) {
-            /* The day is yet to come in this month */
-            return current_month;
-        } else {
-            /* The day has passed in the current month */
-            return (current_month + 1);
-        }
+    if (trigger->date.year != 0) {
+        return trigger->date.year;
     }
-
-    /* Check if schedule is not this year itself, it is in future. */
-    if (trigger->date.year > (current_time->tm_year + 1900)) {
-        /* Find first schedule month of next year */
-        next_schedule_month = ffs(repeat_months);
-        /* Year will be handled by the caller. So no need to add any additional months */
-        return next_schedule_month;
+    if (trigger->date.repeat_every_year || trigger->date.repeat_months == 0) {
+        return 0;
     }
-
-    /* Check if schedule is this month and is yet to come */
-    if (current_month_bit & repeat_months) {
-        if (trigger->date.day == current_time->tm_mday) {
-            /* The schedule day is same. Check if time has already passed */
-            if (schedule_seconds > current_seconds) {
-                /* The schedule is today and is yet to go off */
-                return current_month;
-            }
-        }
-        if (trigger->date.day > current_time->tm_mday) {
-            /* The day is yet to come in this month */
-            return current_month;
-        }
-    }
-
-    /* Check if schedule is this year */
-    if ((repeat_months & (current_month_bit ^ 0xFFFF)) > current_month_bit) {
-        /* Next schedule month is yet to come in this year */
-        next_schedule_month = ffs(repeat_months & (0xFFFF << (current_month)));
-        return next_schedule_month;
-    }
-
-    /* Check if schedule is for this year and does not repeat */
-    if (!trigger->date.repeat_every_year) {
-        /* For yearly repeating schedules with year=0, treat as repeating */
-        if (trigger->date.year != 0 && trigger->date.year <= (current_time->tm_year + 1900)) {
-            ESP_LOGE(TAG, "Schedule does not repeat next year, but get_next_month has been called.");
-            return 0;
-        }
-    }
-
-    /* Schedule is not this year */
-    /* Find first schedule month of next year */
-    next_schedule_month = ffs(repeat_months);
-    /* +12 because the schedule is next year */
-    return (next_schedule_month + 12);
-}
-
-static uint16_t esp_schedule_get_next_year(esp_schedule_trigger_t *trigger, struct tm *current_time, struct tm *schedule_time)
-{
-    uint16_t current_year = current_time->tm_year + 1900;
-    uint16_t schedule_year = trigger->date.year;
-    if (schedule_year > current_year) {
-        return schedule_year;
-    }
-    /* If the schedule is set to repeat_every_year, we return the current year */
-    /* If the schedule has already passed in this year, we still return current year, as the additional months will be handled in get_next_month */
-    return current_year;
+    struct tm now_tm;
+    localtime_r(&now, &now_tm);
+    return (uint16_t)(now_tm.tm_year + 1900);
 }
 
 #if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
-/* Helper function to calculate solar time for a specific date */
-static time_t esp_schedule_calc_solar_time_for_date(const esp_schedule_trigger_t *trigger,
-        int year, int month, int day,
-        const char *schedule_name)
+/**
+ * @brief Calculate solar time for the calendar date of a given UTC timestamp
+ *
+ * The calendar date (year/month/day) is derived from @p time_utc in *local*
+ * time (via localtime_r), by design: scheduling is wall-clock based, so the
+ * solar event is computed for the local date. The returned solar time is UTC.
+ *
+ * @param is_sunrise: true if sunrise, false if sunset
+ * @param time_utc: UTC timestamp whose local calendar date is used
+ * @param latitude: latitude
+ * @param longitude: longitude
+ * @param offset_minutes: offset in minutes
+ * @return solar time in UTC, 0 if calculation failed
+ */
+time_t esp_schedule_calc_solar_time_for_time_utc(bool is_sunrise, time_t time_utc, double latitude, double longitude, int offset_minutes)
 {
+    struct tm time_tm;
+    localtime_r(&time_utc, &time_tm);
     time_t sunrise_utc, sunset_utc;
+    int year = time_tm.tm_year + 1900;
+    int month = time_tm.tm_mon + 1;
+    int day = time_tm.tm_mday;
 
-    bool calc_ok = esp_daylight_calc_sunrise_sunset_utc(
-                       year, month, day,
-                       trigger->solar.latitude,
-                       trigger->solar.longitude,
-                       &sunrise_utc, &sunset_utc);
-
+    bool calc_ok = esp_daylight_calc_sunrise_sunset_utc(year, month, day, latitude, longitude, &sunrise_utc, &sunset_utc);
     if (!calc_ok) {
-        ESP_LOGW(TAG, "Failed to calculate sunrise/sunset for date %04d-%02d-%02d for %s (likely polar night/day condition)",
-                 year, month, day, schedule_name);
+        ESP_LOGW(TAG, "Failed to calculate %s for date %04d-%02d-%02d at latitude %.5f, longitude %.5f (likely polar night/day condition)",
+                 is_sunrise ? "sunrise" : "sunset",
+                 year, month, day, latitude, longitude
+                );
+        return 0;
+    }
+    time_t solar_time = is_sunrise ? sunrise_utc : sunset_utc;
+    return esp_daylight_apply_offset(solar_time, offset_minutes);
+}
+
+time_t esp_schedule_get_next_valid_solar_time(time_t now, const esp_schedule_trigger_t *trigger, const esp_schedule_validity_t *validity, const char *schedule_name)
+{
+    time_t day_end = 0;
+    bool is_sunrise = trigger->type == ESP_SCHEDULE_TYPE_SUNRISE;
+
+    /* Day selection is the day-of-week arm or the date arm, never both (the two
+     * are mutually exclusive, enforced by validation); only the time-of-day is
+     * replaced by the computed solar event. */
+    uint16_t match_year = esp_schedule_date_arm_match_year(trigger, now);
+
+    // Find first candidate day (use 23:59 so day selection logic is "date-only")
+    if (!esp_schedule_get_next_date_time(now, MINUTES_IN_DAY - 1, trigger->day.repeat_days, trigger->date.day, trigger->date.repeat_months, match_year, validity, &day_end)) {
         return 0;
     }
 
-    time_t solar_time = (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE) ? sunrise_utc : sunset_utc;
-    return esp_daylight_apply_offset(solar_time, trigger->solar.offset_minutes);
-}
+    // try for 370 days (max possible days in a year)
+    for (int attempts = 0; attempts < 370; attempts++) {
+        time_t solar_time = esp_schedule_calc_solar_time_for_time_utc(is_sunrise, day_end, trigger->solar.latitude, trigger->solar.longitude, trigger->solar.offset_minutes);
+        if ((solar_time == 0) ||
+                (validity && validity->start_time && solar_time < validity->start_time) ||
+                (solar_time <= now)) {
+            // No solar event on this day (polar conditions) -> advance to next valid day
+            // Outside validity window or not in the future -> advance to next valid day
+        } else if (validity && validity->end_time && solar_time > validity->end_time) {
+            // Past validity window -> return 0
+            ESP_LOGD(TAG, "Schedule %s: next solar event is past validity end_time.", schedule_name);
+            return 0;
+        } else {
+            return solar_time;
+        }
 
-/* Helper function to handle logging and timer calculation for solar schedules */
-static int32_t esp_schedule_finalize_solar_time(time_t solar_time, time_t now,
-        const esp_schedule_trigger_t *trigger,
-        const char *schedule_name)
-{
-    char time_str[64];
-    struct tm schedule_time;
-
-    /* Convert solar time to local time for display and DST handling */
-    localtime_r(&solar_time, &schedule_time);
-
-    /* Print schedule time */
-    memset(time_str, 0, sizeof(time_str));
-    strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
-    ESP_LOGI(TAG, "Schedule %s (%s%+d min) will be active on: %s. DST: %s",
-             schedule_name,
-             (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE) ? "sunrise" : "sunset",
-             trigger->solar.offset_minutes,
-             time_str, schedule_time.tm_isdst ? "Yes" : "No");
-
-    /* Simple epoch-based timer calculation */
-    int32_t timer_seconds = (int32_t)difftime(solar_time, now);
-
-    /* With proactive logic, this should not happen, but log if it does */
-    if (timer_seconds < 0) {
-        ESP_LOGW(TAG, "Unexpected: Solar schedule time has passed (%" PRId32 " seconds ago). This should have been handled proactively.", -timer_seconds);
-        /* Return the negative value to help debug - caller will handle this as error */
+        // Advance anchor to next day
+        if (!esp_schedule_get_next_date_time(day_end + 1, MINUTES_IN_DAY - 1, trigger->day.repeat_days, trigger->date.day, trigger->date.repeat_months, match_year, validity, &day_end)) {
+            ESP_LOGD(TAG, "Schedule %s: no further day matches the date/day-of-week arm.", schedule_name);
+            return 0;
+        }
     }
-
-    return timer_seconds;
+    ESP_LOGD(TAG, "Schedule %s: no solar event found within 370 candidate days.", schedule_name);
+    return 0;
 }
 #endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
 
-static uint32_t esp_schedule_get_next_schedule_time_diff(const char *schedule_name, esp_schedule_trigger_t *trigger)
+/* True if any field of the date arm is populated. There is no encoding for
+ * "field not set", so an all-zero date arm is the wildcard, not "absent". */
+static bool esp_schedule_date_arm_present(const esp_schedule_trigger_t *trigger)
 {
-    struct tm current_time, schedule_time;
+    return (trigger->date.day != 0 ||
+            trigger->date.repeat_months != 0 ||
+            trigger->date.year != 0 ||
+            trigger->date.repeat_every_year);
+}
+
+/*
+ * Validate the date arm (rules V3..V6 of docs/trigger_rules.md, evaluated in
+ * that order). Reached only when the day-of-week arm is unused.
+ */
+static bool esp_schedule_date_arm_is_valid(const esp_schedule_trigger_t *trigger, const char *schedule_name)
+{
+    /* V3: a months mask with no day-of-month would mean every day of those
+     * months, which is never the intended schedule. */
+    if (trigger->date.day == 0 && trigger->date.repeat_months != 0) {
+        ESP_LOGE(TAG, "Schedule %s: date.repeat_months is set but date.day is 0. Set date.day.", schedule_name);
+        return false;
+    }
+    /* V4: a recurrence or a year bound with no date pattern to apply it to. */
+    if (trigger->date.day == 0 && trigger->date.repeat_months == 0 &&
+            (trigger->date.year != 0 || trigger->date.repeat_every_year)) {
+        ESP_LOGE(TAG, "Schedule %s: date.year/date.repeat_every_year set with no date.day or date.repeat_months to apply it to.", schedule_name);
+        return false;
+    }
+    /* V5: "only year N" and "every year" are contradictory. */
+    if (trigger->date.year != 0 && trigger->date.repeat_every_year) {
+        ESP_LOGE(TAG, "Schedule %s: date.year and date.repeat_every_year are mutually exclusive.", schedule_name);
+        return false;
+    }
+    /* V6: repeat_every_year recurs *over the month set*, so with no mask it
+     * would be inert. date.year is exempt: it still constrains the arm. */
+    if (trigger->date.repeat_every_year && trigger->date.repeat_months == 0) {
+        ESP_LOGE(TAG, "Schedule %s: date.repeat_every_year needs date.repeat_months to recur over (use ESP_SCHEDULE_MONTH_ALL for every month).", schedule_name);
+        return false;
+    }
+    return true;
+}
+
+/*
+ * Validate the trigger configuration. Each type reads only the fields it owns
+ * (day.repeat_days for DAYS_OF_WEEK, date.* for DATE, either arm for solar);
+ * setting a field the type does not read, or a combination with no coherent
+ * reading, is a configuration error rather than a silently discarded value.
+ * The rules are tabulated in docs/trigger_rules.md.
+ *
+ * Rejecting these guarantees two invariants the rest of the code relies on: the
+ * day-of-week and day-of-month arms are never both set, and date.year is already
+ * 0 whenever date.repeat_every_year is set.
+ *
+ * Range validation of hours/minutes is separate, see
+ * esp_schedule_config_time_of_day_is_valid().
+ */
+bool esp_schedule_trigger_is_valid(const esp_schedule_trigger_t *trigger, const char *schedule_name)
+{
+    switch (trigger->type) {
+    case ESP_SCHEDULE_TYPE_RELATIVE:
+        /* Reads no date field; all of them are ignored. The one field it does own
+         * must name a future instant. V7: a non-positive delay puts the target at
+         * or before the base time, so the arm path would find nothing to fire and
+         * the schedule would silently never run. */
+        if (trigger->relative_seconds <= 0) {
+            ESP_LOGE(TAG, "Schedule %s: relative_seconds must be > 0, got %d.", schedule_name, trigger->relative_seconds);
+            return false;
+        }
+        return true;
+    case ESP_SCHEDULE_TYPE_DAYS_OF_WEEK:
+        /* V1: this type reads only day.repeat_days. */
+        if (esp_schedule_date_arm_present(trigger)) {
+            ESP_LOGE(TAG, "Schedule %s: DAYS_OF_WEEK reads only day.repeat_days, but a date.* field is set.", schedule_name);
+            return false;
+        }
+        return true;
+    case ESP_SCHEDULE_TYPE_DATE:
+        /* V2: DATE has no day-of-week arm. */
+        if (trigger->day.repeat_days != 0) {
+            ESP_LOGE(TAG, "Schedule %s: DATE reads only date.*, but day.repeat_days is set. Use DAYS_OF_WEEK instead.", schedule_name);
+            return false;
+        }
+        return esp_schedule_date_arm_is_valid(trigger, schedule_name);
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    case ESP_SCHEDULE_TYPE_SUNRISE:
+    /* fall-through */
+    case ESP_SCHEDULE_TYPE_SUNSET:
+        /* Solar selects one day arm from whichever is populated. V2: both
+         * populated is ambiguous, not a union. */
+        if (trigger->day.repeat_days != 0) {
+            if (esp_schedule_date_arm_present(trigger)) {
+                ESP_LOGE(TAG, "Schedule %s: solar day.repeat_days and date.* are mutually exclusive arms; only one may be set.", schedule_name);
+                return false;
+            }
+            return true; /* day-of-week arm */
+        }
+        return esp_schedule_date_arm_is_valid(trigger, schedule_name);
+#endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
+    default:
+        return false;
+    }
+}
+
+/*
+ * One-shot rule for the date arm, shared by DATE and by solar when its date arm
+ * is the selected one.
+ *
+ * The months mask gates all date-arm recurrence: every recurrence iterates the
+ * month set, so with no mask there is nothing to iterate and the trigger fires
+ * exactly once. With a mask it always recurs; how far is decided by the year
+ * constraint above, and exhausting it makes the C engine return no match, which
+ * the arm path turns into disarm-and-delete.
+ */
+static bool esp_schedule_date_arm_is_one_shot(const esp_schedule_trigger_t *trigger)
+{
+    return trigger->date.repeat_months == 0;
+}
+
+/*
+ * Returns true if this trigger fires exactly once, i.e. it has no recurring
+ * pattern that would produce a further occurrence after the current one. This is
+ * a property of the configuration alone and says nothing about whether the
+ * trigger has already fired (see esp_schedule_trigger_fired_and_done).
+ */
+static bool esp_schedule_trigger_is_one_shot(const esp_schedule_trigger_t *trigger)
+{
+    switch (trigger->type) {
+    case ESP_SCHEDULE_TYPE_RELATIVE:
+        return true; /* relative schedules fire exactly once */
+    case ESP_SCHEDULE_TYPE_DAYS_OF_WEEK:
+        return trigger->day.repeat_days == ESP_SCHEDULE_DAY_ONCE;
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    case ESP_SCHEDULE_TYPE_SUNRISE:
+    /* fall-through */
+    case ESP_SCHEDULE_TYPE_SUNSET:
+        if (trigger->day.repeat_days != 0) {
+            return false; /* day-of-week arm: repeats on every set weekday, forever */
+        }
+        /* Otherwise solar shares DATE's date-arm rule; only the time-of-day is
+         * replaced by the computed sunrise/sunset instant. */
+        return esp_schedule_date_arm_is_one_shot(trigger);
+#endif
+    case ESP_SCHEDULE_TYPE_DATE:
+        return esp_schedule_date_arm_is_one_shot(trigger);
+    default:
+        return true;
+    }
+}
+
+/*
+ * Returns true if this is a one-shot trigger that has already fired, and must
+ * therefore NOT be recomputed to a future occurrence. A trigger has "fired"
+ * once its next_scheduled_time_utc is set (>0) and has passed (<=now).
+ *
+ * Repeating triggers (weekly day-of-week, yearly dates, repeating solar) return
+ * false so they are recomputed and re-armed. Without this guard the date engine
+ * treats an empty day/month mask as "any", so a DAY_ONCE schedule would re-fire
+ * every day and a one-time DATE schedule every month.
+ */
+bool esp_schedule_trigger_fired_and_done(const esp_schedule_trigger_t *trigger, time_t now)
+{
+    if (!(trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= now)) {
+        return false; /* not computed yet, or still in the future */
+    }
+    return esp_schedule_trigger_is_one_shot(trigger);
+}
+
+/*
+ * Ensure trigger->next_scheduled_time_utc is set to the next occurrence.
+ * Repeating date/day-of-week/solar triggers are always recomputed on every arm
+ * (so a timezone change is picked up); RELATIVE triggers keep their computed
+ * absolute target; one-shot triggers that already fired are left untouched.
+ * Returns true if a valid future time is present after this call, false otherwise.
+ */
+static bool esp_schedule_set_next_scheduled_time_utc(const char *schedule_name, esp_schedule_trigger_t *trigger, const esp_schedule_validity_t *validity)
+{
+    struct tm schedule_time;
     time_t now;
-    char time_str[64];
-    int32_t time_diff;
 
     /* Get current time */
     time(&now);
+    /* Always recompute the next occurrence for repeating date/day-of-week/solar
+     * triggers instead of reusing a stored next_scheduled_time_utc. This keeps
+     * the fire time correct after a timezone change (picked up on the next arm)
+     * without needing an explicit recalculation API. RELATIVE triggers keep
+     * their computed absolute target (handled below); one-shot triggers that
+     * already fired are guarded next. */
+    /* One-shot triggers that have already fired must not be recomputed to a
+     * future occurrence (see esp_schedule_trigger_fired_and_done). */
+    if (esp_schedule_trigger_fired_and_done(trigger, now)) {
+        return false;
+    }
     /* Handling ESP_SCHEDULE_TYPE_RELATIVE first since it doesn't require any
      * computation based on days, hours, minutes, etc.
      */
     if (trigger->type == ESP_SCHEDULE_TYPE_RELATIVE) {
-        /* If next scheduled time is already set, just compute the difference
-         * between current time and next scheduled time and return that diff.
-         */
-        time_t target;
-        if (trigger->next_scheduled_time_utc > 0) {
-            target = (time_t)trigger->next_scheduled_time_utc;
-            time_diff = difftime(target, now);
-        } else {
-            target = now + (time_t)trigger->relative_seconds;
-            time_diff = trigger->relative_seconds;
-        }
-        localtime_r(&target, &schedule_time);
-        trigger->next_scheduled_time_utc = mktime(&schedule_time);
-        /* Print schedule time */
-        memset(time_str, 0, sizeof(time_str));
-        strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
-        ESP_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule_name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
-        return time_diff;
-    }
-
-    /* Handle solar-based schedules (sunrise/sunset) */
-#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
-    if (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE || trigger->type == ESP_SCHEDULE_TYPE_SUNSET) {
-        time_t solar_time = 0;
-
-        /* Start with current local time for day calculations */
-        localtime_r(&now, &current_time);
-
-        /* Determine schedule pattern using unified approach */
-        if (trigger->date.day != 0) {
-            /* Date-based solar schedule - check if today's solar time + offset has passed */
-            struct tm schedule_time = current_time;
-            schedule_time.tm_mday = trigger->date.day;
-
-            /* For same day, check if solar time + offset has passed before deciding year */
-            if (trigger->date.day == current_time.tm_mday) {
-                uint8_t current_month = current_time.tm_mon + 1;
-                uint16_t repeat_months = trigger->date.repeat_months;
-                uint16_t current_month_bit = 1 << (current_month - 1);
-
-                /* Check if this month is in the repeat pattern */
-                if (current_month_bit & repeat_months) {
-                    /* Calculate today's solar time + offset */
-                    time_t today_solar = esp_schedule_calc_solar_time_for_date(trigger,
-                                         current_time.tm_year + 1900,
-                                         current_time.tm_mon + 1,
-                                         current_time.tm_mday,
-                                         schedule_name);
-
-                    /* If today's solar time + offset hasn't passed, use today */
-                    if (today_solar > 0 && today_solar > now) {
-                        schedule_time.tm_mon = current_time.tm_mon;
-                        schedule_time.tm_year = current_time.tm_year;
-                    } else {
-                        /* Solar time has passed, use next occurrence */
-                        schedule_time.tm_mon = esp_schedule_get_next_month(trigger, &current_time, &schedule_time) - 1;
-                        schedule_time.tm_year = esp_schedule_get_next_year(trigger, &current_time, &schedule_time) - 1900;
-                    }
-                } else {
-                    /* Not this month, use normal logic */
-                    schedule_time.tm_mon = esp_schedule_get_next_month(trigger, &current_time, &schedule_time) - 1;
-                    schedule_time.tm_year = esp_schedule_get_next_year(trigger, &current_time, &schedule_time) - 1900;
-                }
-            } else {
-                /* Different day, use normal logic */
-                schedule_time.tm_mon = esp_schedule_get_next_month(trigger, &current_time, &schedule_time) - 1;
-                schedule_time.tm_year = esp_schedule_get_next_year(trigger, &current_time, &schedule_time) - 1900;
+        /* Compute only once from first encounter. If already set and passed, do not recompute. */
+        if (trigger->next_scheduled_time_utc == 0) {
+            time_t base = now;
+            if (validity && validity->start_time && validity->start_time > now) {
+                base = validity->start_time;
             }
-
-            if (schedule_time.tm_mon < 0) {
-                ESP_LOGE(TAG, "Invalid month found for solar schedule: %s", schedule_name);
-                return 0;
-            }
-            if (schedule_time.tm_mon >= 12) {
-                schedule_time.tm_year += schedule_time.tm_mon / 12;
-                schedule_time.tm_mon = schedule_time.tm_mon % 12;
-            }
-            mktime(&schedule_time);
-
-            /* Calculate solar time for the determined date */
-            solar_time = esp_schedule_calc_solar_time_for_date(trigger,
-                         schedule_time.tm_year + 1900,
-                         schedule_time.tm_mon + 1,
-                         schedule_time.tm_mday,
-                         schedule_name);
-
-        } else if (trigger->day.repeat_days != 0) {
-            /* Day-of-week solar schedule - check if today's solar time + offset has passed */
-            struct tm schedule_time = current_time;
-
-            /* Check if today is one of the scheduled days */
-            int today = current_time.tm_wday == 0 ? 7 : current_time.tm_wday; /* Convert Sunday from 0 to 7 */
-            uint8_t today_bit = 1 << (today - 1); /* Monday=bit0, Tuesday=bit1, etc. */
-
-            if (trigger->day.repeat_days & today_bit) {
-                /* Today is a scheduled day, check if solar time + offset has passed */
-                time_t today_solar = esp_schedule_calc_solar_time_for_date(trigger,
-                                     current_time.tm_year + 1900,
-                                     current_time.tm_mon + 1,
-                                     current_time.tm_mday,
-                                     schedule_name);
-
-                /* If today's solar time + offset hasn't passed, use today */
-                if (today_solar > 0 && today_solar > now) {
-                    /* Use today */
-                    solar_time = today_solar;
-                } else {
-                    /* Solar time has passed, find next scheduled day */
-                    int no_of_days = esp_schedule_get_no_of_days(trigger, &current_time, &schedule_time);
-                    schedule_time.tm_mday += no_of_days;
-                    mktime(&schedule_time);
-
-                    solar_time = esp_schedule_calc_solar_time_for_date(trigger,
-                                 schedule_time.tm_year + 1900,
-                                 schedule_time.tm_mon + 1,
-                                 schedule_time.tm_mday,
-                                 schedule_name);
-                }
-            } else {
-                /* Today is not a scheduled day, use normal logic */
-                int no_of_days = esp_schedule_get_no_of_days(trigger, &current_time, &schedule_time);
-                schedule_time.tm_mday += no_of_days;
-                mktime(&schedule_time);
-
-                solar_time = esp_schedule_calc_solar_time_for_date(trigger,
-                             schedule_time.tm_year + 1900,
-                             schedule_time.tm_mon + 1,
-                             schedule_time.tm_mday,
-                             schedule_name);
-            }
-
-        } else {
-            /* Single-time solar schedule - use logic similar to regular schedules */
-            solar_time = esp_schedule_calc_solar_time_for_date(trigger,
-                         current_time.tm_year + 1900,
-                         current_time.tm_mon + 1,
-                         current_time.tm_mday,
-                         schedule_name);
-
-            /* If time has passed today, calculate for tomorrow (like regular schedules) */
-            if (solar_time > 0 && solar_time <= now) {
-                struct tm tomorrow_time;
-                localtime_r(&now, &tomorrow_time);  // Use fresh local time
-                tomorrow_time.tm_mday += 1;
-                mktime(&tomorrow_time);
-
-                solar_time = esp_schedule_calc_solar_time_for_date(trigger,
-                             tomorrow_time.tm_year + 1900,
-                             tomorrow_time.tm_mon + 1,
-                             tomorrow_time.tm_mday,
-                             schedule_name);
-
-                /* If tomorrow's time is still in the past (due to large negative offset), try day after tomorrow */
-                if (solar_time > 0 && solar_time <= now) {
-                    tomorrow_time.tm_mday += 1;
-                    mktime(&tomorrow_time);
-
-                    solar_time = esp_schedule_calc_solar_time_for_date(trigger,
-                                 tomorrow_time.tm_year + 1900,
-                                 tomorrow_time.tm_mon + 1,
-                                 tomorrow_time.tm_mday,
-                                 schedule_name);
-                }
-            }
+            time_t target = base + (time_t)trigger->relative_seconds;
+            localtime_r(&target, &schedule_time);
+            trigger->next_scheduled_time_utc = mktime(&schedule_time);
         }
-
-        /* Return error if solar calculation failed */
-        if (solar_time == 0) {
-            ESP_LOGW(TAG, "Solar schedule %s cannot be calculated (no sunrise/sunset at this location/date)", schedule_name);
-            return 0;
-        }
-
-        /* Calculate timer - should always be positive since we proactively handle past times */
-        time_diff = esp_schedule_finalize_solar_time(solar_time, now, trigger, schedule_name);
-        if (time_diff < 0) {
-            /* This should not happen with proactive logic, but handle gracefully */
-            ESP_LOGE(TAG, "Solar schedule time calculation error for %s (got %" PRId32 " seconds)", schedule_name, time_diff);
-            return 0;
-        }
-
-        /* Store the final scheduled time - use raw UTC solar time for ts field (phone apps need UTC) */
-        trigger->next_scheduled_time_utc = solar_time;
-
-        return time_diff;
-    }
-#endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
-
-    localtime_r(&now, &current_time);
-
-    /* Get schedule time */
-    localtime_r(&now, &schedule_time);
-    schedule_time.tm_sec = 0;
-    schedule_time.tm_min = trigger->minutes;
-    schedule_time.tm_hour = trigger->hours;
-    mktime(&schedule_time);
-
-    /* Adjust schedule day */
-    if (trigger->type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
-        int no_of_days = 0;
-        no_of_days = esp_schedule_get_no_of_days(trigger, &current_time, &schedule_time);
-        schedule_time.tm_sec += no_of_days * SECONDS_IN_DAY;
-    }
-    if (trigger->type == ESP_SCHEDULE_TYPE_DATE) {
-        schedule_time.tm_mday = trigger->date.day;
-        schedule_time.tm_mon = esp_schedule_get_next_month(trigger, &current_time, &schedule_time) - 1;
-        schedule_time.tm_year = esp_schedule_get_next_year(trigger, &current_time, &schedule_time) - 1900;
-        if (schedule_time.tm_mon < 0) {
-            ESP_LOGE(TAG, "Invalid month found: %d. Setting it to next month.", schedule_time.tm_mon);
-            schedule_time.tm_mon = current_time.tm_mon + 1;
-        }
-        if (schedule_time.tm_mon >= 12) {
-            schedule_time.tm_year += schedule_time.tm_mon / 12;
-            schedule_time.tm_mon = schedule_time.tm_mon % 12;
-        }
-    }
-    mktime(&schedule_time);
-
-    /* Adjust time according to DST */
-    time_t dst_adjust = 0;
-    if (!current_time.tm_isdst && schedule_time.tm_isdst) {
-        dst_adjust = -3600;
-    } else if (current_time.tm_isdst && !schedule_time.tm_isdst) {
-        dst_adjust = 3600;
-    }
-    ESP_LOGD(TAG, "DST adjust seconds: %lld", (long long) dst_adjust);
-    schedule_time.tm_sec += dst_adjust;
-    mktime(&schedule_time);
-
-    /* Print schedule time */
-    memset(time_str, 0, sizeof(time_str));
-    strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
-    ESP_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule_name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
-
-    /* Calculate difference */
-    time_diff = difftime((mktime(&schedule_time)), mktime(&current_time));
-
-    /* For one time schedules to check for expiry after a reboot. If NVS is enabled, this should be stored in NVS. */
-    trigger->next_scheduled_time_utc = mktime(&schedule_time);
-
-    return time_diff;
-}
-
-static bool esp_schedule_is_expired(esp_schedule_trigger_t *trigger)
-{
-    time_t current_timestamp = 0;
-    struct tm current_time = {0};
-    time(&current_timestamp);
-    localtime_r(&current_timestamp, &current_time);
-
-    if (trigger->type == ESP_SCHEDULE_TYPE_RELATIVE) {
-        if (trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= current_timestamp) {
-            /* Relative seconds based schedule has expired */
-            return true;
-        } else if (trigger->next_scheduled_time_utc == 0) {
-            /* Schedule has been disabled, so it is as good as expired. */
-            return true;
-        }
-    } else if (trigger->type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
-        if (trigger->day.repeat_days == ESP_SCHEDULE_DAY_ONCE) {
-            if (trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= current_timestamp) {
-                /* One time schedule has expired */
-                return true;
-            } else if (trigger->next_scheduled_time_utc == 0) {
-                /* Schedule has been disabled, so it is as good as expired. */
-                return true;
-            }
-        }
-#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
-    } else if (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE || trigger->type == ESP_SCHEDULE_TYPE_SUNSET) {
-        /* Check if this is a single-time solar schedule */
-        if (trigger->date.day == 0 && trigger->day.repeat_days == 0) {
-            if (trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= current_timestamp) {
-                /* One time solar schedule has expired */
-                return true;
-            } else if (trigger->next_scheduled_time_utc == 0) {
-                /* Schedule has been disabled, so it is as good as expired. */
-                return true;
-            }
-        }
-        /* Repeating solar schedules (day-of-week or date-based) never expire - they recalculate */
-#endif
-    } else if (trigger->type == ESP_SCHEDULE_TYPE_DATE) {
-        if (trigger->date.repeat_months == 0) {
-            if (trigger->next_scheduled_time_utc > 0 && trigger->next_scheduled_time_utc <= current_timestamp) {
-                /* One time schedule has expired */
-                return true;
-            } else {
+        if (validity) {
+            if ((validity->start_time && trigger->next_scheduled_time_utc < validity->start_time) ||
+                    (validity->end_time && trigger->next_scheduled_time_utc > validity->end_time)) {
+                trigger->next_scheduled_time_utc = 0;
                 return false;
             }
         }
-        if (trigger->date.repeat_every_year == true) {
+        return (trigger->next_scheduled_time_utc > now);
+    }
+
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    /* Handle solar-based schedules (sunrise/sunset) */
+    if (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE || trigger->type == ESP_SCHEDULE_TYPE_SUNSET) {
+        time_t solar_time = esp_schedule_get_next_valid_solar_time(now, trigger, validity, schedule_name);
+        if (solar_time == 0) {
+            ESP_LOGW(TAG, "Solar schedule %s has no next occurrence (no sunrise/sunset at this location/date, no remaining matching day, or past the validity window). Enable debug logs for the cause.", schedule_name);
             return false;
         }
 
-        struct tm schedule_time = {0};
-        localtime_r(&current_timestamp, &schedule_time);
-        schedule_time.tm_sec = 0;
-        schedule_time.tm_min = trigger->minutes;
-        schedule_time.tm_hour = trigger->hours;
-        schedule_time.tm_mday = trigger->date.day;
-        /* For expiry, just check the last month of the repeat_months. */
-        /* '-1' because struct tm has months starting from 0 and we have months starting from 1. */
-        schedule_time.tm_mon = fls(trigger->date.repeat_months) - 1;
-        /* '-1900' because struct tm has number of years after 1900 */
-        schedule_time.tm_year = trigger->date.year - 1900;
-        time_t schedule_timestamp = mktime(&schedule_time);
-
-        if (schedule_timestamp < current_timestamp) {
-            return true;
-        }
-    } else {
-        /* Invalid type. Mark as expired */
-        return true;
+        trigger->next_scheduled_time_utc = solar_time;
+        return (trigger->next_scheduled_time_utc > now);
     }
-    return false;
+#endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
+
+    /* Unified DATE and DAYS_OF_WEEK using date finder */
+    time_t next_time = 0;
+    bool ok = false;
+    uint16_t minutes_since_midnight = (uint16_t)(trigger->hours * 60 + trigger->minutes);
+    if (trigger->type == ESP_SCHEDULE_TYPE_DATE) {
+        /* DATE has no day-of-week arm, so 0 is passed for it. The year constraint
+         * comes from esp_schedule_date_arm_match_year(). */
+        ok = esp_schedule_get_next_date_time(now, minutes_since_midnight, 0, trigger->date.day, trigger->date.repeat_months, esp_schedule_date_arm_match_year(trigger, now), validity, &next_time);
+    } else if (trigger->type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
+        ok = esp_schedule_get_next_date_time(now, minutes_since_midnight, trigger->day.repeat_days, 0, 0, 0, validity, &next_time);
+    }
+    if (!ok || next_time == 0) {
+        return false;
+    }
+    trigger->next_scheduled_time_utc = next_time;
+    return (trigger->next_scheduled_time_utc > now);
+}
+
+/*
+ * Compute the seconds until the next occurrence of this schedule's single
+ * trigger, updating trigger->next_scheduled_time_utc. Returns 0 if there is no
+ * valid future occurrence (expired, disabled, or calculation failed).
+ */
+static uint32_t esp_schedule_get_next_schedule_time_diff(esp_schedule_t *schedule)
+{
+    time_t now;
+    time(&now);
+
+    if (!esp_schedule_set_next_scheduled_time_utc(schedule->name, &schedule->trigger, &schedule->validity)) {
+        schedule->trigger.next_scheduled_time_utc = 0;
+        return 0;
+    }
+    if (schedule->trigger.next_scheduled_time_utc <= now) {
+        return 0;
+    }
+
+    /* Print chosen schedule time once */
+    char time_str[64];
+    struct tm schedule_time;
+    localtime_r(&schedule->trigger.next_scheduled_time_utc, &schedule_time);
+    memset(time_str, 0, sizeof(time_str));
+    strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
+    ESP_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule->name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
+
+    /* Clamp before the uint32_t cast: casting a double outside uint32_t range is
+     * undefined behavior. */
+    double diff = difftime(schedule->trigger.next_scheduled_time_utc, now);
+    if (diff < 0) {
+        diff = 0;
+    } else if (diff > (double)UINT32_MAX) {
+        diff = (double)UINT32_MAX;
+    }
+    return (uint32_t)diff;
 }
 
 static void esp_schedule_stop_timer(esp_schedule_t *schedule)
 {
     xTimerStop(schedule->timer, portMAX_DELAY);
+}
+
+/*
+ * Arm the FreeRTOS software timer for the given number of seconds. The period
+ * is computed in 64-bit and clamped so that a large seconds value cannot
+ * overflow the 32-bit tick math ((seconds * 1000) used to overflow for diffs
+ * beyond ~49 days). If the requested delay exceeds what a single TickType_t
+ * period can represent, it is clamped; esp_schedule_common_timer_cb re-arms for
+ * the remaining time when it detects an early expiry.
+ */
+static void esp_schedule_arm_timer(esp_schedule_t *schedule, uint32_t seconds)
+{
+    uint64_t ticks = ((uint64_t)seconds * 1000ULL) / (uint64_t)portTICK_PERIOD_MS;
+    if (ticks == 0) {
+        ticks = 1;
+    }
+    /* portMAX_DELAY is the maximum representable period. Clamp to one below it so
+     * it is never confused with the "block forever" sentinel. */
+    const uint64_t max_ticks = (uint64_t)portMAX_DELAY - 1;
+    if (ticks > max_ticks) {
+        ticks = max_ticks;
+    }
+    xTimerStop(schedule->timer, portMAX_DELAY);
+    xTimerChangePeriod(schedule->timer, (TickType_t)ticks, portMAX_DELAY);
 }
 
 static void esp_schedule_start_timer(esp_schedule_t *schedule)
@@ -554,15 +681,26 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
     time(&current_time);
     if (current_time < SECONDS_TILL_2020) {
         ESP_LOGE(TAG, "Time is not updated");
+        /* Time is no longer valid (e.g. RTC lost). Stop any already-armed timer
+         * and clear the chosen time so we don't keep firing on a stale diff. It
+         * will be recomputed once time is synced and the schedule re-enabled. */
+        if (schedule->timer) {
+            esp_schedule_stop_timer(schedule);
+        }
+        schedule->trigger.next_scheduled_time_utc = 0;
         return;
     }
 
-    schedule->next_scheduled_time_diff = esp_schedule_get_next_schedule_time_diff(schedule->name, &schedule->trigger);
+    schedule->next_scheduled_time_diff = esp_schedule_get_next_schedule_time_diff(schedule);
 
     /* Check if schedule calculation failed (returns 0) */
     if (schedule->next_scheduled_time_diff == 0) {
         ESP_LOGW(TAG, "Schedule %s calculation failed or returned invalid time. Skipping timer creation.", schedule->name);
-        /* Reset timestamp to indicate schedule is not active */
+        /* Stop any already-armed timer so a stale diff cannot still fire, then
+         * reset timestamp to indicate schedule is not active */
+        if (schedule->timer) {
+            esp_schedule_stop_timer(schedule);
+        }
         schedule->trigger.next_scheduled_time_utc = 0;
         return;
     }
@@ -570,11 +708,10 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
     ESP_LOGI(TAG, "Starting a timer for %"PRIu32" seconds for schedule %s", schedule->next_scheduled_time_diff, schedule->name);
 
     if (schedule->timestamp_cb) {
-        schedule->timestamp_cb((esp_schedule_handle_t)schedule, schedule->trigger.next_scheduled_time_utc, schedule->priv_data);
+        schedule->timestamp_cb((esp_schedule_handle_t)schedule, (uint32_t)schedule->trigger.next_scheduled_time_utc, schedule->priv_data);
     }
 
-    xTimerStop(schedule->timer, portMAX_DELAY);
-    xTimerChangePeriod(schedule->timer, (schedule->next_scheduled_time_diff * 1000) / portTICK_PERIOD_MS, portMAX_DELAY);
+    esp_schedule_arm_timer(schedule, schedule->next_scheduled_time_diff);
 }
 
 static void esp_schedule_common_timer_cb(TimerHandle_t timer)
@@ -584,42 +721,36 @@ static void esp_schedule_common_timer_cb(TimerHandle_t timer)
         return;
     }
     esp_schedule_t *schedule = (esp_schedule_t *)priv_data;
-    time_t now;
+
+    /* Guard against a premature timer expiry: if the scheduled instant has not
+     * actually arrived (e.g. tick truncation on a very long delay that had to be
+     * clamped), re-arm for the remaining time instead of firing early.
+     * esp_schedule_start_timer recomputes the diff from the still-future
+     * next_scheduled_time_utc, so it re-arms for what remains. */
+    time_t now = 0;
     time(&now);
-    struct tm validity_time;
-    char time_str[64] = {0};
-    if (schedule->validity.start_time != 0) {
-        if (now < schedule->validity.start_time) {
-            memset(time_str, 0, sizeof(time_str));
-            localtime_r(&schedule->validity.start_time, &validity_time);
-            strftime(time_str, sizeof(time_str), "%c %z[%Z]", &validity_time);
-            ESP_LOGW(TAG, "Schedule %s skipped. It will be active only after: %s. DST: %s.", schedule->name, time_str, validity_time.tm_isdst ? "Yes" : "No");
-            /* TODO: Start the timer such that the next time it triggers, it will be within the valid window.
-             * Currently, it will just keep triggering and then get skipped if not in valid range.
-             */
-            goto restart_schedule;
-        }
+    if (schedule->trigger.next_scheduled_time_utc > now) {
+        ESP_LOGW(TAG, "Schedule %s fired early; rescheduling for the remaining time", schedule->name);
+        esp_schedule_start_timer(schedule);
+        return;
     }
-    if (schedule->validity.end_time != 0) {
-        if (now > schedule->validity.end_time) {
-            localtime_r(&schedule->validity.end_time, &validity_time);
-            strftime(time_str, sizeof(time_str), "%c %z[%Z]", &validity_time);
-            ESP_LOGW(TAG, "Schedule %s skipped. It can't be active after: %s. DST: %s.", schedule->name, time_str, validity_time.tm_isdst ? "Yes" : "No");
-            /* Return from here will ensure that the timer does not start again for this schedule */
-            return;
-        }
+
+    /* Re-check the validity window at fire time. The occurrence was computed to
+     * be within [start,end], but callback dispatch can be delayed past end_time
+     * (tick truncation, timer-queue latency, system load). Suppress a trigger
+     * that is now outside the window; the re-arm below will find no further
+     * valid occurrence and leave the schedule disarmed. */
+    if (schedule->validity.end_time != 0 && now > schedule->validity.end_time) {
+        ESP_LOGW(TAG, "Schedule %s expired before dispatch; suppressing out-of-window trigger", schedule->name);
+        esp_schedule_start_timer(schedule);
+        return;
     }
+
     ESP_LOGI(TAG, "Schedule %s triggered", schedule->name);
     if (schedule->trigger_cb) {
         schedule->trigger_cb((esp_schedule_handle_t)schedule, schedule->priv_data);
     }
 
-restart_schedule:
-
-    if (esp_schedule_is_expired(&schedule->trigger)) {
-        /* Not deleting the schedule here. Just not starting it again. */
-        return;
-    }
     esp_schedule_start_timer(schedule);
 }
 
@@ -630,9 +761,15 @@ static void esp_schedule_delete_timer(esp_schedule_t *schedule)
 
 static void esp_schedule_create_timer(esp_schedule_t *schedule)
 {
-    if (esp_schedule_nvs_is_enabled()) {
-        /* This is just used for calculating next_scheduled_time_utc for ESP_SCHEDULE_DAY_ONCE (in case of ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) or for ESP_SCHEDULE_MONTH_ONCE (in case of ESP_SCHEDULE_TYPE_DATE), and only used when NVS is enabled. And if NVS is enabled, time will already be synced and the time will be correctly calculated. */
-        schedule->next_scheduled_time_diff = esp_schedule_get_next_schedule_time_diff(schedule->name, &schedule->trigger);
+    /* RELATIVE only: computing the diff here anchors the absolute target at
+     * create time (the target is computed once and then reused, see
+     * esp_schedule_set_next_scheduled_time_utc), and makes it readable via
+     * esp_schedule_get() before the schedule is enabled. Every other type is
+     * recomputed from scratch in esp_schedule_start_timer(), so precomputing
+     * here would only duplicate work. NVS-enabled implies time is already
+     * synced, so the calculation is valid. */
+    if (schedule->trigger.type == ESP_SCHEDULE_TYPE_RELATIVE && esp_schedule_nvs_is_enabled()) {
+        schedule->next_scheduled_time_diff = esp_schedule_get_next_schedule_time_diff(schedule);
     }
 
     /* Temporarily setting the timer for 1 (anything greater than 0) tick. This will get changed when xTimerChangePeriod() is called. */
@@ -653,13 +790,29 @@ esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *
     schedule_config->trigger.type = schedule->trigger.type;
     schedule_config->trigger.hours = schedule->trigger.hours;
     schedule_config->trigger.minutes = schedule->trigger.minutes;
-    if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
+    if (schedule->trigger.type == ESP_SCHEDULE_TYPE_RELATIVE) {
+        schedule_config->trigger.relative_seconds = schedule->trigger.relative_seconds;
+        schedule_config->trigger.next_scheduled_time_utc = schedule->trigger.next_scheduled_time_utc;
+    } else if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
         schedule_config->trigger.day.repeat_days = schedule->trigger.day.repeat_days;
     } else if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DATE) {
+        schedule_config->trigger.day.repeat_days = schedule->trigger.day.repeat_days;
         schedule_config->trigger.date.day = schedule->trigger.date.day;
         schedule_config->trigger.date.repeat_months = schedule->trigger.date.repeat_months;
         schedule_config->trigger.date.year = schedule->trigger.date.year;
         schedule_config->trigger.date.repeat_every_year = schedule->trigger.date.repeat_every_year;
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    } else if (schedule->trigger.type == ESP_SCHEDULE_TYPE_SUNRISE || schedule->trigger.type == ESP_SCHEDULE_TYPE_SUNSET) {
+        /* Solar carries the same day/date pattern as DATE, plus location. */
+        schedule_config->trigger.day.repeat_days = schedule->trigger.day.repeat_days;
+        schedule_config->trigger.date.day = schedule->trigger.date.day;
+        schedule_config->trigger.date.repeat_months = schedule->trigger.date.repeat_months;
+        schedule_config->trigger.date.year = schedule->trigger.date.year;
+        schedule_config->trigger.date.repeat_every_year = schedule->trigger.date.repeat_every_year;
+        schedule_config->trigger.solar.latitude = schedule->trigger.solar.latitude;
+        schedule_config->trigger.solar.longitude = schedule->trigger.solar.longitude;
+        schedule_config->trigger.solar.offset_minutes = schedule->trigger.solar.offset_minutes;
+#endif
     }
 
     schedule_config->trigger_cb = schedule->trigger_cb;
@@ -676,6 +829,14 @@ esp_err_t esp_schedule_enable(esp_schedule_handle_t handle)
     }
     esp_schedule_t *schedule = (esp_schedule_t *)handle;
     esp_schedule_start_timer(schedule);
+    /* Persist the armed target of a one-shot schedule: create/edit store it while
+     * it is still 0, which is indistinguishable from "never armed", so a reboot
+     * after it fired would recompute and re-arm it (see
+     * esp_schedule_trigger_fired_and_done). Repeating triggers never consult the
+     * stored value, so they are not written. */
+    if (schedule->trigger.next_scheduled_time_utc > 0 && esp_schedule_trigger_is_one_shot(&schedule->trigger)) {
+        esp_schedule_nvs_add(schedule);
+    }
     return ESP_OK;
 }
 
@@ -693,6 +854,19 @@ esp_err_t esp_schedule_disable(esp_schedule_handle_t handle)
     return ESP_OK;
 }
 
+/*
+ * Validate the time-of-day fields. RELATIVE schedules do not use hours/minutes.
+ * An out-of-range value would otherwise be silently normalized by mktime() into
+ * a following day, landing on a day that violates the configured day/month mask.
+ */
+static bool esp_schedule_config_time_of_day_is_valid(const esp_schedule_config_t *schedule_config)
+{
+    if (schedule_config->trigger.type == ESP_SCHEDULE_TYPE_RELATIVE) {
+        return true;
+    }
+    return (schedule_config->trigger.hours < 24 && schedule_config->trigger.minutes < 60);
+}
+
 static esp_err_t esp_schedule_set(esp_schedule_t *schedule, esp_schedule_config_t *schedule_config)
 {
     /* Setting everything apart from name. */
@@ -707,6 +881,7 @@ static esp_err_t esp_schedule_set(esp_schedule_t *schedule, esp_schedule_config_
         if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
             schedule->trigger.day.repeat_days = schedule_config->trigger.day.repeat_days;
         } else if (schedule->trigger.type == ESP_SCHEDULE_TYPE_DATE) {
+            schedule->trigger.day.repeat_days = schedule_config->trigger.day.repeat_days;
             schedule->trigger.date.day = schedule_config->trigger.date.day;
             schedule->trigger.date.repeat_months = schedule_config->trigger.date.repeat_months;
             schedule->trigger.date.year = schedule_config->trigger.date.year;
@@ -743,6 +918,16 @@ esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t 
     if (strncmp(schedule->name, schedule_config->name, sizeof(schedule->name)) != 0) {
         ESP_LOGE(TAG, "Schedule name mismatch. Expected: %s, Passed: %s", schedule->name, schedule_config->name);
         return ESP_FAIL;
+    }
+
+    if (!esp_schedule_config_time_of_day_is_valid(schedule_config)) {
+        ESP_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
+                 schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!esp_schedule_trigger_is_valid(&schedule_config->trigger, schedule_config->name)) {
+        return ESP_ERR_INVALID_ARG;
     }
 
     /* Editing a schedule with relative time should also reset it. */
@@ -785,6 +970,16 @@ esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config
         return NULL;
     }
 
+    if (!esp_schedule_config_time_of_day_is_valid(schedule_config)) {
+        ESP_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
+                 schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
+        return NULL;
+    }
+
+    if (!esp_schedule_trigger_is_valid(&schedule_config->trigger, schedule_config->name)) {
+        return NULL;
+    }
+
     esp_schedule_t *schedule = (esp_schedule_t *)MEM_CALLOC_EXTRAM(1, sizeof(esp_schedule_t));
     if (schedule == NULL) {
         ESP_LOGE(TAG, "Could not allocate handle");
@@ -812,6 +1007,11 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
         return NULL;
     }
 
+    if (schedule_count == NULL) {
+        ESP_LOGE(TAG, "schedule_count cannot be NULL when NVS is enabled");
+        return NULL;
+    }
+
     /* Wait for time to be updated here */
 
     /* Below this is initialising schedules from NVS */
@@ -833,10 +1033,15 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
         schedule->trigger_cb = NULL;
         schedule->timestamp_cb = NULL;
         schedule->timer = NULL;
-        /* Check for ONCE and expired schedules and delete them. */
-        if (esp_schedule_is_expired(&schedule->trigger)) {
-            /* This schedule has already expired. */
-            ESP_LOGI(TAG, "Schedule %s does not repeat and has already expired. Deleting it.", schedule->name);
+        /* Drop schedules we cannot arm: a stored config may have been written by
+         * an older version that accepted combinations now rejected, and a
+         * schedule with no valid future occurrence (already-fired one-shot, or a
+         * year bounded in the past) is expired. */
+        bool has_future = esp_schedule_trigger_is_valid(&schedule->trigger, schedule->name) &&
+                          esp_schedule_set_next_scheduled_time_utc(schedule->name, &schedule->trigger, &schedule->validity);
+        if (!has_future) {
+            /* This schedule is invalid or has already expired. */
+            ESP_LOGI(TAG, "Schedule %s cannot be armed (invalid config, or does not repeat and has already expired). Deleting it.", schedule->name);
             esp_schedule_delete((esp_schedule_handle_t)schedule);
             /* Removing the schedule from the list */
             handle_list[handle_count] = handle_list[*schedule_count - 1];

--- a/esp_schedule/src/esp_schedule_internal.h
+++ b/esp_schedule/src/esp_schedule_internal.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,8 +34,62 @@ typedef struct esp_schedule {
     esp_schedule_validity_t validity;
 } esp_schedule_t;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 esp_err_t esp_schedule_nvs_add(esp_schedule_t *schedule);
 esp_err_t esp_schedule_nvs_remove(esp_schedule_t *schedule);
+esp_err_t esp_schedule_nvs_remove_all(void);
 esp_schedule_handle_t *esp_schedule_nvs_get_all(uint8_t *schedule_count);
 bool esp_schedule_nvs_is_enabled(void);
 esp_err_t esp_schedule_nvs_init(char *nvs_partition);
+
+/* Returns true if the trigger configuration is valid, i.e. it sets no field its
+ * type does not read and no combination without a coherent reading. Logs the
+ * offending field(s) on rejection. Exposed for unit testing. */
+bool esp_schedule_trigger_is_valid(const esp_schedule_trigger_t *trigger, const char *schedule_name);
+
+/* Year constraint the date arm passes to the date engine: date.year when set,
+ * 0 when the pattern recurs every year or fires once, and the current year for a
+ * months mask with neither. Exposed for unit testing. */
+uint16_t esp_schedule_date_arm_match_year(const esp_schedule_trigger_t *trigger, time_t now);
+
+/* Returns true if a one-shot trigger has already fired and must not be
+ * recomputed to a future occurrence. Exposed for unit testing. */
+bool esp_schedule_trigger_fired_and_done(const esp_schedule_trigger_t *trigger, time_t now);
+
+/* Unified date-based next occurrence calculation. Returns true and sets
+ * *next_time to the next valid time matching all provided constraints.
+ * Shared across implementation files and exposed for unit testing. */
+bool esp_schedule_get_next_date_time(
+    time_t now,
+    uint16_t minutes_since_midnight,
+    uint8_t days_of_week_mask,
+    uint8_t day_of_month,
+    uint16_t months_of_year_mask,
+    uint16_t year,
+    const esp_schedule_validity_t *validity,
+    time_t *next_time
+);
+
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+time_t esp_schedule_calc_solar_time_for_time_utc(
+    bool is_sunrise,
+    time_t time_utc,
+    double latitude,
+    double longitude,
+    int offset_minutes
+);
+
+time_t esp_schedule_get_next_valid_solar_time(
+    time_t now,
+    const esp_schedule_trigger_t *trigger,
+    const esp_schedule_validity_t *validity,
+    const char *schedule_name
+);
+#endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp_schedule/test_app/CMakeLists.txt
+++ b/esp_schedule/test_app/CMakeLists.txt
@@ -1,0 +1,5 @@
+# This is the project CMakeLists.txt file for the test subproject
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp_schedule_test)

--- a/esp_schedule/test_app/main/CMakeLists.txt
+++ b/esp_schedule/test_app/main/CMakeLists.txt
@@ -1,0 +1,9 @@
+# The tests exercise the component's internal helpers (esp_schedule_internal.h),
+# so the component's private src/ directory is added to the include path. The
+# esp_schedule dependency itself is pulled in via main/idf_component.yml.
+set(_srcs "test_app_main.c" "test_esp_schedule.c")
+idf_component_register(SRCS ${_srcs}
+                    PRIV_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../src"
+                    PRIV_REQUIRES "esp_daylight" "unity" "nvs_flash" "esp_netif"
+                    WHOLE_ARCHIVE
+                    )

--- a/esp_schedule/test_app/main/idf_component.yml
+++ b/esp_schedule/test_app/main/idf_component.yml
@@ -1,0 +1,4 @@
+dependencies:
+  espressif/esp_schedule:
+    version: '*'
+    override_path: '../../.'

--- a/esp_schedule/test_app/main/test_app_main.c
+++ b/esp_schedule/test_app/main/test_app_main.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include "unity.h"
+#include "esp_err.h"
+#include "nvs_flash.h"
+#include "esp_schedule_internal.h"
+
+// NVS initialization for tests
+static void init_nvs_for_tests(void)
+{
+    // Initialize NVS flash storage with specific partition
+    esp_err_t err = nvs_flash_init_partition("nvs");
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        // NVS partition was truncated or has new version - erase and reinitialize
+        ESP_ERROR_CHECK(nvs_flash_erase_partition("nvs"));
+        err = nvs_flash_init_partition("nvs");
+    }
+    ESP_ERROR_CHECK(err);
+
+    // Initialize NVS for schedules
+    esp_err_t nvs_init_result = esp_schedule_nvs_init("nvs");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(ESP_OK, nvs_init_result, "NVS initialization should succeed");
+
+    // Check if NVS is enabled
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_nvs_is_enabled(), "NVS should be enabled");
+}
+
+void app_main(void)
+{
+    printf("Running esp_schedule component tests\n");
+    init_nvs_for_tests();
+    unity_run_menu();
+}

--- a/esp_schedule/test_app/main/test_esp_schedule.c
+++ b/esp_schedule/test_app/main/test_esp_schedule.c
@@ -1,0 +1,1588 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include "esp_err.h"
+#include "esp_netif.h"
+#include "esp_log.h"
+#include "unity.h"
+#include "esp_schedule_internal.h"
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+#include "esp_daylight.h"
+#endif
+
+static const char *TAG = "test_app";
+
+static void print_time(const char *label, time_t t)
+{
+    struct tm tm_local;
+    localtime_r(&t, &tm_local);
+    char buf[64];
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %z[%Z]", &tm_local);
+    ESP_LOGI(TAG, "%s: %s (%ld)", label, buf, (long)t);
+}
+
+/* Builds an epoch time_t from a broken-down LOCAL wall-clock time (mktime
+ * interprets tm in the active TZ, not UTC). Tests build both `now` and expected
+ * instants with this same helper, so comparisons stay TZ-independent; the DST
+ * tests set TZ=NY on purpose to exercise wall-clock behavior. */
+static time_t make_time_local(int year, int mon, int mday, int hour, int min, int sec)
+{
+    struct tm tmv = {0};
+    tmv.tm_year = year - 1900;
+    tmv.tm_mon = mon - 1;
+    tmv.tm_mday = mday;
+    tmv.tm_hour = hour;
+    tmv.tm_min = min;
+    tmv.tm_sec = sec;
+    tmv.tm_isdst = -1; /* let mktime resolve DST for the active timezone */
+    return mktime(&tmv);
+}
+
+static void assert_time_eq(const char *name, time_t got, time_t want)
+{
+    if (got != want) {
+        print_time("got ", got);
+        print_time("want", want);
+    }
+    TEST_ASSERT_TRUE_MESSAGE(got == want, name);
+}
+
+// --- Date permutations ---
+TEST_CASE("date permutations", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 1, 16, 12, 0, 0); // Thu
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 365 * 24 * 3600 };
+
+    // 17th at 00:24
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, /*00:24*/24, /*days_of_week*/0, /*day_of_month*/17, /*months*/0, /*year*/0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date: 17th 00:24");
+    assert_time_eq("date: 17th 00:24", next_ts, make_time_local(2025, 1, 17, 0, 24, 0));
+
+    // Specific month mask (Jan, Mar) on 20th at 08:00 => Jan 20 since we're in Jan
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 8 * 60, 0, 20, (1u << 0) | (1u << 2), 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date: month mask Jan/Mar day=20 08:00");
+    assert_time_eq("date: month mask Jan/Mar day=20 08:00", next_ts, make_time_local(2025, 1, 20, 8, 0, 0));
+
+    // Specific year constraint (2026) day 5 at 09:15
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 9 * 60 + 15, 0, 5, 0, 2026, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date: year=2026 day=5 09:15");
+    assert_time_eq("date: year=2026 day=5 09:15", next_ts, make_time_local(2026, 1, 5, 9, 15, 0));
+}
+
+// --- More date permutations (day-31 across months, year rollover) ---
+TEST_CASE("date permutations more", "[esp_schedule]")
+{
+    // Day=31 with months mask including a 30-day month (Apr) and 31-day month (May).
+    // Regression: a day-31 schedule must NOT fire on a normalized Mar/May-1 after a
+    // short month; it must land on May 31.
+    time_t now = make_time_local(2025, 4, 29, 10, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 400 * 24 * 3600 };
+
+    time_t next_ts = 0; bool ok = esp_schedule_get_next_date_time(now, 6 * 60, 0, 31, (1u << 3) | (1u << 4), 0, &validity, &next_ts); // Apr(3), May(4)
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date: 31st across months");
+    assert_time_eq("date: 31st across months -> May 31 06:00", next_ts, make_time_local(2025, 5, 31, 6, 0, 0));
+
+    // Month rollover year: months {Nov, Dec, Jan}, day=1 at 00:00 from Dec 31
+    now = make_time_local(2025, 12, 31, 23, 30, 0);
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 0, 0, 1, (1u << 10) | (1u << 11) | (1u << 0), 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date: Nov/Dec/Jan day=1 at year boundary");
+    assert_time_eq("date: Nov/Dec/Jan day=1 -> Jan 1 00:00", next_ts, make_time_local(2026, 1, 1, 0, 0, 0));
+}
+
+// --- Feb 29 in non-leap years must skip to the next leap Feb 29 ---
+TEST_CASE("date feb29 non leap", "[esp_schedule]")
+{
+    // From Mar 2025 (non-leap), a Feb-29 schedule must NOT fire on Mar 1 2026;
+    // it must land on Feb 29 2028 (next leap year).
+    time_t now = make_time_local(2025, 3, 1, 12, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 1500L * 24 * 3600 };
+
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 9 * 60, 0, 29, ESP_SCHEDULE_MONTH_FEBRUARY, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date: Feb 29 skips non-leap years");
+    assert_time_eq("date: Feb 29 -> 2028-02-29 09:00", next_ts, make_time_local(2028, 2, 29, 9, 0, 0));
+
+    /* Worst satisfiable case for the search horizon (§1.2 step 6): 2100 is not a
+     * leap year, so from Mar 2096 the next Feb 29 is 2104 - an 8-year gap, which
+     * the month-attempt budget must still cover. Needs a 64-bit time_t. */
+    if (sizeof(time_t) > 4) {
+        time_t far = make_time_local(2096, 3, 1, 12, 0, 0);
+        esp_schedule_validity_t wide = { .start_time = 0, .end_time = 0 };
+        next_ts = 0;
+        ok = esp_schedule_get_next_date_time(far, 9 * 60, 0, 29, ESP_SCHEDULE_MONTH_FEBRUARY, 0, &wide, &next_ts);
+        TEST_ASSERT_TRUE_MESSAGE(ok, "date: Feb 29 across the 8-year leap gap");
+        assert_time_eq("date: Feb 29 -> 2104-02-29 09:00", next_ts, make_time_local(2104, 2, 29, 9, 0, 0));
+    }
+}
+
+// --- Day of week ---
+TEST_CASE("day of week", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 1, 16, 7, 45, 0); // Thu 07:45
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 30 * 24 * 3600 };
+
+    uint8_t days_of_week = (1 << 0) | (1 << 1); // Mon/Tue
+    time_t next_ts = 0; bool ok = esp_schedule_get_next_date_time(now, 8 * 60 + 30, days_of_week, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "dow: Mon/Tue 08:30");
+    assert_time_eq("dow: Mon/Tue 08:30", next_ts, make_time_local(2025, 1, 20, 8, 30, 0));
+}
+
+// --- Caller-side OR of two independent single-arm schedules ---
+// NOTE: this exercises CALLER composition (min of two separate engine calls),
+// NOT the engine's built-in dow|dom OR. The engine's own union is covered by
+// "date type dow or dom".
+TEST_CASE("caller or two single-arm schedules", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 1, 16, 7, 45, 0); // Thu 07:45
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 40 * 24 * 3600 };
+
+    uint8_t days_of_week = (1 << 0) | (1 << 1);
+    time_t a = 0, b = 0; bool ok_a, ok_b;
+    ok_a = esp_schedule_get_next_date_time(now, 9 * 60, days_of_week, 0, 0, 0, &validity, &a);
+    ok_b = esp_schedule_get_next_date_time(now, 30, 0, 17, 0, 0, &validity, &b);
+    TEST_ASSERT_TRUE_MESSAGE(ok_a && ok_b, "caller-or: Mon/Tue 09:00 OR 17th 00:30");
+
+    time_t chosen = (a < b) ? a : b;
+    assert_time_eq("caller-or: Mon/Tue 09:00 OR 17th 00:30", chosen, make_time_local(2025, 1, 17, 0, 30, 0));
+}
+
+// --- Engine-internal: the day-of-week / day-of-month union ---
+// NOTE: no trigger configuration can reach this. Both day arms set is rejected
+// (rule V2) for DATE and for solar, so the engine's OR of the two arms is dead
+// code from the caller's point of view. This test pins the engine contract only;
+// the rejection of these shapes is covered by "trigger validation truth
+// table".
+TEST_CASE("date type dow or dom", "[esp_schedule]")
+{
+    /* Thu Jan 16 2025 07:45. Passing both a DOW mask (Mon) and a day-of-month
+     * (17th) selects the union: the nearer of next Mon or the 17th. From Thu,
+     * the 17th (Fri) comes before Mon the 20th. */
+    time_t now = make_time_local(2025, 1, 16, 7, 45, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 40 * 24 * 3600 };
+
+    uint8_t dow = ESP_SCHEDULE_DAY_MONDAY;
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 9 * 60, dow, 17, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date-dow-or-dom: Mon OR 17th 09:00");
+    assert_time_eq("date-dow-or-dom: 17th before next Mon", next_ts, make_time_local(2025, 1, 17, 9, 0, 0));
+
+    /* Next occurrence after the 17th is Monday the 20th (the DOW arm). */
+    time_t t2 = 0;
+    ok = esp_schedule_get_next_date_time(next_ts, 9 * 60, dow, 17, 0, 0, &validity, &t2);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date-dow-or-dom: next is Mon 20th");
+    assert_time_eq("date-dow-or-dom: Mon 20th", t2, make_time_local(2025, 1, 20, 9, 0, 0));
+
+    /* Union scoped by a months mask: Mon OR the 15th, but only in June.
+     * From January the first hit is the first June Monday (Jun 2), which is
+     * earlier than June 15. */
+    esp_schedule_validity_t val_long = { .start_time = 0, .end_time = now + 220L * 24 * 3600 };
+    time_t t3 = 0;
+    ok = esp_schedule_get_next_date_time(now, 9 * 60, dow, 15, ESP_SCHEDULE_MONTH_JUNE, 0, &val_long, &t3);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "date-dow-or-dom: Mon OR 15th in June");
+    assert_time_eq("date-dow-or-dom: first June Monday", t3, make_time_local(2025, 6, 2, 9, 0, 0));
+}
+
+// --- Engine-internal: DOW + months mask with NO day-of-month (day=0), e.g.
+//     "every Monday in June". No trigger can reach this either: a DOW mask with
+//     any date field set is rejected (rule V2), and there is no month-scoped
+//     weekday shape in the API. Engine contract only. ---
+TEST_CASE("date dow months mask", "[esp_schedule]")
+{
+    /* From January, year=0 so the pattern recurs. Validity spans ~1.5 years so
+     * the wrap into next year's June is reachable. */
+    time_t now = make_time_local(2025, 1, 10, 7, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 550L * 24 * 3600 };
+
+    /* Single DOW + months mask: every Monday in June. June 2025 Mondays:
+     * 2, 9, 16, 23, 30. First hit from January is Jun 2. */
+    time_t t1 = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 7 * 60, ESP_SCHEDULE_DAY_MONDAY, 0, ESP_SCHEDULE_MONTH_JUNE, 0, &validity, &t1);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "dow+months: first Monday in June");
+    assert_time_eq("dow+months: Jun 2 2025", t1, make_time_local(2025, 6, 2, 7, 0, 0));
+
+    time_t t2 = 0;
+    ok = esp_schedule_get_next_date_time(t1, 7 * 60, ESP_SCHEDULE_DAY_MONDAY, 0, ESP_SCHEDULE_MONTH_JUNE, 0, &validity, &t2);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "dow+months: second Monday in June");
+    assert_time_eq("dow+months: Jun 9 2025", t2, make_time_local(2025, 6, 9, 7, 0, 0));
+
+    /* From the last June Monday (Jun 30 2025), the months gate forbids any July
+     * match -> wrap to the first Monday of June 2026 (Jun 1 2026 is a Monday). */
+    time_t last_jun = make_time_local(2025, 6, 30, 7, 0, 0);
+    time_t t3 = 0;
+    ok = esp_schedule_get_next_date_time(last_jun, 7 * 60, ESP_SCHEDULE_DAY_MONDAY, 0, ESP_SCHEDULE_MONTH_JUNE, 0, &validity, &t3);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "dow+months: wraps to next June");
+    assert_time_eq("dow+months: Jun 1 2026", t3, make_time_local(2026, 6, 1, 7, 0, 0));
+
+    /* Multiple DOW + months mask: every Mon/Wed/Fri in June. June 2025:
+     * Mon 2, Wed 4, Fri 6, Mon 9, ... First three hits from January. */
+    uint8_t mwf = ESP_SCHEDULE_DAY_MONDAY | ESP_SCHEDULE_DAY_WEDNESDAY | ESP_SCHEDULE_DAY_FRIDAY;
+    time_t m1 = 0;
+    ok = esp_schedule_get_next_date_time(now, 7 * 60, mwf, 0, ESP_SCHEDULE_MONTH_JUNE, 0, &validity, &m1);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "multi-dow+months: first (Mon Jun 2)");
+    assert_time_eq("multi-dow+months: Jun 2 2025", m1, make_time_local(2025, 6, 2, 7, 0, 0));
+
+    time_t m2 = 0;
+    ok = esp_schedule_get_next_date_time(m1, 7 * 60, mwf, 0, ESP_SCHEDULE_MONTH_JUNE, 0, &validity, &m2);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "multi-dow+months: second (Wed Jun 4)");
+    assert_time_eq("multi-dow+months: Jun 4 2025", m2, make_time_local(2025, 6, 4, 7, 0, 0));
+
+    time_t m3 = 0;
+    ok = esp_schedule_get_next_date_time(m2, 7 * 60, mwf, 0, ESP_SCHEDULE_MONTH_JUNE, 0, &validity, &m3);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "multi-dow+months: third (Fri Jun 6)");
+    assert_time_eq("multi-dow+months: Jun 6 2025", m3, make_time_local(2025, 6, 6, 7, 0, 0));
+}
+
+// --- Engine-internal: EVERYDAY OR'd with a day-of-month subsumes the
+//     day-of-month (all days). Unreachable from a trigger (rule V2) — this was
+//     the footgun that motivated making the two arms exclusive. ---
+TEST_CASE("date everyday subsumes dom", "[esp_schedule]")
+{
+    /* dow=EVERYDAY covers all 7 weekdays, so OR'ing it with day-of-month=15
+     * matches EVERY day, not just the 15th. Discriminator: a bare day=15 from
+     * Jan 16 would jump to Feb 15; EVERYDAY makes it fire tomorrow (Jan 17). */
+    time_t now = make_time_local(2025, 1, 16, 12, 0, 0); // Thu 12:00
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 60L * 24 * 3600 };
+
+    time_t t1 = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 6 * 60, ESP_SCHEDULE_DAY_EVERYDAY, 15, 0, 0, &validity, &t1);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "everyday+dom: first (tomorrow, not next 15th)");
+    assert_time_eq("everyday+dom -> Jan 17 (not Feb 15)", t1, make_time_local(2025, 1, 17, 6, 0, 0));
+
+    /* Confirms daily cadence: next occurrence is the following day. */
+    time_t t2 = 0;
+    ok = esp_schedule_get_next_date_time(t1, 6 * 60, ESP_SCHEDULE_DAY_EVERYDAY, 15, 0, 0, &validity, &t2);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "everyday+dom: second (next day)");
+    assert_time_eq("everyday+dom -> Jan 18", t2, make_time_local(2025, 1, 18, 6, 0, 0));
+}
+
+// --- DATE has no day-of-week arm: a weekday pattern belongs to DAYS_OF_WEEK ---
+TEST_CASE("date type dow rejected", "[esp_schedule]")
+{
+    esp_schedule_trigger_t tr;
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DATE;
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "date_dow"),
+                              "DATE with day.repeat_days -> V2");
+
+    /* Adding a date field does not make it legal either - the arms are exclusive. */
+    tr.date.day = 15;
+    tr.date.repeat_months = ESP_SCHEDULE_MONTH_ALL;
+    tr.date.repeat_every_year = true;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "date_dow_dom"),
+                              "DATE with both arms -> V2");
+
+    /* The intended spelling of "every Monday" is DAYS_OF_WEEK with no date field. */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "dow"), "DOW-1 is valid");
+    tr.next_scheduled_time_utc = make_time_local(2025, 6, 15, 12, 0, 0) - 1;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, make_time_local(2025, 6, 15, 12, 0, 0)),
+                              "DOW-1 repeats forever");
+}
+
+// --- Knife edge: now equals target -> should select next occurrence ---
+TEST_CASE("knife edge now equals target", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 1, 16, 8, 0, 0); // Thu 08:00
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 10 * 24 * 3600 };
+
+    uint8_t days_of_week = (1 << 3); // Thursday
+    time_t next_ts = 0; bool ok = esp_schedule_get_next_date_time(now, 8 * 60, days_of_week, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "knife-edge: now != target (Thu 08:00)");
+
+    // should be the next Thursday at 08:00
+    assert_time_eq("knife-edge: now != target (Thu 08:00)", next_ts, make_time_local(2025, 1, 23, 8, 0, 0));
+}
+
+// --- Validity window ---
+TEST_CASE("validity respected", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 1, 16, 23, 50, 0);
+    esp_schedule_validity_t validity = { .start_time = now + 20 * 60, .end_time = now + 2 * 24 * 3600 };
+
+    time_t next_ts = 0; bool ok = esp_schedule_get_next_date_time(now, 10, 0, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "validity: start boundary honored");
+    assert_time_eq("validity: start boundary honored", next_ts, validity.start_time);
+
+    /* Open-ended window (start==0 && end==0): both bounds disabled -> just the
+     * next occurrence, here tomorrow 00:10 since 00:10 already passed today. */
+    esp_schedule_validity_t open = { .start_time = 0, .end_time = 0 };
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 10, 0, 0, 0, 0, &open, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "validity: open-ended");
+    assert_time_eq("validity: open-ended -> tomorrow 00:10", next_ts, make_time_local(2025, 1, 17, 0, 10, 0));
+
+    /* NULL validity behaves the same as an open-ended window. */
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 10, 0, 0, 0, 0, NULL, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "validity: NULL");
+    assert_time_eq("validity: NULL -> tomorrow 00:10", next_ts, make_time_local(2025, 1, 17, 0, 10, 0));
+
+    /* Each bound is disabled INDEPENDENTLY (not only when both are zero). */
+
+    /* start-only (end_time == 0 disabled): future start honored, no upper cap. */
+    esp_schedule_validity_t start_only = { .start_time = now + 20 * 60, .end_time = 0 };
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 10, 0, 0, 0, 0, &start_only, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "validity: start-only honored, end disabled");
+    assert_time_eq("validity: start-only -> start_time", next_ts, start_only.start_time);
+
+    /* end-only (start_time == 0 disabled): next occurrence bounded only by end. */
+    esp_schedule_validity_t end_only = { .start_time = 0, .end_time = now + 2 * 24 * 3600 };
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 10, 0, 0, 0, 0, &end_only, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "validity: end-only, start disabled");
+    assert_time_eq("validity: end-only -> tomorrow 00:10", next_ts, make_time_local(2025, 1, 17, 0, 10, 0));
+
+    /* end-only that cuts off the next occurrence -> no match. 00:10 already passed
+     * today (23:50), and tomorrow's 00:10 is past this tight end_time. */
+    esp_schedule_validity_t end_tight = { .start_time = 0, .end_time = now + 5 * 60 };
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 10, 0, 0, 0, 0, &end_tight, &next_ts);
+    TEST_ASSERT_FALSE_MESSAGE(ok, "validity: end-only cutoff -> no match");
+    TEST_ASSERT_TRUE(next_ts == 0);
+}
+
+// --- Sequences for same trigger type ---
+TEST_CASE("sequence dow mon wed", "[esp_schedule]")
+{
+    // Sequence Mon/Wed 09:00 from Monday 08:50 -> Mon 09:00, Wed 09:00, next Mon 09:00
+    time_t now = make_time_local(2025, 1, 13, 8, 50, 0); // Monday
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 30 * 24 * 3600 };
+    uint8_t days_of_week = (1 << 0) | (1 << 2); // Mon, Wed
+
+    time_t t1 = 0; bool ok = esp_schedule_get_next_date_time(now, 9 * 60, days_of_week, 0, 0, 0, &validity, &t1);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq dow: first");
+    assert_time_eq("seq dow: first", t1, make_time_local(2025, 1, 13, 9, 0, 0));
+
+    time_t t2 = 0; ok = esp_schedule_get_next_date_time(t1, 9 * 60, days_of_week, 0, 0, 0, &validity, &t2);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq dow: second");
+    assert_time_eq("seq dow: second", t2, make_time_local(2025, 1, 15, 9, 0, 0));
+
+    time_t t3 = 0; ok = esp_schedule_get_next_date_time(t2, 9 * 60, days_of_week, 0, 0, 0, &validity, &t3);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq dow: third");
+    assert_time_eq("seq dow: third", t3, make_time_local(2025, 1, 20, 9, 0, 0));
+}
+
+TEST_CASE("sequence date months mask", "[esp_schedule]")
+{
+    // Day=15 at 07:00 for months {Jan, Mar, Apr}
+    time_t now = make_time_local(2025, 1, 10, 7, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 370 * 24 * 3600 };
+    uint16_t months = (1u << 0) | (1u << 2) | (1u << 3); // Jan, Mar, Apr
+
+    time_t t1 = 0; bool ok = esp_schedule_get_next_date_time(now, 7 * 60, 0, 15, months, 0, &validity, &t1);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq date: first");
+    assert_time_eq("seq date: first", t1, make_time_local(2025, 1, 15, 7, 0, 0));
+
+    time_t t2 = 0; ok = esp_schedule_get_next_date_time(t1, 7 * 60, 0, 15, months, 0, &validity, &t2);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq date: second");
+    assert_time_eq("seq date: second", t2, make_time_local(2025, 3, 15, 7, 0, 0));
+
+    time_t t3 = 0; ok = esp_schedule_get_next_date_time(t2, 7 * 60, 0, 15, months, 0, &validity, &t3);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq date: third");
+    assert_time_eq("seq date: third", t3, make_time_local(2025, 4, 15, 7, 0, 0));
+
+    // Engine-level: year=0 leaves the year unconstrained, so the masked-month
+    // pattern wraps into the next year. A DATE-3 trigger does NOT reach this - the
+    // arm path passes the current year (see "date months mask year scoping"); only
+    // DATE-4 (repeat_every_year) passes 0 and wraps like this.
+    time_t t4 = 0; ok = esp_schedule_get_next_date_time(t3, 7 * 60, 0, 15, months, 0, &validity, &t4);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq date: fourth wraps to next year");
+    assert_time_eq("seq date: fourth -> Jan 15 2026", t4, make_time_local(2026, 1, 15, 7, 0, 0));
+}
+
+TEST_CASE("sequence validity cutoff", "[esp_schedule]")
+{
+    // Validity end should stop sequences
+    time_t now = make_time_local(2025, 1, 13, 8, 50, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = make_time_local(2025, 1, 16, 0, 0, 0) };
+    uint8_t days_of_week = (1 << 0) | (1 << 2); // Mon, Wed
+
+    time_t t1 = 0; bool ok = esp_schedule_get_next_date_time(now, 9 * 60, days_of_week, 0, 0, 0, &validity, &t1);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq cutoff: first");
+    assert_time_eq("seq cutoff: first", t1, make_time_local(2025, 1, 13, 9, 0, 0));
+
+    time_t t2 = 0; ok = esp_schedule_get_next_date_time(t1, 9 * 60, days_of_week, 0, 0, 0, &validity, &t2);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "seq cutoff: second");
+    assert_time_eq("seq cutoff: second", t2, make_time_local(2025, 1, 15, 9, 0, 0));
+
+    time_t t3 = 0; ok = esp_schedule_get_next_date_time(t2, 9 * 60, days_of_week, 0, 0, 0, &validity, &t3);
+    TEST_ASSERT_FALSE_MESSAGE(ok, "seq cutoff: third should fail due to validity end");
+    TEST_ASSERT_TRUE(t3 == 0);
+}
+
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+TEST_CASE("solar with dow", "[esp_schedule]")
+{
+    double lat = 37.7749, lon = -122.4194; // San Francisco, CA
+    time_t now = make_time_local(2025, 1, 12, 6, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 15 * 24 * 3600 };
+
+    esp_schedule_trigger_t tr = (esp_schedule_trigger_t) {
+        0
+    };
+    tr.type = ESP_SCHEDULE_TYPE_SUNRISE;
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY | ESP_SCHEDULE_DAY_TUESDAY | ESP_SCHEDULE_DAY_WEDNESDAY | ESP_SCHEDULE_DAY_THURSDAY | ESP_SCHEDULE_DAY_FRIDAY;
+    tr.solar.latitude = lat; tr.solar.longitude = lon; tr.solar.offset_minutes = 0;
+
+    /* Get first expected sunrise of the triggered day */
+    time_t last_solar = now;
+    for (int day = 13; day <= 17; day++) {
+        time_t sunrise = 0, sunset = 0;
+        bool ok = esp_daylight_calc_sunrise_sunset_utc(2025, 1, day, lat, lon, &sunrise, &sunset);
+        TEST_ASSERT_TRUE_MESSAGE(ok, "sunrise/sunset calculation");
+        TEST_ASSERT_NOT_EQUAL(0, sunrise);
+        TEST_ASSERT_NOT_EQUAL(0, sunset);
+        last_solar = esp_schedule_get_next_valid_solar_time(last_solar, &tr, &validity, "solar_dow");
+        char buf[128];
+        snprintf(buf, sizeof(buf), "solar: day %d: failed to get next valid solar time", day);
+        TEST_ASSERT_TRUE_MESSAGE(last_solar != 0, buf);
+        snprintf(buf, sizeof(buf), "solar: day %d: %" PRIu32 " != %" PRIu32, day, (uint32_t)last_solar, (uint32_t)sunrise);
+        TEST_ASSERT_TRUE_MESSAGE(last_solar == sunrise, buf);
+    }
+}
+
+/* A DATE-3 shape (day-of-month + months mask, no year and no repeat_every_year):
+ * bounded to the current year, so it fires on the 15th of each masked month of
+ * 2025 - exactly the sequence asserted below. */
+TEST_CASE("solar with date mask", "[esp_schedule]")
+{
+    double lat = 52.5200, lon = 13.4050; // Berlin, Germany
+    // Use midday to avoid edge near-sunset timing
+    time_t now = make_time_local(2025, 6, 15, 12, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 90 * 24 * 3600 };
+
+    esp_schedule_trigger_t tr = (esp_schedule_trigger_t) {
+        0
+    };
+    tr.type = ESP_SCHEDULE_TYPE_SUNSET;
+    tr.date.day = 15;
+    tr.date.repeat_months = ESP_SCHEDULE_MONTH_JUNE | ESP_SCHEDULE_MONTH_JULY | ESP_SCHEDULE_MONTH_AUGUST;
+    tr.solar.latitude = lat; tr.solar.longitude = lon; tr.solar.offset_minutes = -15;
+
+    time_t last_solar = now;
+    for (int month = 6; month <= 8; month++) {
+        time_t sunrise = 0, sunset = 0;
+        bool ok = esp_daylight_calc_sunrise_sunset_utc(2025, month, 15, lat, lon, &sunrise, &sunset);
+        TEST_ASSERT_TRUE_MESSAGE(ok, "sunrise/sunset calculation");
+        TEST_ASSERT_NOT_EQUAL(0, sunset);
+        last_solar = esp_schedule_get_next_valid_solar_time(last_solar, &tr, &validity, "solar_date_mask");
+        char buf[128];
+        snprintf(buf, sizeof(buf), "solar: month %d: failed to get next valid solar time", month);
+        TEST_ASSERT_TRUE_MESSAGE(last_solar != 0, buf);
+        time_t expected = sunset - 15 * 60;
+        snprintf(buf, sizeof(buf), "solar: month %d: %" PRIu32 " != %" PRIu32, month, (uint32_t)last_solar, (uint32_t)expected);
+        TEST_ASSERT_TRUE_MESSAGE(last_solar == expected, buf);
+    }
+}
+
+TEST_CASE("solar sequence monotonic", "[esp_schedule]")
+{
+    int year = 2025, month = 1, day = 12; // Jan 12, 2025: Sunday
+    double lat = 37.7749, lon = -122.4194; // San Francisco, CA
+    time_t now = make_time_local(year, month, day, 0, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 10 * 24 * 3600 };
+
+    esp_schedule_trigger_t tr = (esp_schedule_trigger_t) {
+        0
+    };
+    tr.type = ESP_SCHEDULE_TYPE_SUNRISE;
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY | ESP_SCHEDULE_DAY_WEDNESDAY | ESP_SCHEDULE_DAY_FRIDAY; // Mon, Wed, Fri
+    tr.solar.latitude = lat; tr.solar.longitude = lon; tr.solar.offset_minutes = 0;
+
+    /* Get first expected sunrise of the triggered day */
+    time_t sunrise = 0, sunset = 0;
+    bool ok = esp_daylight_calc_sunrise_sunset_utc(year, month, day + 1, /*next day*/ lat, lon, &sunrise, &sunset);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "sunrise/sunset calculation");
+    TEST_ASSERT_NOT_EQUAL(0, sunrise);
+    TEST_ASSERT_NOT_EQUAL(0, sunset);
+
+    time_t s1 = esp_schedule_get_next_valid_solar_time(now, &tr, &validity, "solar_seq");
+    TEST_ASSERT_TRUE_MESSAGE(s1 != 0, "solar seq first");
+
+    char buf[128];
+    snprintf(buf, sizeof(buf), "solar seq first: %" PRIu32 " != %" PRIu32, (uint32_t)s1, (uint32_t)sunrise);
+    TEST_ASSERT_TRUE_MESSAGE(s1 == sunrise, buf);
+
+    /* Get next expected sunrise on next triggered day */
+    ok = esp_daylight_calc_sunrise_sunset_utc(year, month, day + 3, /*next triggered day*/ lat, lon, &sunrise, &sunset);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "sunrise/sunset calculation");
+    TEST_ASSERT_NOT_EQUAL(0, sunrise);
+    TEST_ASSERT_NOT_EQUAL(0, sunset);
+
+    time_t s2 = esp_schedule_get_next_valid_solar_time(s1, &tr, &validity, "solar_seq");
+    TEST_ASSERT_TRUE_MESSAGE(s2 != 0, "solar seq second");
+    snprintf(buf, sizeof(buf), "solar seq second: %" PRIu32 " != %" PRIu32, (uint32_t)s2, (uint32_t)sunrise);
+    TEST_ASSERT_TRUE_MESSAGE(s2 == sunrise, buf);
+    TEST_ASSERT_TRUE_MESSAGE(s2 > s1, "solar seq monotonic");
+}
+
+// --- Solar one-shot semantics must match DATE exactly ---
+TEST_CASE("solar one shot matches date", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 6, 15, 12, 0, 0);
+    esp_schedule_trigger_t tr;
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_SUNRISE;
+    tr.next_scheduled_time_utc = now - 1; /* already fired */
+
+    /* Bare solar (all-wildcard date arm) -> one-shot, same as an all-wildcard
+     * DATE (DATE-0). */
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now),
+                             "solar bare -> one-shot");
+
+    /* Day-of-week arm: solar's only weekday shape, and it repeats forever
+     * (SOL-0). This is where solar differs from DATE, which has no DOW arm. */
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "solar_dow"), "SOL-0 is valid");
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now),
+                              "solar DOW arm -> repeats forever");
+
+    /* A months mask without year or repeat_every_year recurs through the masked
+     * months of the current year (DATE-3). */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_SUNSET;
+    tr.date.day = 15;
+    tr.date.repeat_months = ESP_SCHEDULE_MONTH_JUNE | ESP_SCHEDULE_MONTH_JULY;
+    tr.next_scheduled_time_utc = now - 1;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now),
+                              "solar months mask alone -> recurs within the current year (DATE-3)");
+
+    /* repeat_every_year over that mask makes it recur forever (DATE-4). */
+    tr.date.repeat_every_year = true;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now),
+                              "solar months mask + repeat_every_year -> repeats (DATE-4)");
+
+    /* A year over the mask recurs through that year, then the engine bounds it
+     * (DATE-5). */
+    tr.date.repeat_every_year = false;
+    tr.date.year = 2025;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now),
+                              "solar months mask + year -> recurs within the year (DATE-5)");
+
+    /* Day-of-month alone -> one-shot on the next 15th's solar event (DATE-1). */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_SUNRISE;
+    tr.date.day = 15;
+    tr.next_scheduled_time_utc = now - 1;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now),
+                             "solar day-of-month alone -> one-shot (DATE-1)");
+
+    /* Adding a year but no mask stays one-shot (DATE-2); repeat_every_year with no
+     * mask is not a schedule at all (V6). */
+    tr.date.year = 2025;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now),
+                             "solar day-of-month + year, no mask -> one-shot (DATE-2)");
+    tr.date.year = 0;
+    tr.date.repeat_every_year = true;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "solar_ry_nomask"),
+                              "solar repeat_every_year with no months mask -> V6");
+}
+
+// --- Solar day-selection variants: daily, weekend, monthly, offset, year bound ---
+TEST_CASE("solar variants", "[esp_schedule]")
+{
+    const double lat = 37.7749, lon = -122.4194; // San Francisco, CA
+    time_t sr = 0, ss = 0;
+
+    /* Wildcard day arm (DATE-0): the engine walks day by day. The trigger itself
+     * is one-shot, so this pins the day-selection walk only. */
+    {
+        time_t now = make_time_local(2025, 1, 12, 0, 0, 0);
+        esp_schedule_validity_t val = { .start_time = 0, .end_time = now + 30L * 24 * 3600 };
+        esp_schedule_trigger_t tr; memset(&tr, 0, sizeof(tr));
+        tr.type = ESP_SCHEDULE_TYPE_SUNRISE;
+        tr.solar.latitude = lat; tr.solar.longitude = lon;
+        TEST_ASSERT_TRUE(esp_schedule_trigger_is_valid(&tr, "DATE-0"));
+        time_t prev = now;
+        for (int d = 12; d <= 14; d++) {
+            TEST_ASSERT_TRUE(esp_daylight_calc_sunrise_sunset_utc(2025, 1, d, lat, lon, &sr, &ss));
+            time_t got = esp_schedule_get_next_valid_solar_time(prev, &tr, &val, "daily");
+            assert_time_eq("solar daily sunrise", got, sr);
+            prev = got;
+        }
+        /* The EVERYDAY day-of-week arm (SOL-0) selects the same first day as the
+         * wildcard, and is the way to spell "every day at sunrise". */
+        esp_schedule_trigger_t tr_every = tr;
+        tr_every.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+        TEST_ASSERT_TRUE(esp_schedule_trigger_is_valid(&tr_every, "SOL-0"));
+        time_t a = esp_schedule_get_next_valid_solar_time(now, &tr, &val, "wild");
+        time_t b = esp_schedule_get_next_valid_solar_time(now, &tr_every, &val, "every");
+        assert_time_eq("solar EVERYDAY == wildcard", b, a);
+    }
+
+    /* Weekends only (Sat|Sun). Jan 12 2025 is a Sunday. */
+    {
+        time_t now = make_time_local(2025, 1, 12, 0, 0, 0);
+        esp_schedule_validity_t val = { .start_time = 0, .end_time = now + 30L * 24 * 3600 };
+        esp_schedule_trigger_t tr; memset(&tr, 0, sizeof(tr));
+        tr.type = ESP_SCHEDULE_TYPE_SUNRISE;
+        tr.day.repeat_days = ESP_SCHEDULE_DAY_SATURDAY | ESP_SCHEDULE_DAY_SUNDAY;
+        tr.solar.latitude = lat; tr.solar.longitude = lon;
+        TEST_ASSERT_TRUE(esp_schedule_trigger_is_valid(&tr, "SOL-0 weekend"));
+        const int weekend_days[] = { 12, 18, 19 }; // Sun, Sat, Sun
+        time_t prev = now;
+        for (int i = 0; i < 3; i++) {
+            TEST_ASSERT_TRUE(esp_daylight_calc_sunrise_sunset_utc(2025, 1, weekend_days[i], lat, lon, &sr, &ss));
+            time_t got = esp_schedule_get_next_valid_solar_time(prev, &tr, &val, "weekend");
+            assert_time_eq("solar weekend sunrise", got, sr);
+            prev = got;
+        }
+    }
+
+    /* 15th of every month at sunset (DATE-4: day-of-month + full month mask +
+     * repeat_every_year). The mask is what makes it recur; repeat_every_year with
+     * no mask is rejected (V6). */
+    {
+        time_t now = make_time_local(2025, 1, 12, 0, 0, 0);
+        esp_schedule_validity_t val = { .start_time = 0, .end_time = now + 60L * 24 * 3600 };
+        esp_schedule_trigger_t tr; memset(&tr, 0, sizeof(tr));
+        tr.type = ESP_SCHEDULE_TYPE_SUNSET;
+        tr.date.day = 15;
+        tr.date.repeat_months = ESP_SCHEDULE_MONTH_ALL;
+        tr.date.repeat_every_year = true;
+        tr.solar.latitude = lat; tr.solar.longitude = lon;
+        TEST_ASSERT_TRUE(esp_schedule_trigger_is_valid(&tr, "DATE-4"));
+        TEST_ASSERT_TRUE(esp_daylight_calc_sunrise_sunset_utc(2025, 1, 15, lat, lon, &sr, &ss));
+        time_t t1 = esp_schedule_get_next_valid_solar_time(now, &tr, &val, "monthly");
+        assert_time_eq("solar 15th sunset (Jan)", t1, ss);
+        TEST_ASSERT_TRUE(esp_daylight_calc_sunrise_sunset_utc(2025, 2, 15, lat, lon, &sr, &ss));
+        time_t t2 = esp_schedule_get_next_valid_solar_time(t1, &tr, &val, "monthly");
+        assert_time_eq("solar 15th sunset (Feb)", t2, ss);
+    }
+
+    /* Offset: 15 minutes after sunrise, every day (SOL-0 with EVERYDAY). */
+    {
+        time_t now = make_time_local(2025, 1, 12, 0, 0, 0);
+        esp_schedule_validity_t val = { .start_time = 0, .end_time = now + 30L * 24 * 3600 };
+        esp_schedule_trigger_t tr; memset(&tr, 0, sizeof(tr));
+        tr.type = ESP_SCHEDULE_TYPE_SUNRISE;
+        tr.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+        tr.solar.latitude = lat; tr.solar.longitude = lon;
+        tr.solar.offset_minutes = 15;
+        TEST_ASSERT_TRUE(esp_daylight_calc_sunrise_sunset_utc(2025, 1, 12, lat, lon, &sr, &ss));
+        time_t got = esp_schedule_get_next_valid_solar_time(now, &tr, &val, "offset");
+        assert_time_eq("solar sunrise +15min", got, sr + 15 * 60);
+    }
+
+    /* Year-bounded (DATE-5): the 5th of every month in 2026 only. Jan 5 2026 is
+     * the first occurrence. A solar day-of-week pattern cannot be year-bounded
+     * (V2) - a date arm is the only year-bounded shape. */
+    {
+        time_t now = make_time_local(2025, 6, 1, 0, 0, 0);
+        esp_schedule_validity_t val = { .start_time = 0, .end_time = make_time_local(2027, 1, 1, 0, 0, 0) };
+        esp_schedule_trigger_t tr; memset(&tr, 0, sizeof(tr));
+        tr.type = ESP_SCHEDULE_TYPE_SUNRISE;
+        tr.date.day = 5;
+        tr.date.repeat_months = ESP_SCHEDULE_MONTH_ALL;
+        tr.date.year = 2026;
+        tr.date.repeat_every_year = false;
+        tr.solar.latitude = lat; tr.solar.longitude = lon;
+        TEST_ASSERT_TRUE(esp_schedule_trigger_is_valid(&tr, "DATE-5"));
+        TEST_ASSERT_TRUE(esp_daylight_calc_sunrise_sunset_utc(2026, 1, 5, lat, lon, &sr, &ss));
+        time_t got = esp_schedule_get_next_valid_solar_time(now, &tr, &val, "yearbound");
+        assert_time_eq("solar year-bounded first occurrence 2026", got, sr);
+        struct tm lt; localtime_r(&got, &lt);
+        TEST_ASSERT_EQUAL_INT_MESSAGE(2026 - 1900, lt.tm_year, "solar year-bounded must be in 2026");
+
+        /* Once that year is in the past, there is no further occurrence. */
+        time_t past = make_time_local(2027, 2, 1, 0, 0, 0);
+        time_t none = esp_schedule_get_next_valid_solar_time(past, &tr, &val, "yearbound-expired");
+        TEST_ASSERT_TRUE_MESSAGE(none == 0, "solar year-bounded expires after its year");
+    }
+}
+#endif
+
+/* --- esp_schedule_init must not dereference a NULL schedule_count --- */
+TEST_CASE("init null schedule_count", "[esp_schedule]")
+{
+    /* esp_schedule_init() runs timesync (SNTP), which needs the TCP/IP stack up.
+     * On a device this is already initialized; bring it up here for the test. */
+    esp_netif_init();
+
+    /* NVS-off path used to write *schedule_count unconditionally. */
+    esp_schedule_handle_t *h = esp_schedule_init(false, NULL, NULL);
+    TEST_ASSERT_NULL_MESSAGE(h, "init(false, NULL, NULL) should return NULL and not crash");
+
+    /* NVS-on path with NULL count is rejected. */
+    h = esp_schedule_init(true, NULL, NULL);
+    TEST_ASSERT_NULL_MESSAGE(h, "init(true, NULL, NULL) should return NULL and not crash");
+}
+
+/* --- one-shot triggers must be detected as fired-and-done --- */
+TEST_CASE("one-shot fired and done", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 6, 15, 12, 0, 0);
+    esp_schedule_trigger_t tr;
+
+    /* Not computed yet -> never "done". */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_ONCE;
+    tr.next_scheduled_time_utc = 0;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "uncomputed -> not done");
+
+    /* DAY_ONCE fired in the past -> done (must not re-arm daily). */
+    tr.next_scheduled_time_utc = now - 10;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DAY_ONCE fired -> done");
+
+    /* Still in the future -> not done. */
+    tr.next_scheduled_time_utc = now + 10;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "future -> not done");
+
+    /* Repeating weekday -> never done, even after firing. */
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY;
+    tr.next_scheduled_time_utc = now - 10;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "repeating weekday -> not done");
+
+    /* RELATIVE fires exactly once. */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_RELATIVE;
+    tr.next_scheduled_time_utc = now - 1;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "RELATIVE fired -> done");
+
+    /* DATE-1: day-of-month alone -> one-shot. */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DATE;
+    tr.date.day = 15;
+    tr.date.year = 0;
+    tr.date.repeat_every_year = false;
+    tr.next_scheduled_time_utc = now - 1;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DATE-1 -> done");
+
+    /* DATE-4: the month mask is what repeat_every_year recurs over. Without it,
+     * repeat_every_year is rejected outright (V6). */
+    tr.date.repeat_every_year = true;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "V6"), "V6: rep_yr with no month mask -> V6");
+    tr.date.repeat_months = ESP_SCHEDULE_MONTH_ALL;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "DATE-4"), "DATE-4 is valid");
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DATE-4 -> not done");
+
+    /* DATE-2: a year with no month mask has nothing to recur over -> one-shot. */
+    tr.date.repeat_every_year = false;
+    tr.date.repeat_months = 0;
+    tr.date.year = 2025;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "DATE-2"), "DATE-2 is valid");
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DATE-2 -> done");
+
+    /* DATE-5: the same year over a month mask recurs through that year's masked
+     * months; the engine then bounds it. */
+    tr.date.repeat_months = ESP_SCHEDULE_MONTH_ALL;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DATE-5 -> not done");
+
+    /* DATE-3: a months mask with neither year nor repeat_every_year is bounded to
+     * the *current* year, so it recurs through that year's masked months. */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DATE;
+    tr.date.day = 16;
+    tr.date.repeat_months = ESP_SCHEDULE_MONTH_JUNE | ESP_SCHEDULE_MONTH_JULY | ESP_SCHEDULE_MONTH_AUGUST;
+    tr.next_scheduled_time_utc = now - 1;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DATE-3 -> not done");
+    TEST_ASSERT_EQUAL_MESSAGE(2025, esp_schedule_date_arm_match_year(&tr, now), "DATE-3 is bound to the current year");
+
+    /* DATE-0: all-wildcard DATE -> one-shot at the next HH:MM. Adding
+     * repeat_every_year gives it nothing to recur over (V4). */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DATE;
+    tr.next_scheduled_time_utc = now - 1;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "DATE-0"), "DATE-0 is valid");
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DATE-0 -> done");
+    tr.date.repeat_every_year = true;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "rep_yr_no_pattern"), "all-wildcard + rep_yr -> V4");
+
+    /* DATE has no day-of-week arm at all: EVERYDAY is rejected, not ignored.
+     * Daily is DAYS_OF_WEEK + EVERYDAY (DOW-3). */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DATE;
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "V2"), "DATE + EVERYDAY -> V2");
+}
+
+/* --- Exhaustive configuration truth table ---
+ *
+ * The two helpers below transcribe the tables in docs/trigger_rules.md §4
+ * directly, so
+ * they are an independent statement of the rules rather than a paraphrase of the
+ * implementation. Every one of the 32 (dow, dom, mon, yr, ry) combinations is
+ * checked for each type: whether it is accepted at all (the I rules) and, when
+ * accepted, whether it re-arms after firing (the T engine). */
+
+/* Accepted per docs/trigger_rules.md §4. Booleans are "field is non-zero". */
+static bool shape_is_valid(esp_schedule_type_t type, bool dow, bool dom, bool mon, bool yr, bool ry)
+{
+    bool date_arm = dom || mon || yr || ry;
+    if (type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
+        return !date_arm;                           /* V1: DOW-0, DOW-1 */
+    }
+    bool solar = (type != ESP_SCHEDULE_TYPE_DATE);
+    if (dow) {
+        /* Solar picks the day-of-week arm only when the date arm is empty
+         * (SOL-0); DATE has no day-of-week arm at all. */
+        return solar && !date_arm;
+    }
+    if (!dom && mon) {
+        return false;                               /* V3 */
+    }
+    if (!dom && !mon && (yr || ry)) {
+        return false;                               /* V4 */
+    }
+    if (yr && ry) {
+        return false;                               /* V5 */
+    }
+    if (ry && !mon) {
+        return false;                               /* V6 */
+    }
+    return true;                                    /* DATE-0 .. DATE-5 */
+}
+
+/* Re-arms after firing per docs/trigger_rules.md §3. Only called for accepted shapes. */
+static bool shape_repeats(esp_schedule_type_t type, bool dow, bool dom, bool mon, bool yr, bool ry)
+{
+    (void)dom;
+    (void)yr;
+    (void)ry;
+    if (type == ESP_SCHEDULE_TYPE_DAYS_OF_WEEK) {
+        return dow;                                 /* DOW-1 repeats, DOW-0 does not */
+    }
+    if (type != ESP_SCHEDULE_TYPE_DATE && dow) {
+        return true;                                /* SOL-0 */
+    }
+    /* §3: the month mask alone decides. How far it recurs depends on year /
+     * repeat_every_year (forever, the named year, or the current year), but a
+     * masked date arm always re-arms. */
+    return mon;
+}
+
+static void check_all_shapes(esp_schedule_type_t type, const char *type_name, int expect_valid)
+{
+    time_t now = make_time_local(2025, 6, 15, 12, 0, 0);
+    int valid_count = 0;
+    char msg[128];
+
+    for (int bits = 0; bits < 32; bits++) {
+        bool dow = bits & 1, dom = bits & 2, mon = bits & 4, yr = bits & 8, ry = bits & 16;
+        esp_schedule_trigger_t tr;
+        memset(&tr, 0, sizeof(tr));
+        tr.type = type;
+        tr.day.repeat_days = dow ? ESP_SCHEDULE_DAY_MONDAY : 0;
+        tr.date.day = dom ? 15 : 0;
+        tr.date.repeat_months = mon ? ESP_SCHEDULE_MONTH_ALL : 0;
+        tr.date.year = yr ? 2025 : 0;
+        tr.date.repeat_every_year = ry;
+
+        bool want_valid = shape_is_valid(type, dow, dom, mon, yr, ry);
+        snprintf(msg, sizeof(msg), "%s dow=%d dom=%d mon=%d yr=%d ry=%d: validity", type_name, dow, dom, mon, yr, ry);
+        TEST_ASSERT_EQUAL_MESSAGE(want_valid, esp_schedule_trigger_is_valid(&tr, "shape"), msg);
+        if (!want_valid) {
+            continue;
+        }
+        valid_count++;
+
+        /* Accepted shapes: an already-fired trigger is "done" iff it does not repeat. */
+        tr.next_scheduled_time_utc = now - 1;
+        snprintf(msg, sizeof(msg), "%s dow=%d dom=%d mon=%d yr=%d ry=%d: lifetime", type_name, dow, dom, mon, yr, ry);
+        TEST_ASSERT_EQUAL_MESSAGE(!shape_repeats(type, dow, dom, mon, yr, ry),
+                                  esp_schedule_trigger_fired_and_done(&tr, now), msg);
+    }
+    snprintf(msg, sizeof(msg), "%s: number of valid shapes out of 32", type_name);
+    TEST_ASSERT_EQUAL_MESSAGE(expect_valid, valid_count, msg);
+}
+
+TEST_CASE("trigger validation truth table", "[esp_schedule]")
+{
+    /* Counts per docs/trigger_rules.md §4.7: 2 of 32 for DAYS_OF_WEEK, 6 for
+     * DATE, 7 for solar. */
+    check_all_shapes(ESP_SCHEDULE_TYPE_DAYS_OF_WEEK, "DAYS_OF_WEEK", 2);
+    check_all_shapes(ESP_SCHEDULE_TYPE_DATE, "DATE", 6);
+#if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
+    check_all_shapes(ESP_SCHEDULE_TYPE_SUNRISE, "SUNRISE", 7);
+    check_all_shapes(ESP_SCHEDULE_TYPE_SUNSET, "SUNSET", 7);
+#endif
+
+    /* RELATIVE reads no date field, so nothing there can invalidate it. */
+    esp_schedule_trigger_t tr;
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_RELATIVE;
+    tr.relative_seconds = 30;
+    tr.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+    tr.date.day = 15;
+    tr.date.repeat_months = ESP_SCHEDULE_MONTH_ALL;
+    tr.date.year = 2025;
+    tr.date.repeat_every_year = true;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "relative"), "RELATIVE ignores date fields");
+
+    /* The one field RELATIVE does own must name a future instant (V7). A delay of
+     * 0 or less puts the target at or before the base time, which the arm path
+     * cannot fire. */
+    tr.relative_seconds = 0;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "relative_zero"), "relative_seconds = 0 -> V7");
+    tr.relative_seconds = -10;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "relative_neg"), "relative_seconds < 0 -> V7");
+
+    /* An unset type is never armable. */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_INVALID;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_is_valid(&tr, "invalid"), "TYPE_INVALID rejected");
+}
+
+/* --- create()/edit() must reject an invalid configuration --- */
+TEST_CASE("create and edit reject invalid config", "[esp_schedule]")
+{
+    /* One rejected shape per rule. */
+    esp_schedule_config_t cfg;
+    const struct {
+        const char *rule;
+        esp_schedule_type_t type;
+        uint8_t dow, dom;
+        uint16_t mon, yr;
+        bool ry;
+    } bad[] = {
+        { "V1",  ESP_SCHEDULE_TYPE_DAYS_OF_WEEK, ESP_SCHEDULE_DAY_MONDAY, 15, 0, 0, false },
+        { "V2", ESP_SCHEDULE_TYPE_DATE, ESP_SCHEDULE_DAY_MONDAY, 0, 0, 0, false },
+        { "V3", ESP_SCHEDULE_TYPE_DATE, 0, 0, ESP_SCHEDULE_MONTH_ALL, 0, false },
+        { "V4", ESP_SCHEDULE_TYPE_DATE, 0, 0, 0, 2026, false },
+        { "V5", ESP_SCHEDULE_TYPE_DATE, 0, 15, ESP_SCHEDULE_MONTH_ALL, 2026, true },
+        { "V6", ESP_SCHEDULE_TYPE_DATE, 0, 15, 0, 0, true },
+    };
+
+    for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); i++) {
+        memset(&cfg, 0, sizeof(cfg));
+        strlcpy(cfg.name, "bad_cfg", sizeof(cfg.name));
+        cfg.trigger.type = bad[i].type;
+        cfg.trigger.hours = 9;
+        cfg.trigger.day.repeat_days = bad[i].dow;
+        cfg.trigger.date.day = bad[i].dom;
+        cfg.trigger.date.repeat_months = bad[i].mon;
+        cfg.trigger.date.year = bad[i].yr;
+        cfg.trigger.date.repeat_every_year = bad[i].ry;
+        char msg[64];
+        snprintf(msg, sizeof(msg), "rule %s: create() must return NULL", bad[i].rule);
+        TEST_ASSERT_NULL_MESSAGE(esp_schedule_create(&cfg), msg);
+    }
+
+    /* V7: RELATIVE with a non-positive delay. Not in the table above because it
+     * is the one rule that does not involve a date field. */
+    memset(&cfg, 0, sizeof(cfg));
+    strlcpy(cfg.name, "bad_cfg", sizeof(cfg.name));
+    cfg.trigger.type = ESP_SCHEDULE_TYPE_RELATIVE;
+    cfg.trigger.relative_seconds = 0;
+    TEST_ASSERT_NULL_MESSAGE(esp_schedule_create(&cfg), "rule V7: create() must return NULL");
+
+    /* A valid schedule can be created, and editing it into an invalid shape is
+     * rejected without disturbing the stored config. */
+    memset(&cfg, 0, sizeof(cfg));
+    strlcpy(cfg.name, "good_cfg", sizeof(cfg.name));
+    cfg.trigger.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+    cfg.trigger.hours = 9;
+    cfg.trigger.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY;
+    esp_schedule_handle_t handle = esp_schedule_create(&cfg);
+    TEST_ASSERT_NOT_NULL_MESSAGE(handle, "DOW-1 must be accepted");
+
+    cfg.trigger.date.day = 15; /* rule V1: a date field on a DAYS_OF_WEEK trigger */
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_ERR_INVALID_ARG, esp_schedule_edit(handle, &cfg), "edit() must reject rule V1");
+
+    esp_schedule_config_t got;
+    memset(&got, 0, sizeof(got));
+    TEST_ASSERT_EQUAL(ESP_OK, esp_schedule_get(handle, &got));
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_SCHEDULE_DAY_MONDAY, got.trigger.day.repeat_days, "rejected edit must not apply");
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_schedule_delete(handle));
+}
+
+/* --- Month-mask regression guard (docs/trigger_rules.md §3) ---
+ * DATE-2 and DATE-5 differ only in repeat_months: DATE-2 fires once in its year,
+ * DATE-5 fires once per masked month of that year. */
+TEST_CASE("date one shot vs recurring month mask", "[esp_schedule]")
+{
+    time_t now = make_time_local(2026, 1, 1, 0, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = make_time_local(2028, 1, 1, 0, 0, 0) };
+    time_t fired = now - 1;
+
+    /* DATE-2: day = 15, year = 2026, no mask -> one-shot. */
+    esp_schedule_trigger_t one_shot;
+    memset(&one_shot, 0, sizeof(one_shot));
+    one_shot.type = ESP_SCHEDULE_TYPE_DATE;
+    one_shot.date.day = 15;
+    one_shot.date.year = 2026;
+    one_shot.next_scheduled_time_utc = fired;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_is_valid(&one_shot, "DATE-2"), "DATE-2 is valid");
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_fired_and_done(&one_shot, now), "DATE-2 fires once");
+
+    /* DATE-5: the same, plus a full month mask -> one fire per month of 2026. */
+    esp_schedule_trigger_t recurring = one_shot;
+    recurring.date.repeat_months = ESP_SCHEDULE_MONTH_ALL;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_trigger_is_valid(&recurring, "DATE-5"), "DATE-5 is valid");
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&recurring, now), "DATE-5 re-arms");
+
+    /* Both arms select the same first instant; only the lifetime differs. */
+    time_t a = 0, b = 0;
+    TEST_ASSERT_TRUE(esp_schedule_get_next_date_time(now, 7 * 60, 0, 15, 0, 2026, &validity, &a));
+    TEST_ASSERT_TRUE(esp_schedule_get_next_date_time(now, 7 * 60, 0, 15, ESP_SCHEDULE_MONTH_ALL, 2026, &validity, &b));
+    assert_time_eq("DATE-2 first fire", a, make_time_local(2026, 1, 15, 7, 0, 0));
+    assert_time_eq("DATE-5 first fire == DATE-2 first fire", b, a);
+
+    /* DATE-5 walks all 12 masked months of the bound year, then stops. */
+    time_t t = now;
+    for (int month = 1; month <= 12; month++) {
+        time_t next = 0;
+        char msg[64];
+        snprintf(msg, sizeof(msg), "DATE-5 fire %d of 12", month);
+        TEST_ASSERT_TRUE_MESSAGE(esp_schedule_get_next_date_time(t, 7 * 60, 0, 15, ESP_SCHEDULE_MONTH_ALL, 2026, &validity, &next), msg);
+        assert_time_eq(msg, next, make_time_local(2026, month, 15, 7, 0, 0));
+        t = next;
+    }
+    time_t none = 0;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_get_next_date_time(t, 7 * 60, 0, 15, ESP_SCHEDULE_MONTH_ALL, 2026, &validity, &none),
+                              "DATE-5 expires after the last masked month of its year");
+}
+
+/* --- Which year the date arm is bound to, and what that means for the sequence.
+ * Three spellings of "recurs over the month set", with three different ends. --- */
+TEST_CASE("date months mask year scoping", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 5, 1, 0, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = make_time_local(2028, 1, 1, 0, 0, 0) };
+    uint16_t months = ESP_SCHEDULE_MONTH_JUNE | ESP_SCHEDULE_MONTH_JULY;
+
+    esp_schedule_trigger_t tr;
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DATE;
+    tr.date.day = 15;
+    tr.date.repeat_months = months;
+
+    /* DATE-3 - neither year nor repeat_every_year: bound to the current year. */
+    TEST_ASSERT_TRUE(esp_schedule_trigger_is_valid(&tr, "DATE-3"));
+    TEST_ASSERT_EQUAL_MESSAGE(2025, esp_schedule_date_arm_match_year(&tr, now), "DATE-3 -> current year");
+    /* Nothing is stored, so the bound is re-resolved from `now` on every arm. */
+    TEST_ASSERT_EQUAL_MESSAGE(2027, esp_schedule_date_arm_match_year(&tr, make_time_local(2027, 3, 1, 0, 0, 0)),
+                              "DATE-3 re-resolves the bound from now");
+
+    /* It is therefore not a one-shot: it fires each masked month of that year. */
+    tr.next_scheduled_time_utc = now - 1;
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DATE-3 re-arms");
+
+    time_t t1 = 0, t2 = 0, t3 = 0;
+    uint16_t bound = esp_schedule_date_arm_match_year(&tr, now);
+    TEST_ASSERT_TRUE(esp_schedule_get_next_date_time(now, 7 * 60, 0, 15, months, bound, &validity, &t1));
+    assert_time_eq("DATE-3 first fire", t1, make_time_local(2025, 6, 15, 7, 0, 0));
+    TEST_ASSERT_TRUE(esp_schedule_get_next_date_time(t1, 7 * 60, 0, 15, months, bound, &validity, &t2));
+    assert_time_eq("DATE-3 second fire", t2, make_time_local(2025, 7, 15, 7, 0, 0));
+    /* Past the last masked month of the bound year there is no match, which the
+     * arm path turns into disarm-and-delete. */
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_get_next_date_time(t2, 7 * 60, 0, 15, months, bound, &validity, &t3),
+                              "DATE-3 expires after the current year");
+
+    /* DATE-4 - repeat_every_year: unconstrained, so the pattern wraps years. */
+    tr.date.repeat_every_year = true;
+    TEST_ASSERT_EQUAL_MESSAGE(0, esp_schedule_date_arm_match_year(&tr, now), "DATE-4 -> unconstrained");
+    time_t t4 = 0;
+    TEST_ASSERT_TRUE(esp_schedule_get_next_date_time(t2, 7 * 60, 0, 15, months,
+                     esp_schedule_date_arm_match_year(&tr, t2), &validity, &t4));
+    assert_time_eq("DATE-4 wraps into the next year", t4, make_time_local(2026, 6, 15, 7, 0, 0));
+
+    /* DATE-5 - an explicit year: that year regardless of `now`, and the bound
+     * survives a reboot because it is stored. */
+    tr.date.repeat_every_year = false;
+    tr.date.year = 2026;
+    TEST_ASSERT_EQUAL_MESSAGE(2026, esp_schedule_date_arm_match_year(&tr, now), "DATE-5 -> its own year");
+    TEST_ASSERT_EQUAL_MESSAGE(2026, esp_schedule_date_arm_match_year(&tr, make_time_local(2027, 3, 1, 0, 0, 0)),
+                              "DATE-5 bound is independent of now");
+
+    /* No months mask: nothing to iterate, so the year is left unconstrained and
+     * the single fire may land in the next year (DATE-1). */
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DATE;
+    tr.date.day = 15;
+    TEST_ASSERT_EQUAL_MESSAGE(0, esp_schedule_date_arm_match_year(&tr, now), "DATE-1 -> unconstrained");
+}
+
+/* --- DATE-4: unbounded recurrence over the month set (monthly and seasonal) --- */
+TEST_CASE("date months mask recurs over month set", "[esp_schedule]")
+{
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = make_time_local(2028, 1, 1, 0, 0, 0) };
+    time_t now = make_time_local(2025, 1, 1, 0, 0, 0);
+
+    /* Mon = MONTH_ALL: the 15th of every month, wrapping into the next year. */
+    const int monthly[][2] = { {1, 15}, {2, 15}, {3, 15} };
+    time_t t = now;
+    for (size_t i = 0; i < sizeof(monthly) / sizeof(monthly[0]); i++) {
+        time_t next = 0;
+        TEST_ASSERT_TRUE(esp_schedule_get_next_date_time(t, 7 * 60, 0, 15, ESP_SCHEDULE_MONTH_ALL, 0, &validity, &next));
+        assert_time_eq("DATE-4 monthly", next, make_time_local(2025, monthly[i][0], monthly[i][1], 7, 0, 0));
+        TEST_ASSERT_TRUE_MESSAGE(next > t, "DATE-4 strictly increasing");
+        t = next;
+    }
+
+    /* Sparse mask: the 15th of Jun/Jul, every year -> wraps to next June. */
+    uint16_t months = ESP_SCHEDULE_MONTH_JUNE | ESP_SCHEDULE_MONTH_JULY;
+    const time_t want[] = {
+        make_time_local(2025, 6, 15, 7, 0, 0),
+        make_time_local(2025, 7, 15, 7, 0, 0),
+        make_time_local(2026, 6, 15, 7, 0, 0),
+    };
+    t = now;
+    for (size_t i = 0; i < sizeof(want) / sizeof(want[0]); i++) {
+        time_t next = 0;
+        TEST_ASSERT_TRUE(esp_schedule_get_next_date_time(t, 7 * 60, 0, 15, months, 0, &validity, &next));
+        assert_time_eq("DATE-4 seasonal", next, want[i]);
+        t = next;
+    }
+
+    /* Both spellings are valid triggers that never finish. */
+    esp_schedule_trigger_t tr;
+    memset(&tr, 0, sizeof(tr));
+    tr.type = ESP_SCHEDULE_TYPE_DATE;
+    tr.date.day = 15;
+    tr.date.repeat_months = months;
+    tr.date.repeat_every_year = true;
+    tr.next_scheduled_time_utc = now - 1;
+    TEST_ASSERT_TRUE(esp_schedule_trigger_is_valid(&tr, "DATE-4 sparse"));
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_trigger_fired_and_done(&tr, now), "DATE-4 never done");
+}
+
+/* --- repeat_every_year / year bounding in the date engine --- */
+TEST_CASE("date year bounding", "[esp_schedule]")
+{
+    time_t now = make_time_local(2026, 3, 1, 12, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 800L * 24 * 3600 };
+    time_t next_ts = 0;
+
+    /* A year in the past yields no match (bounds a non-repeating date). */
+    bool ok = esp_schedule_get_next_date_time(now, 9 * 60, 0, 10, 0, 2025, &validity, &next_ts);
+    TEST_ASSERT_FALSE_MESSAGE(ok, "year=2025 in the past -> no match");
+
+    /* year=0 leaves the year unconstrained -> the next occurrence. */
+    next_ts = 0;
+    ok = esp_schedule_get_next_date_time(now, 9 * 60, 0, 10, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "year=0 -> matches next occurrence");
+    assert_time_eq("year=0 day=10 09:00", next_ts, make_time_local(2026, 3, 10, 9, 0, 0));
+
+    /* Day-of-month + a FUTURE specific year: the first match is in that year, and
+     * once the year is past there is no match at all. This is the engine bound
+     * behind DATE-2 (one-shot in that year) and DATE-5 (per masked month, then
+     * dead). */
+    time_t before = make_time_local(2025, 1, 16, 12, 0, 0);
+    esp_schedule_validity_t wide = { .start_time = 0, .end_time = make_time_local(2028, 1, 1, 0, 0, 0) };
+    next_ts = 0;
+    ok = esp_schedule_get_next_date_time(before, 9 * 60 + 15, 0, 5, 0, 2026, &wide, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "day=5 year=2026 -> first fire in 2026");
+    assert_time_eq("day=5 year=2026 -> Jan 5 2026", next_ts, make_time_local(2026, 1, 5, 9, 15, 0));
+
+    /* Same config once 2026 is in the past -> no further occurrence (expired). */
+    time_t after = make_time_local(2027, 2, 1, 12, 0, 0);
+    next_ts = 0;
+    ok = esp_schedule_get_next_date_time(after, 9 * 60 + 15, 0, 5, 0, 2026, &wide, &next_ts);
+    TEST_ASSERT_FALSE_MESSAGE(ok, "day=5 year=2026 -> expires after 2026");
+    TEST_ASSERT_TRUE(next_ts == 0);
+}
+
+/* --- wildcard-day, EVERYDAY, monthly and every-day-in-month selection --- */
+TEST_CASE("date wildcard and daily", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 1, 16, 12, 0, 0); // Thu 12:00
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 400L * 24 * 3600 };
+    time_t next_ts = 0;
+
+    /* All wildcards, time already passed today -> fires tomorrow at 06:00. */
+    bool ok = esp_schedule_get_next_date_time(now, 6 * 60, 0, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "wildcard 06:00");
+    assert_time_eq("wildcard -> tomorrow 06:00", next_ts, make_time_local(2025, 1, 17, 6, 0, 0));
+
+    /* All wildcards, time still ahead today -> fires today at 15:00. */
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 15 * 60, 0, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "wildcard 15:00");
+    assert_time_eq("wildcard -> today 15:00", next_ts, make_time_local(2025, 1, 16, 15, 0, 0));
+
+    /* EVERYDAY mask is equivalent to a wildcard day. */
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 6 * 60, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "EVERYDAY 06:00");
+    assert_time_eq("EVERYDAY -> tomorrow 06:00 (== wildcard)", next_ts, make_time_local(2025, 1, 17, 6, 0, 0));
+
+    /* Day-of-month only: the 15th already passed this month -> next month's 15th. */
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 7 * 60, 0, 15, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "day=15 monthly");
+    assert_time_eq("day=15 -> Feb 15 07:00", next_ts, make_time_local(2025, 2, 15, 7, 0, 0));
+
+    /* Engine-internal: wildcard day + a months mask -> every day in that month.
+     * No trigger can reach this (rule V3 rejects a mask without date.day); the
+     * rejection is covered by "trigger validation truth table". */
+    next_ts = 0; ok = esp_schedule_get_next_date_time(now, 8 * 60, 0, 0, ESP_SCHEDULE_MONTH_JUNE, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "day=0 months=Jun");
+    assert_time_eq("day=0 + Jun -> Jun 1 08:00", next_ts, make_time_local(2025, 6, 1, 8, 0, 0));
+}
+
+/* --- A months mask bound to a specific year expires after its last masked
+ * month (v1.3.3 is_expired semantics: fire the year's masked months, then stop). */
+TEST_CASE("date months year bounded expires", "[esp_schedule]")
+{
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = make_time_local(2027, 1, 1, 0, 0, 0) };
+    uint16_t months = ESP_SCHEDULE_MONTH_JUNE | ESP_SCHEDULE_MONTH_JULY;
+
+    time_t t1 = 0;
+    bool ok = esp_schedule_get_next_date_time(make_time_local(2025, 1, 1, 0, 0, 0), 7 * 60, 0, 15, months, 2025, &validity, &t1);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "bounded months: first");
+    assert_time_eq("bounded months -> Jun 15 2025", t1, make_time_local(2025, 6, 15, 7, 0, 0));
+
+    time_t t2 = 0;
+    ok = esp_schedule_get_next_date_time(t1, 7 * 60, 0, 15, months, 2025, &validity, &t2);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "bounded months: second");
+    assert_time_eq("bounded months -> Jul 15 2025", t2, make_time_local(2025, 7, 15, 7, 0, 0));
+
+    /* Past the last masked month of the bound year -> no more occurrences. */
+    time_t t3 = 0;
+    ok = esp_schedule_get_next_date_time(t2, 7 * 60, 0, 15, months, 2025, &validity, &t3);
+    TEST_ASSERT_FALSE_MESSAGE(ok, "bounded months: expires after last masked month");
+    TEST_ASSERT_TRUE(t3 == 0);
+}
+
+/* --- VAL-4: a match that lands before validity.start_time must not be returned;
+ * the search continues to the following occurrence (docs §1.2 step 5). This is
+ * distinct from VAL-0, where the window opens between two occurrences and the
+ * first candidate already qualifies. --- */
+TEST_CASE("validity start skips earlier match", "[esp_schedule]")
+{
+    /* Mondays at 09:00, window opening Mon Jan 20 2025 at 12:00. Jan 20 09:00 is
+     * a matching day but falls before start_time -> Mon Jan 27 09:00. */
+    time_t now = make_time_local(2025, 1, 15, 8, 0, 0); // Wed
+    esp_schedule_validity_t validity = {
+        .start_time = make_time_local(2025, 1, 20, 12, 0, 0),
+        .end_time = make_time_local(2025, 3, 1, 0, 0, 0),
+    };
+
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 9 * 60, ESP_SCHEDULE_DAY_MONDAY, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "VAL-4: match before start_time -> keep searching");
+    assert_time_eq("VAL-4 -> Mon Jan 27 09:00", next_ts, make_time_local(2025, 1, 27, 9, 0, 0));
+
+    /* Same shape for the date arm: the 15th, window opening Feb 15 at 12:00. */
+    esp_schedule_validity_t val_date = {
+        .start_time = make_time_local(2025, 2, 15, 12, 0, 0),
+        .end_time = make_time_local(2025, 6, 1, 0, 0, 0),
+    };
+    next_ts = 0;
+    ok = esp_schedule_get_next_date_time(now, 9 * 60, 0, 15, 0, 0, &val_date, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "VAL-4 date arm: 15th before start_time -> keep searching");
+    assert_time_eq("VAL-4 date arm -> Mar 15 09:00", next_ts, make_time_local(2025, 3, 15, 9, 0, 0));
+
+    /* VAL-0 for contrast: a window opening between two occurrences returns the
+     * first candidate at or after start_time, not the one after it. */
+    esp_schedule_validity_t val_between = {
+        .start_time = make_time_local(2025, 1, 20, 8, 0, 0),
+        .end_time = make_time_local(2025, 3, 1, 0, 0, 0),
+    };
+    next_ts = 0;
+    ok = esp_schedule_get_next_date_time(now, 9 * 60, ESP_SCHEDULE_DAY_MONDAY, 0, 0, 0, &val_between, &next_ts);
+    TEST_ASSERT_TRUE_MESSAGE(ok, "VAL-0: window opens before the occurrence");
+    assert_time_eq("VAL-0 -> Mon Jan 20 09:00", next_ts, make_time_local(2025, 1, 20, 9, 0, 0));
+}
+
+/* --- Day/month combinations with no finite match must fail, not loop forever
+ * (docs §4.2: "Patterns with no finite match ... exhaust the search horizon and
+ * never fire"). --- */
+TEST_CASE("date no finite match", "[esp_schedule]")
+{
+    time_t now = make_time_local(2025, 1, 1, 0, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = 0 }; /* open-ended */
+
+    /* Feb never has a 30th. */
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 9 * 60, 0, 30, ESP_SCHEDULE_MONTH_FEBRUARY, 0, &validity, &next_ts);
+    TEST_ASSERT_FALSE_MESSAGE(ok, "day=30 masked to February -> no match");
+    TEST_ASSERT_TRUE(next_ts == 0);
+
+    /* Apr and Jun are both 30-day months, so a 31st never lands. */
+    next_ts = 0;
+    ok = esp_schedule_get_next_date_time(now, 9 * 60, 0, 31, ESP_SCHEDULE_MONTH_APRIL | ESP_SCHEDULE_MONTH_JUNE, 0, &validity, &next_ts);
+    TEST_ASSERT_FALSE_MESSAGE(ok, "day=31 masked to 30-day months -> no match");
+    TEST_ASSERT_TRUE(next_ts == 0);
+
+    /* Feb 29 bounded to a non-leap year cannot be satisfied either. */
+    next_ts = 0;
+    ok = esp_schedule_get_next_date_time(now, 9 * 60, 0, 29, ESP_SCHEDULE_MONTH_FEBRUARY, 2027, &validity, &next_ts);
+    TEST_ASSERT_FALSE_MESSAGE(ok, "Feb 29 in a non-leap year -> no match");
+    TEST_ASSERT_TRUE(next_ts == 0);
+}
+
+/* --- Time-of-day range validation (docs §4.7, last paragraph): hours < 24 and
+ * minutes < 60. Out of range must be refused, not normalized by mktime() into a
+ * following day that violates the matched day/month mask. --- */
+TEST_CASE("time of day range validation", "[esp_schedule]")
+{
+    /* Engine level: minutes_since_midnight must stay inside the day. */
+    time_t now = make_time_local(2025, 1, 16, 12, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = 0 };
+    time_t next_ts = 0;
+
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_get_next_date_time(now, 24 * 60, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &next_ts),
+                              "minutes_since_midnight == 24*60 -> rejected");
+    TEST_ASSERT_TRUE(next_ts == 0);
+    TEST_ASSERT_FALSE_MESSAGE(esp_schedule_get_next_date_time(now, 24 * 60 + 30, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &next_ts),
+                              "minutes_since_midnight past midnight -> rejected");
+
+    /* The last valid minute of the day is accepted. */
+    next_ts = 0;
+    TEST_ASSERT_TRUE_MESSAGE(esp_schedule_get_next_date_time(now, 23 * 60 + 59, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &next_ts),
+                             "23:59 -> accepted");
+    assert_time_eq("23:59 today", next_ts, make_time_local(2025, 1, 16, 23, 59, 0));
+
+    /* Public API: create() refuses an out-of-range time of day. */
+    esp_schedule_config_t cfg;
+    const struct {
+        const char *what;
+        uint8_t hours, minutes;
+    } bad[] = {
+        { "hours = 24", 24, 0 },
+        { "hours = 250", 250, 0 },
+        { "minutes = 60", 9, 60 },
+        { "minutes = 200", 9, 200 },
+    };
+    for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); i++) {
+        memset(&cfg, 0, sizeof(cfg));
+        strlcpy(cfg.name, "bad_time", sizeof(cfg.name));
+        cfg.trigger.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+        cfg.trigger.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+        cfg.trigger.hours = bad[i].hours;
+        cfg.trigger.minutes = bad[i].minutes;
+        char msg[64];
+        snprintf(msg, sizeof(msg), "%s: create() must return NULL", bad[i].what);
+        TEST_ASSERT_NULL_MESSAGE(esp_schedule_create(&cfg), msg);
+    }
+
+    /* 23:59 is accepted, and editing it out of range is refused without
+     * disturbing the stored config. */
+    memset(&cfg, 0, sizeof(cfg));
+    strlcpy(cfg.name, "good_time", sizeof(cfg.name));
+    cfg.trigger.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+    cfg.trigger.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+    cfg.trigger.hours = 23;
+    cfg.trigger.minutes = 59;
+    esp_schedule_handle_t handle = esp_schedule_create(&cfg);
+    TEST_ASSERT_NOT_NULL_MESSAGE(handle, "23:59 must be accepted");
+
+    cfg.trigger.minutes = 60;
+    TEST_ASSERT_EQUAL_MESSAGE(ESP_ERR_INVALID_ARG, esp_schedule_edit(handle, &cfg), "edit() must reject minutes = 60");
+
+    esp_schedule_config_t got;
+    memset(&got, 0, sizeof(got));
+    TEST_ASSERT_EQUAL(ESP_OK, esp_schedule_get(handle, &got));
+    TEST_ASSERT_EQUAL_MESSAGE(59, got.trigger.minutes, "rejected edit must not apply");
+
+    /* RELATIVE does not read hours/minutes, so no range applies to them. */
+    memset(&cfg, 0, sizeof(cfg));
+    strlcpy(cfg.name, "rel_time", sizeof(cfg.name));
+    cfg.trigger.type = ESP_SCHEDULE_TYPE_RELATIVE;
+    cfg.trigger.relative_seconds = 60;
+    cfg.trigger.hours = 99;
+    cfg.trigger.minutes = 99;
+    esp_schedule_handle_t rel = esp_schedule_create(&cfg);
+    TEST_ASSERT_NOT_NULL_MESSAGE(rel, "RELATIVE ignores hours/minutes");
+
+    TEST_ASSERT_EQUAL(ESP_OK, esp_schedule_delete(rel));
+    TEST_ASSERT_EQUAL(ESP_OK, esp_schedule_delete(handle));
+}
+
+/* --- DST must not be double-corrected --- */
+#define NY_TZ "EST5EDT,M3.2.0,M11.1.0" /* America/New_York */
+
+/* TZ guard so tests restore the previous value even if a Unity assertion
+ * longjmps past the test's own tz_pop(). */
+static bool s_tz_active = false;
+static bool s_tz_had = false;
+static char s_tz_saved[64];
+
+static void tz_push(const char *tz)
+{
+    const char *cur = getenv("TZ");
+    s_tz_had = (cur != NULL);
+    if (cur) {
+        strlcpy(s_tz_saved, cur, sizeof(s_tz_saved));
+    }
+    setenv("TZ", tz, 1);
+    tzset();
+    s_tz_active = true;
+}
+
+static void tz_pop(void)
+{
+    if (!s_tz_active) {
+        return;
+    }
+    if (s_tz_had) {
+        setenv("TZ", s_tz_saved, 1);
+    } else {
+        unsetenv("TZ");
+    }
+    tzset();
+    s_tz_active = false;
+}
+
+TEST_CASE("dst daily across spring forward", "[esp_schedule]")
+{
+    tz_push(NY_TZ);
+
+    /* Spring forward 2025: Sun Mar 9. Daily 12:00 from Sat Mar 8 13:00. */
+    time_t now = make_time_local(2025, 3, 8, 13, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 10L * 24 * 3600 };
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 12 * 60, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE(ok);
+    assert_time_eq("spring-forward daily 12:00", next_ts, make_time_local(2025, 3, 9, 12, 0, 0));
+
+    tz_pop();
+}
+
+TEST_CASE("dst daily across fall back", "[esp_schedule]")
+{
+    tz_push(NY_TZ);
+
+    /* Fall back 2025: Sun Nov 2. Daily 12:00 from Sat Nov 1 13:00. */
+    time_t now = make_time_local(2025, 11, 1, 13, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 10L * 24 * 3600 };
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 12 * 60, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE(ok);
+    assert_time_eq("fall-back daily 12:00", next_ts, make_time_local(2025, 11, 2, 12, 0, 0));
+
+    tz_pop();
+}
+
+TEST_CASE("dst skipped local time", "[esp_schedule]")
+{
+    tz_push(NY_TZ);
+
+    /* 02:30 on spring-forward day does not exist (clocks jump 02:00->03:00).
+     * mktime(tm_isdst=-1) must resolve it to a real future instant, not drift. */
+    time_t now = make_time_local(2025, 3, 9, 1, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 2L * 24 * 3600 };
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 2 * 60 + 30, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_TRUE_MESSAGE(next_ts > now, "skipped local time resolves to a future instant");
+    TEST_ASSERT_TRUE_MESSAGE(next_ts < now + 4 * 3600, "resolved within a few hours, no day/hour drift");
+
+    tz_pop();
+}
+
+/* --- advancing days must not skip a day across spring forward --- */
+TEST_CASE("dst next dow near midnight", "[esp_schedule]")
+{
+    tz_push(NY_TZ);
+
+    /* Sat Mar 8 2025 23:30, next Sunday 23:45 -> Sun Mar 9 (NOT Mar 16).
+     * The old code advanced by 86400s and skipped the 23h DST day. */
+    time_t now = make_time_local(2025, 3, 8, 23, 30, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 30L * 24 * 3600 };
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 23 * 60 + 45, ESP_SCHEDULE_DAY_SUNDAY, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE(ok);
+    assert_time_eq("next Sunday 23:45 across spring-forward", next_ts, make_time_local(2025, 3, 9, 23, 45, 0));
+
+    tz_pop();
+}
+
+/* --- RainMaker DST compliance ---
+ * https://legacy.rainmaker.espressif.com/docs/scheduling/#managing-daylight-saving-time-dst
+ * Schedules fire on LOCAL wall-clock time:
+ *  - Spring forward: a 02:00-02:59 local time does not exist; the schedule is
+ *    delayed by 1hr and fires at 03:00-03:59 on the switch day.
+ *  - Fall back: a 01:00-01:59 local time occurs twice; the schedule fires only
+ *    once (the first occurrence, before the switch), not again after it. */
+TEST_CASE("dst rainmaker spring forward delayed one hour", "[esp_schedule]")
+{
+    tz_push(NY_TZ);
+
+    /* Daily 02:30. On spring-forward day (Sun Mar 9 2025) 02:30 does not exist,
+     * so it must fire at 03:30. From Sat Mar 8 12:00 the next occurrence is Mar 9. */
+    time_t now = make_time_local(2025, 3, 8, 12, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 10L * 24 * 3600 };
+    time_t next_ts = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 2 * 60 + 30, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &next_ts);
+    TEST_ASSERT_TRUE(ok);
+    /* 02:30 Mar 9 resolves to the same instant as 03:30 EDT. */
+    assert_time_eq("spring 02:30 -> 03:30", next_ts, make_time_local(2025, 3, 9, 3, 30, 0));
+    struct tm lt;
+    localtime_r(&next_ts, &lt);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(3, lt.tm_hour, "must fire in the 03:00-03:59 window (delayed 1hr)");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(9, lt.tm_mday, "must fire on the switch day, not skip to the next");
+
+    tz_pop();
+}
+
+TEST_CASE("dst rainmaker fall back fires once", "[esp_schedule]")
+{
+    tz_push(NY_TZ);
+
+    /* Daily 01:30. On fall-back day (Sun Nov 2 2025) 01:30 occurs twice. It must
+     * fire once at the first (EDT) occurrence and then advance to the next day,
+     * NOT fire again at the repeated 01:30 EST. */
+    time_t now = make_time_local(2025, 11, 1, 12, 0, 0);
+    esp_schedule_validity_t validity = { .start_time = 0, .end_time = now + 10L * 24 * 3600 };
+
+    time_t t1 = 0;
+    bool ok = esp_schedule_get_next_date_time(now, 1 * 60 + 30, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &t1);
+    TEST_ASSERT_TRUE(ok);
+    assert_time_eq("fall 01:30 first occurrence (EDT)", t1, make_time_local(2025, 11, 2, 1, 30, 0));
+
+    /* Next occurrence must be the next day, not the repeated 01:30 EST. */
+    time_t t2 = 0;
+    ok = esp_schedule_get_next_date_time(t1, 1 * 60 + 30, ESP_SCHEDULE_DAY_EVERYDAY, 0, 0, 0, &validity, &t2);
+    TEST_ASSERT_TRUE(ok);
+    assert_time_eq("fall next occurrence is next day", t2, make_time_local(2025, 11, 3, 1, 30, 0));
+    TEST_ASSERT_TRUE_MESSAGE((t2 - t1) >= 24 * 3600, "advanced a full day, not the repeated DST hour");
+
+    tz_pop();
+}
+
+/* --- A stored config that is invalid under the current rules must be dropped on
+ * restore, not armed. Configurations written by older versions can contain
+ * combinations that are now rejected. --- */
+TEST_CASE("nvs restore drops invalid config", "[esp_schedule]")
+{
+    esp_netif_init(); /* esp_schedule_init() runs SNTP, which needs the TCP/IP stack */
+    /* app_main() already brought up NVS for this test app. Start from an empty
+     * schedule namespace so the count assertions below are exact. */
+    TEST_ASSERT_EQUAL(ESP_OK, esp_schedule_nvs_remove_all());
+
+    /* Store a DATE schedule carrying a weekday mask (rule V2) - accepted by
+     * 1.3.3, which silently discarded day.repeat_days. */
+    esp_schedule_t *stored = calloc(1, sizeof(esp_schedule_t));
+    TEST_ASSERT_NOT_NULL(stored);
+    strlcpy(stored->name, "stale_cfg", sizeof(stored->name));
+    stored->trigger.type = ESP_SCHEDULE_TYPE_DATE;
+    stored->trigger.hours = 9;
+    stored->trigger.day.repeat_days = ESP_SCHEDULE_DAY_MONDAY;
+    stored->trigger.date.day = 15;
+    TEST_ASSERT_FALSE(esp_schedule_trigger_is_valid(&stored->trigger, stored->name));
+    TEST_ASSERT_EQUAL(ESP_OK, esp_schedule_nvs_add(stored));
+    free(stored);
+
+    uint8_t count = 0xFF;
+    esp_schedule_handle_t *handle_list = esp_schedule_init(true, NULL, &count);
+    TEST_ASSERT_EQUAL_MESSAGE(0, count, "invalid stored config must not be armed");
+    free(handle_list);
+
+    /* It was also removed from NVS, so it cannot come back on the next boot. */
+    count = 0xFF;
+    handle_list = esp_schedule_nvs_get_all(&count);
+    TEST_ASSERT_EQUAL_MESSAGE(0, count, "invalid stored config must be deleted from NVS");
+    free(handle_list);
+}
+
+/* Unity runs setUp()/tearDown() before/after every TEST_CASE. tearDown()
+ * restores TZ even if a DST test aborted via a failed assertion before its own
+ * tz_pop(), so a leaked TZ cannot make later timezone-independent tests fail. */
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+    tz_pop();
+}

--- a/esp_schedule/test_app/pytest_esp_schedule.py
+++ b/esp_schedule/test_app/pytest_esp_schedule.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import glob
+from pathlib import Path
+
+import pytest
+from pytest_embedded import Dut
+from pytest_embedded_idf.utils import idf_parametrize
+
+
+# The `generic` marker is what selects this case on CI: the run-target job filters
+# with `-m <runner marker>`, so an unmarked test is deselected everywhere and the
+# app would only ever be built, never run.
+@pytest.mark.generic
+@pytest.mark.skipif(
+    not bool(glob.glob(f'{Path(__file__).parent.absolute()}/build*/')),
+    reason='Skipping: no build directory found for this IDF version'
+)
+# esp32 is one of the `generic` runners in the run-target matrix; the tests are
+# pure date/time logic, so one target is enough coverage.
+@idf_parametrize('target', ['esp32'], indirect=['target'])
+def test_esp_schedule(dut: Dut) -> None:
+    dut.run_all_single_board_cases()

--- a/esp_schedule/test_app/sdkconfig.defaults
+++ b/esp_schedule/test_app/sdkconfig.defaults
@@ -1,0 +1,2 @@
+# Disable watchdog
+CONFIG_ESP_TASK_WDT_INIT=n


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description

Fixes correctness bugs in the `esp_schedule` date/solar next-occurrence logic and a timer overflow, and adds a `test_app` with unit tests.

## Bug fixes

**Date engine rewrite.** Replaced the per-type ad-hoc next-time calculation with a single unified engine (`esp_schedule_get_next_date_time`) shared by date and solar triggers. It scans forward (up to 370 days) matching all constraints:
- Time of day (`hours`/`minutes`)
- Day-of-week mask (`day.repeat_days`)
- Day-of-month (`date.day`)
- Months-of-year mask (`date.repeat_months`)
- Specific year (`date.year` + `date.repeat_every_year`)

Day-of-week and day-of-month combine with **OR**; month and year act as additional filters. This adds flexibility (combined weekday/monthday/month/year patterns, one-shot specific-date triggers) that the previous per-type paths could not express.

**Timer overflow fix.** Old code computed the timer period as `(diff * 1000) / portTICK_PERIOD_MS` in 32-bit, which overflowed for large diffs (long-horizon schedules fired early). Period is now computed in 64-bit and clamped to `portMAX_DELAY - 1`; `esp_schedule_common_timer_cb` re-arms for the remaining time when a diff exceeds one timer period.

**One-shot handling.** Added `esp_schedule_trigger_fired_and_done` so a fired one-shot trigger is not recomputed to a future occurrence.

**Solar triggers** now honor the same day/month/year filters when computing the next valid sunrise/sunset, plus `solar.offset_minutes`.

## Other

- Header: added `extern "C"` guards, exposed internal functions for unit testing, updated copyright to 2025-2026.
- README: documented date-based and solar trigger patterns with examples.
- `test_app` with 23 unit tests covering the date/solar engine, DST (spring-forward / fall-back compliance), validity windows, and one-shot fired-and-done detection. Registered in `.build-test-rules.yml` and `test_app/CMakeLists.txt`; `pytest_esp_schedule.py` runs them.