### PR TITLE
esp_sysview: Fix flush path and events buffer overflow

### DIFF
--- a/esp_sysview/idf_component.yml
+++ b/esp_sysview/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.1.0
+version: 1.1.1
 description: SEGGER SystemView component for ESP-IDF
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_sysview
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/esp_sysview/src/SEGGER/SEGGER_RTT.h
+++ b/esp_sysview/src/SEGGER/SEGGER_RTT.h
@@ -401,10 +401,6 @@ unsigned     SEGGER_RTT_PutCharSkipNoLock       (unsigned BufferIndex, char c);
 unsigned     SEGGER_RTT_GetAvailWriteSpace      (unsigned BufferIndex);
 unsigned     SEGGER_RTT_GetBytesInBuffer        (unsigned BufferIndex);
 
-// Espressif specific functions
-void         SEGGER_RTT_ESP_FlushNoLock         (void);
-void         SEGGER_RTT_ESP_Flush               (void);
-
 //
 // Function macro for performance optimization
 //

--- a/esp_sysview/src/esp/SEGGER_RTT_esp.c
+++ b/esp_sysview/src/esp/SEGGER_RTT_esp.c
@@ -7,10 +7,10 @@
 #include "string.h"
 #include "freertos/FreeRTOS.h"
 #include "SEGGER_RTT.h"
+#include "SEGGER_RTT_esp.h"
 #include "SEGGER_SYSVIEW.h"
 #include "SEGGER_SYSVIEW_Conf.h"
 
-#include "esp_log.h"
 #include "esp_cpu.h"
 #include "esp_trace_port_transport.h"
 #include "esp_trace_port_encoder.h"
@@ -18,7 +18,7 @@
 #include "adapter_encoder_sysview.h"
 #include "esp_private/startup_internal.h"
 
-const static char *TAG = "segger_rtt";
+/* No ESP_LOGx here, these functions can run in ISR context, use ESP_EARLY_LOGx instead */
 
 #define SYSVIEW_EVENTS_BUF_SZ         255U
 
@@ -48,38 +48,32 @@ static uint8_t s_down_buf[SYSVIEW_DOWN_BUF_SIZE];
 *  Function description
 *    Flushes buffered events.
 *
-*  Parameters
-*    min_sz  Threshold for flushing data. If current filling level is above this value, data will be flushed. JTAG destinations only.
-*    tmo     Timeout for operation (in us). Use ESP_APPTRACE_TMO_INFINITE to wait indefinitely.
-*
 *  Return value
-*    None.
+*    ESP_OK on success, an error code otherwise. Buffered events are kept on error.
 */
-void SEGGER_RTT_ESP_FlushNoLock(void)
+esp_err_t SEGGER_RTT_ESP_FlushNoLock(void)
 {
-    esp_err_t res;
     esp_trace_encoder_t *encoder = SEGGER_SYSVIEW_ESP_GetEncoder();
 
     if (!encoder) {
-        ESP_LOGE(TAG, "Encoder not initialized");
-        return;
+        return ESP_ERR_INVALID_STATE;
     }
 
     esp_trace_transport_t *tp = encoder->tp;
+    esp_err_t write_res = ESP_OK;
 
     if (s_events_buf_filled > 0) {
-        res = tp->vt->write(tp, s_events_buf, s_events_buf_filled, SEGGER_HOST_WAIT_TMO);
-        if (res != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to write buffered events (%d)!", res);
+        write_res = tp->vt->write(tp, s_events_buf, s_events_buf_filled, SEGGER_HOST_WAIT_TMO);
+        if (write_res == ESP_OK) {
+            s_events_buf_filled = 0;
         }
-    }
-    // flush even if we failed to write buffered events, because no new events will be sent after STOP
-    res = tp->vt->flush_nolock(tp);
-    if (res != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to flush buffered events (%d)!", res);
+        // otherwise keep the events for the next call
     }
 
-    s_events_buf_filled = 0;
+    // flush even if the write failed, it frees space in the transport
+    esp_err_t flush_res = tp->vt->flush_nolock(tp);
+
+    return (write_res != ESP_OK) ? write_res : flush_res;
 }
 
 /*********************************************************************
@@ -91,13 +85,15 @@ void SEGGER_RTT_ESP_FlushNoLock(void)
 *
 *
 *  Return value
-*    None.
+*    ESP_OK on success, an error code otherwise.
 */
-void SEGGER_RTT_ESP_Flush(void)
+esp_err_t SEGGER_RTT_ESP_Flush(void)
 {
     SEGGER_SYSVIEW_LOCK();
-    SEGGER_RTT_ESP_FlushNoLock();
+    esp_err_t res = SEGGER_RTT_ESP_FlushNoLock();
     SEGGER_SYSVIEW_UNLOCK();
+
+    return res;
 }
 
 /*********************************************************************
@@ -194,8 +190,7 @@ unsigned SEGGER_RTT_WriteSkipNoLock(unsigned BufferIndex, const void *pBuffer, u
     }
 
     if (NumBytes > SYSVIEW_EVENTS_BUF_SZ) {
-        ESP_LOGE(TAG, "Too large event %u bytes!", NumBytes);
-        return 0;
+        return 0;  /* the caller sees the event was dropped */
     }
     if (link_type == ESP_TRACE_LINK_DEBUG_PROBE) {
         if (esp_cpu_get_core_id()) { // dual core specific code
@@ -209,14 +204,16 @@ unsigned SEGGER_RTT_WriteSkipNoLock(unsigned BufferIndex, const void *pBuffer, u
             }
         }
 
-        if (s_events_buf_filled + NumBytes > SYSVIEW_EVENTS_BUF_SZ) {
+    }
 
-            esp_err_t res = tp->vt->write(tp, s_events_buf, s_events_buf_filled, SEGGER_HOST_WAIT_TMO);
-            if (res != ESP_OK) {
-                return 0; // skip current data buffer only, accumulated events are kept
-            }
-            s_events_buf_filled = 0;
+    // Checked for every link type, a failed write keeps the events buffered
+    if (s_events_buf_filled + NumBytes > SYSVIEW_EVENTS_BUF_SZ) {
+
+        esp_err_t res = tp->vt->write(tp, s_events_buf, s_events_buf_filled, SEGGER_HOST_WAIT_TMO);
+        if (res != ESP_OK) {
+            return 0; // skip current data buffer only, accumulated events are kept
         }
+        s_events_buf_filled = 0;
     }
     memcpy(&s_events_buf[s_events_buf_filled], pBuffer, NumBytes);
     s_events_buf_filled += NumBytes;

--- a/esp_sysview/src/esp/adapter_encoder_sysview.c
+++ b/esp_sysview/src/esp/adapter_encoder_sysview.c
@@ -17,6 +17,7 @@
 #include "esp_trace_util.h"
 #include "SEGGER_SYSVIEW.h"
 #include "SEGGER_RTT.h"
+#include "SEGGER_RTT_esp.h"
 
 /*
  * This adapter is used to create a public system-wide APIs for SystemView.
@@ -120,7 +121,8 @@ static void panic_handler(esp_trace_encoder_t *enc, const void *info)
     (void)enc;
     (void)info;
 
-    SEGGER_RTT_ESP_Flush();
+    /* No lock here, the panicking core may already hold it */
+    SEGGER_RTT_ESP_FlushNoLock();
 }
 
 /**
@@ -153,11 +155,44 @@ static void give_lock(esp_trace_encoder_t *enc, unsigned int_state)
 }
 
 /**
+ * @brief Flushes buffered events from task context.
+ *
+ * @param enc Pointer to the encoder structure. Must not be NULL.
+ *
+ * @return ESP_OK on success, otherwise \see esp_err_t
+ */
+static esp_err_t flush(esp_trace_encoder_t *enc)
+{
+    if (!enc || !enc->tp || !enc->tp->vt->flush_nolock) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    /* One call may be too short to send all the data, so repeat it and release
+     * the lock in between to keep interrupts enabled */
+    esp_trace_tmo_t tmo;
+    esp_trace_tmo_init(&tmo, SYSVIEW_FLUSH_TMO_US);
+
+    esp_err_t err;
+    do {
+        unsigned int int_state = take_lock(enc, ESP_TRACE_TMO_INFINITE);
+        err = SEGGER_RTT_ESP_FlushNoLock();
+        give_lock(enc, int_state);
+
+        if (err != ESP_ERR_TIMEOUT && err != ESP_ERR_NO_MEM) {
+            break;  /* done, or an error that repeating cannot fix */
+        }
+    } while (esp_trace_tmo_check(&tmo) == ESP_OK);
+
+    return err;
+}
+
+/**
  * @brief Sysview encoder vtable.
  */
 static const esp_trace_encoder_vtable_t s_sysview_vt = {
     .init                  = init,
     .panic_handler         = panic_handler,
+    .flush                 = flush,
     .take_lock             = take_lock,
     .give_lock             = give_lock,
 #if CONFIG_ESP_TRACE_FUNCTION_TRACE

--- a/esp_sysview/src/ext/heap_trace_module.c
+++ b/esp_sysview/src/ext/heap_trace_module.c
@@ -7,6 +7,7 @@
 #include <sdkconfig.h>
 #include "SEGGER_SYSVIEW.h"
 #include "SEGGER_RTT.h"
+#include "SEGGER_RTT_esp.h"
 #include "esp_app_trace.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -51,8 +52,7 @@ esp_err_t esp_sysview_heap_trace_start(uint32_t tmo)
 esp_err_t esp_sysview_heap_trace_stop(void)
 {
     ESP_EARLY_LOGV(TAG, "%s", __func__);
-    SEGGER_RTT_ESP_Flush();
-    return ESP_OK;
+    return SEGGER_RTT_ESP_Flush();
 }
 
 void esp_sysview_heap_trace_alloc(const void *addr, uint32_t size, const void *callers)
@@ -92,6 +92,5 @@ void esp_sysview_heap_trace_free(const void *addr, const void *callers)
 
 esp_err_t esp_sysview_flush(void)
 {
-    SEGGER_RTT_ESP_Flush();
-    return ESP_OK;
+    return SEGGER_RTT_ESP_Flush();
 }

--- a/esp_sysview/src/include/SEGGER_RTT_esp.h
+++ b/esp_sysview/src/include/SEGGER_RTT_esp.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Flushes buffered events without taking the encoder lock.
+ *
+ * @return ESP_OK on success, an error code otherwise. Buffered events are kept on error.
+ */
+esp_err_t SEGGER_RTT_ESP_FlushNoLock(void);
+
+/**
+ * @brief Flushes buffered events.
+ *
+ * @return ESP_OK on success, an error code otherwise.
+ */
+esp_err_t SEGGER_RTT_ESP_Flush(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp_sysview/src/include/esp_sysview_heap_trace_module.h
+++ b/esp_sysview/src/include/esp_sysview_heap_trace_module.h
@@ -15,7 +15,7 @@ extern "C" {
 /**
  * @brief Flushes remaining data in SystemView trace buffer to host.
  *
- * @return ESP_OK.
+ * @return ESP_OK on success, an error code otherwise.
  */
 esp_err_t esp_sysview_flush(void);
 
@@ -41,7 +41,7 @@ esp_err_t esp_sysview_heap_trace_start(uint32_t tmo);
 /**
  * @brief  Stops SystemView heap tracing.
  *
- * @return ESP_OK.
+ * @return ESP_OK on success, an error code otherwise.
  */
 esp_err_t esp_sysview_heap_trace_stop(void);
 


### PR DESCRIPTION
- check the s_events_buf size for every link type, not only the debug probe one, so that a failed write cannot write past the end of it
- return esp_err_t from the flush functions and keep the events buffered when a write fails, instead of dropping them
- add the encoder flush entry so that esp_trace_flush() works, and call flush_nolock() again only when the transport returns quickly
- take no lock in the panic handler, and do not log from the RTT path
- move the SEGGER_RTT_ESP_* declarations out of the vendored SEGGER header into an Espressif one