### PR TITLE
refactor(esp_schedule): add porting glue layer and split public header (IEC-569)

### DIFF
--- a/esp_schedule/CMakeLists.txt
+++ b/esp_schedule/CMakeLists.txt
@@ -1,8 +1,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/esp_schedule_variables.cmake)
 
 # Include ESP-IDF specific glue sources and include directories
-list(APPEND ESP_SCHEDULE_SRCS "src/esp_schedule_nvs.c"
-                              "glue/esp/nvs.c"
+list(APPEND ESP_SCHEDULE_SRCS "glue/esp/nvs.c"
                               "glue/esp/time.c"
                               "glue/esp/timer.c")
 list(APPEND ESP_SCHEDULE_INCLUDE_DIRS "include/esp")

--- a/esp_schedule/CMakeLists.txt
+++ b/esp_schedule/CMakeLists.txt
@@ -1,7 +1,15 @@
-set(component_srcs "src/esp_schedule.c"
-                   "src/esp_schedule_nvs.c")
+include(${CMAKE_CURRENT_LIST_DIR}/esp_schedule_variables.cmake)
 
-idf_component_register(SRCS "${component_srcs}"
-                       INCLUDE_DIRS "include"
-                       PRIV_INCLUDE_DIRS "src"
-                       PRIV_REQUIRES nvs_flash esp_netif)
+# Include ESP-IDF specific glue sources and include directories
+list(APPEND ESP_SCHEDULE_SRCS "src/esp_schedule_nvs.c"
+                              "glue/esp/nvs.c"
+                              "glue/esp/time.c"
+                              "glue/esp/timer.c")
+list(APPEND ESP_SCHEDULE_INCLUDE_DIRS "include/esp")
+list(APPEND ESP_SCHEDULE_PRIV_INCLUDE_DIRS "glue/esp")
+list(APPEND ESP_SCHEDULE_PRIV_REQUIRES "nvs_flash" "esp_netif")
+
+idf_component_register(SRCS ${ESP_SCHEDULE_SRCS}
+                       INCLUDE_DIRS ${ESP_SCHEDULE_INCLUDE_DIRS}
+                       PRIV_INCLUDE_DIRS ${ESP_SCHEDULE_PRIV_INCLUDE_DIRS}
+                       PRIV_REQUIRES ${ESP_SCHEDULE_PRIV_REQUIRES})

--- a/esp_schedule/README.md
+++ b/esp_schedule/README.md
@@ -162,3 +162,30 @@ s3.solar.longitude = -122.4194;
 ```
 
 The day is selected first, then the actual sunrise/sunset instant for that day is computed for your location. Days with no solar event (polar night/day) are skipped.
+
+## Glue Layers
+
+This component makes use of the following glue abstraction layers under `glue`:
+- `glue_log.h`: Logging
+- `glue_mem.h`: Memory allocation
+- `glue_nvs.h`: Non-Volatile Storage
+- `glue_time.h`: Time provider and synchronization
+- `glue_timer.h`: Timer implementation
+
+### As an ESP-IDF component
+
+When using this component normally, the default glue implementations are used:
+- Logging: `glue/esp/glue_log_impl.h`
+- Memory allocation: `glue/esp/glue_mem_impl.h`
+- Non-Volatile Storage: `glue/esp/nvs.c`
+- Time provider and synchronization: `glue/esp/time.c`
+- Timer implementation: `glue/esp/timer.c`
+
+### Custom glue implementations
+
+If the underlying implementations are required to be changed, then you would need to implement a custom `CMakeLists.txt` for this component:
+1. Common non-glue sources and include directories can be included using `esp_schedule_variables.cmake`.
+2. Append your glue sources and include directories to the variables provided.
+3. Use the variables to build your target library (e.g., passing them to `idf_component_register`).
+
+The [default implementation](#as-an-esp-idf-component) does this in this component's `CMakeLists.txt` with the default glue implementations.

--- a/esp_schedule/README.md
+++ b/esp_schedule/README.md
@@ -163,6 +163,26 @@ s3.solar.longitude = -122.4194;
 
 The day is selected first, then the actual sunrise/sunset instant for that day is computed for your location. Days with no solar event (polar night/day) are skipped.
 
+## Timer Task Stack Requirement
+
+> **Set `CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH` to at least 3072.** The 2048-byte default is not enough and overflows the timer daemon task on some IDF versions.
+
+With the default ESP-IDF glue, a schedule is driven by a FreeRTOS software timer, so its callback runs on the shared timer daemon task (`Tmr Svc`). A repeating schedule re-arms itself from inside that callback, and the re-arm computes the next occurrence through the date engine and formats it for logging (`localtime_r`, `strftime`) — all on the daemon's stack.
+
+An overflow here is not local to your schedule: it takes down the one task that services **every** software timer in the application. It surfaces as
+
+```
+***ERROR*** A stack overflow in task Tmr Svc has been detected.
+```
+
+Add to `sdkconfig.defaults`:
+
+```
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3072
+```
+
+If you supply a [custom timer glue](#custom-glue-implementations) that dispatches callbacks on its own task instead, size that task's stack for the same work.
+
 ## Glue Layers
 
 This component makes use of the following glue abstraction layers under `glue`:

--- a/esp_schedule/esp_schedule_variables.cmake
+++ b/esp_schedule/esp_schedule_variables.cmake
@@ -1,0 +1,15 @@
+# This file is used to set the common non-glue variables for the esp_schedule component.
+# Include this file and extend the variables to add glue sources and include directories.
+
+# Source files
+set(ESP_SCHEDULE_SRCS "${CMAKE_CURRENT_LIST_DIR}/src/esp_schedule.c")
+
+# Include directories
+set(ESP_SCHEDULE_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/include/common")
+
+# Private include directories
+set(ESP_SCHEDULE_PRIV_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/src"
+                                   "${CMAKE_CURRENT_LIST_DIR}/glue")
+
+# Private requirements
+set(ESP_SCHEDULE_PRIV_REQUIRES "esp_daylight")

--- a/esp_schedule/esp_schedule_variables.cmake
+++ b/esp_schedule/esp_schedule_variables.cmake
@@ -1,8 +1,11 @@
 # This file is used to set the common non-glue variables for the esp_schedule component.
 # Include this file and extend the variables to add glue sources and include directories.
 
-# Source files
-set(ESP_SCHEDULE_SRCS "${CMAKE_CURRENT_LIST_DIR}/src/esp_schedule.c")
+# Source files. src/esp_schedule_nvs.c is platform-agnostic: it talks to storage
+# only through glue_nvs.h, so it belongs here rather than with the glue sources.
+# Leaving it out would silently build a port with no schedule persistence.
+set(ESP_SCHEDULE_SRCS "${CMAKE_CURRENT_LIST_DIR}/src/esp_schedule.c"
+                      "${CMAKE_CURRENT_LIST_DIR}/src/esp_schedule_nvs.c")
 
 # Include directories
 set(ESP_SCHEDULE_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/include/common")

--- a/esp_schedule/examples/get_started/README.md
+++ b/esp_schedule/examples/get_started/README.md
@@ -210,5 +210,5 @@ If you run out of memory when creating many schedules:
 
 ## Further Reading
 
-- [ESP Schedule API Reference](../../include/esp_schedule.h)
+- [ESP Schedule API Reference](../../include/common/esp_schedule_untyped.h)
 - [ESP Schedule README](../../README.md)

--- a/esp_schedule/examples/get_started/README.md
+++ b/esp_schedule/examples/get_started/README.md
@@ -210,5 +210,5 @@ If you run out of memory when creating many schedules:
 
 ## Further Reading
 
-- [ESP Schedule API Reference](../../include/common/esp_schedule_untyped.h)
+- [ESP Schedule API Reference](../../include/esp/esp_schedule.h)
 - [ESP Schedule README](../../README.md)

--- a/esp_schedule/examples/get_started/main/idf_component.yml
+++ b/esp_schedule/examples/get_started/main/idf_component.yml
@@ -3,7 +3,7 @@ dependencies:
   idf:
     version: ">=5.1"
   espressif/esp_schedule:
-    version: "~1.4.0"
+    version: "~1.4.1"
     override_path: "../../../."
   espressif/network_provisioning:
     version: "~1.2.0"

--- a/esp_schedule/examples/get_started/sdkconfig.defaults
+++ b/esp_schedule/examples/get_started/sdkconfig.defaults
@@ -5,3 +5,10 @@ CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT=y
 
 # Example can become pretty big, so enable larger partition
 CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y
+
+# A schedule re-arms from inside its own timer callback, which runs on the
+# FreeRTOS timer daemon task. That path formats the next fire time (strftime,
+# localtime_r) and runs the date engine, which does not fit in the 2048-byte
+# default on every IDF version. See "Timer Task Stack Requirement" in the
+# component README.
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3072

--- a/esp_schedule/glue/esp/glue_log_impl.h
+++ b/esp_schedule/glue/esp/glue_log_impl.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file glue_log_impl.h
+ * @brief Implementation of the logging glue layer for ESP-IDF.
+ */
+
+#pragma once
+
+/** Use esp_log.h for logging. */
+#include "esp_log.h"
+#define ESP_SCHEDULE_LOGE(tag, fmt, ...) ESP_LOGE(tag, fmt, ##__VA_ARGS__)
+#define ESP_SCHEDULE_LOGW(tag, fmt, ...) ESP_LOGW(tag, fmt, ##__VA_ARGS__)
+#define ESP_SCHEDULE_LOGI(tag, fmt, ...) ESP_LOGI(tag, fmt, ##__VA_ARGS__)
+#define ESP_SCHEDULE_LOGD(tag, fmt, ...) ESP_LOGD(tag, fmt, ##__VA_ARGS__)
+#define ESP_SCHEDULE_LOGV(tag, fmt, ...) ESP_LOGV(tag, fmt, ##__VA_ARGS__)

--- a/esp_schedule/glue/esp/glue_mem_impl.h
+++ b/esp_schedule/glue/esp/glue_mem_impl.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file glue_mem_impl.h
+ * @brief Implementation of the memory allocation glue layer for ESP-IDF.
+ */
+
+#pragma once
+
+/** Use esp_heap_caps.h for memory allocation in external RAM. */
+#include "esp_heap_caps.h"
+
+#if ((CONFIG_SPIRAM || CONFIG_SPIRAM_SUPPORT) && \
+        (CONFIG_SPIRAM_USE_CAPS_ALLOC || CONFIG_SPIRAM_USE_MALLOC))
+#define ESP_SCHEDULE_MALLOC(size)        heap_caps_malloc_prefer(size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
+#define ESP_SCHEDULE_CALLOC(num, size)   heap_caps_calloc_prefer(num, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
+#define ESP_SCHEDULE_REALLOC(ptr, size)  heap_caps_realloc_prefer(ptr, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
+#else
+#define ESP_SCHEDULE_MALLOC(size)        malloc(size)
+#define ESP_SCHEDULE_CALLOC(num, size)   calloc(num, size)
+#define ESP_SCHEDULE_REALLOC(ptr, size)  realloc(ptr, size)
+#endif
+
+#define ESP_SCHEDULE_FREE(ptr) free(ptr)

--- a/esp_schedule/glue/esp/glue_mem_impl.h
+++ b/esp_schedule/glue/esp/glue_mem_impl.h
@@ -11,6 +11,9 @@
 
 #pragma once
 
+/* The non-SPIRAM fallbacks below expand to the standard allocators. */
+#include <stdlib.h>
+
 /** Use esp_heap_caps.h for memory allocation in external RAM. */
 #include "esp_heap_caps.h"
 

--- a/esp_schedule/glue/esp/nvs.c
+++ b/esp_schedule/glue/esp/nvs.c
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file esp_nvs.c
+ * @brief ESP NVS implementation.
+ */
+
+#include "nvs_flash.h"
+#include "glue_nvs.h"
+
+#include <string.h>
+
+static nvs_open_mode_t to_nvs_open_mode(esp_schedule_nvs_open_mode_t mode)
+{
+    switch (mode) {
+    case ESP_SCHEDULE_NVS_OPEN_READONLY:
+        return NVS_READONLY;
+    case ESP_SCHEDULE_NVS_OPEN_READWRITE:
+        return NVS_READWRITE;
+    default:
+        return NVS_READWRITE;
+    }
+}
+
+static esp_schedule_nvs_error_t to_esp_schedule_nvs_error(esp_err_t err)
+{
+    switch (err) {
+    case ESP_OK:
+        return ESP_SCHEDULE_NVS_OK;
+    case ESP_ERR_NVS_NOT_FOUND:
+        return ESP_SCHEDULE_NVS_NOT_FOUND;
+    case ESP_ERR_NO_MEM:
+    case ESP_ERR_NVS_NOT_ENOUGH_SPACE:
+        /* Preserve the out-of-memory / out-of-space signal so callers can tell
+         * resource exhaustion apart from a generic failure and take the correct
+         * recovery path (e.g. free cached data and retry the save). */
+        return ESP_SCHEDULE_NVS_NO_MEM;
+    default:
+        return ESP_SCHEDULE_NVS_ERROR;
+    }
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_open_from_partition(const char *partition_label, const char *name_space, esp_schedule_nvs_open_mode_t mode, esp_schedule_nvs_handle_t *p_handle)
+{
+    return to_esp_schedule_nvs_error(nvs_open_from_partition(partition_label, name_space, to_nvs_open_mode(mode), (nvs_handle_t *) p_handle));
+}
+
+void esp_schedule_nvs_close(esp_schedule_nvs_handle_t handle)
+{
+    nvs_close((nvs_handle_t) handle);
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_commit(esp_schedule_nvs_handle_t handle)
+{
+    return to_esp_schedule_nvs_error(nvs_commit((nvs_handle_t) handle));
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_erase_key(esp_schedule_nvs_handle_t handle, const char *key)
+{
+    return to_esp_schedule_nvs_error(nvs_erase_key((nvs_handle_t) handle, key));
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_erase_all(esp_schedule_nvs_handle_t handle)
+{
+    return to_esp_schedule_nvs_error(nvs_erase_all((nvs_handle_t) handle));
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_set_blob(esp_schedule_nvs_handle_t handle, const char *key, const void *value, size_t value_len)
+{
+    return to_esp_schedule_nvs_error(nvs_set_blob((nvs_handle_t) handle, key, value, value_len));
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_get_blob(esp_schedule_nvs_handle_t handle, const char *key, void *value, size_t *p_value_len)
+{
+    return to_esp_schedule_nvs_error(nvs_get_blob((nvs_handle_t) handle, key, value, p_value_len));
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_set_u8(esp_schedule_nvs_handle_t handle, const char *key, uint8_t value)
+{
+    return to_esp_schedule_nvs_error(nvs_set_u8((nvs_handle_t) handle, key, value));
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_get_u8(esp_schedule_nvs_handle_t handle, const char *key, uint8_t *value)
+{
+    return to_esp_schedule_nvs_error(nvs_get_u8((nvs_handle_t) handle, key, value));
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_entry_find_blobs(const char *partition_label, const char *name_space, esp_schedule_nvs_iterator_t *iterator)
+{
+    return to_esp_schedule_nvs_error(nvs_entry_find(partition_label, name_space, NVS_TYPE_BLOB, (nvs_iterator_t *) iterator));
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_entry_get_key(esp_schedule_nvs_iterator_t iterator, char **p_key)
+{
+    nvs_entry_info_t nvs_entry;
+    esp_err_t err = nvs_entry_info((nvs_iterator_t) iterator, &nvs_entry);
+    if (err != ESP_OK) {
+        return to_esp_schedule_nvs_error(err);
+    }
+    size_t key_len = strlen(nvs_entry.key);
+    *p_key = (char *)malloc(key_len + 1);
+    if (*p_key == NULL) {
+        return ESP_SCHEDULE_NVS_NO_MEM;
+    }
+    memcpy(*p_key, nvs_entry.key, key_len + 1);
+    return ESP_SCHEDULE_NVS_OK;
+}
+
+esp_schedule_nvs_error_t esp_schedule_nvs_entry_next(esp_schedule_nvs_iterator_t *iterator)
+{
+    return to_esp_schedule_nvs_error(nvs_entry_next((nvs_iterator_t *) iterator));
+}
+
+void esp_schedule_nvs_release_iterator(esp_schedule_nvs_iterator_t iterator)
+{
+    nvs_release_iterator((nvs_iterator_t) iterator);
+}

--- a/esp_schedule/glue/esp/nvs.c
+++ b/esp_schedule/glue/esp/nvs.c
@@ -5,12 +5,13 @@
  */
 
 /**
- * @file esp_nvs.c
+ * @file nvs.c
  * @brief ESP NVS implementation.
  */
 
 #include "nvs_flash.h"
 #include "glue_nvs.h"
+#include "glue_mem.h"
 
 #include <string.h>
 
@@ -102,7 +103,9 @@ esp_schedule_nvs_error_t esp_schedule_nvs_entry_get_key(esp_schedule_nvs_iterato
         return to_esp_schedule_nvs_error(err);
     }
     size_t key_len = strlen(nvs_entry.key);
-    *p_key = (char *)malloc(key_len + 1);
+    /* Freed by the caller with ESP_SCHEDULE_FREE, so it must come from the
+     * same allocator. */
+    *p_key = (char *)ESP_SCHEDULE_MALLOC(key_len + 1);
     if (*p_key == NULL) {
         return ESP_SCHEDULE_NVS_NO_MEM;
     }

--- a/esp_schedule/glue/esp/time.c
+++ b/esp_schedule/glue/esp/time.c
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file esp_time.c
+ * @brief ESP implementation of the time interface for the esp_schedule component
+ */
+
+#include "glue_time.h"
+#include <esp_sntp.h>
+
+time_t esp_schedule_get_time(time_t *p_time)
+{
+    return time(p_time);
+}
+
+void esp_schedule_timesync_init(void)
+{
+    if (!esp_sntp_enabled()) {
+        esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
+        esp_sntp_setservername(0, "pool.ntp.org");
+        esp_sntp_init();
+    }
+}

--- a/esp_schedule/glue/esp/time.c
+++ b/esp_schedule/glue/esp/time.c
@@ -5,7 +5,7 @@
  */
 
 /**
- * @file esp_time.c
+ * @file time.c
  * @brief ESP implementation of the time interface for the esp_schedule component
  */
 

--- a/esp_schedule/glue/esp/timer.c
+++ b/esp_schedule/glue/esp/timer.c
@@ -5,12 +5,13 @@
  */
 
 /**
- * @file esp_timer.c
+ * @file timer.c
  * @brief ESP Timer implementation.
  */
 
 #include "glue_timer.h"
 #include "glue_log.h"
+#include "glue_mem.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -40,7 +41,7 @@ typedef struct {
     esp_schedule_timer_cb_t cb;
     void *priv_data;
     uint64_t remaining_ticks; /* ticks still to wait after the current period */
-} __timer_priv_data_t;
+} esp_schedule_timer_priv_data_t;
 
 /* Callback serialization ******************************************************
  *
@@ -48,7 +49,7 @@ typedef struct {
  * while esp_schedule_timer_cancel() runs in the caller's (app) task. xTimerStop
  * only prevents FUTURE expiries; it does not wait for a callback that is already
  * executing. Without synchronization, cancel() would free() the priv_data (and
- * the caller then frees the schedule) while __timer_common_cb is still
+ * the caller then frees the schedule) while esp_schedule_timer_common_cb is still
  * dereferencing them in the daemon task -> use-after-free.
  *
  * A single global mutex serializes the callback body against cancel(). The
@@ -70,7 +71,7 @@ static portMUX_TYPE s_cb_mutex_init_lock = portMUX_INITIALIZER_UNLOCKED;
 static StaticSemaphore_t s_cb_mutex_buf;
 static SemaphoreHandle_t s_cb_mutex = NULL;
 
-static void __ensure_cb_mutex(void)
+static void esp_schedule_ensure_cb_mutex(void)
 {
     if (s_cb_mutex != NULL) {
         return;
@@ -87,7 +88,7 @@ static void __ensure_cb_mutex(void)
 /**
  * @brief Whether the caller is running in the FreeRTOS timer daemon task.
  */
-static bool __in_timer_daemon(void)
+static bool esp_schedule_in_timer_daemon(void)
 {
     return xTaskGetCurrentTaskHandle() == xTimerGetTimerDaemonTaskHandle();
 }
@@ -101,9 +102,9 @@ static bool __in_timer_daemon(void)
  * task via the user trigger callback, so the block time must be chosen from the
  * calling context rather than hardcoded.
  */
-static TickType_t __cmd_block_ticks(void)
+static TickType_t esp_schedule_cmd_block_ticks(void)
 {
-    return __in_timer_daemon() ? 0 : portMAX_DELAY;
+    return esp_schedule_in_timer_daemon() ? 0 : portMAX_DELAY;
 }
 
 /* Private functions **********************************************************/
@@ -111,7 +112,7 @@ static TickType_t __cmd_block_ticks(void)
 /**
  * @brief Convert a delay in seconds to timer ticks (64-bit to avoid overflow).
  */
-static uint64_t __ticks_from_seconds(uint32_t delay_seconds)
+static uint64_t esp_schedule_ticks_from_seconds(uint32_t delay_seconds)
 {
     return (((uint64_t) delay_seconds) * 1000) / portTICK_PERIOD_MS;
 }
@@ -119,7 +120,7 @@ static uint64_t __ticks_from_seconds(uint32_t delay_seconds)
 /**
  * @brief Clamp a 64-bit tick count to a valid single timer period (>0).
  */
-static TickType_t __period_ticks(uint64_t total_ticks)
+static TickType_t esp_schedule_period_ticks(uint64_t total_ticks)
 {
     if (total_ticks == 0) {
         return 1; /* a timer period must be strictly greater than 0 */
@@ -138,9 +139,9 @@ static TickType_t __period_ticks(uint64_t total_ticks)
  *
  * @return Pointer to the timer private data.
  */
-static __timer_priv_data_t *__timer_priv_data_create(esp_schedule_timer_cb_t cb, void *priv_data)
+static esp_schedule_timer_priv_data_t *esp_schedule_timer_priv_data_create(esp_schedule_timer_cb_t cb, void *priv_data)
 {
-    __timer_priv_data_t *data = calloc(1, sizeof(__timer_priv_data_t));
+    esp_schedule_timer_priv_data_t *data = ESP_SCHEDULE_CALLOC(1, sizeof(esp_schedule_timer_priv_data_t));
     if (data == NULL) {
         return NULL;
     }
@@ -156,9 +157,9 @@ static __timer_priv_data_t *__timer_priv_data_create(esp_schedule_timer_cb_t cb,
  *
  * @return Pointer to the timer private data.
  */
-static __timer_priv_data_t *__timer_priv_data_get(esp_schedule_timer_handle_t timer_handle)
+static esp_schedule_timer_priv_data_t *esp_schedule_timer_priv_data_get(esp_schedule_timer_handle_t timer_handle)
 {
-    return (__timer_priv_data_t *) pvTimerGetTimerID(timer_handle);
+    return (esp_schedule_timer_priv_data_t *) pvTimerGetTimerID(timer_handle);
 }
 
 /**
@@ -166,15 +167,15 @@ static __timer_priv_data_t *__timer_priv_data_get(esp_schedule_timer_handle_t ti
  *
  * @param[in] timer_handle Timer handle.
  */
-static void __timer_common_cb(TimerHandle_t timer_handle)
+static void esp_schedule_timer_common_cb(TimerHandle_t timer_handle)
 {
-    __ensure_cb_mutex();
+    esp_schedule_ensure_cb_mutex();
     /* Hold the mutex for the whole callback so cancel() can barrier against it.
      * priv_data is read AFTER acquiring the mutex: cancel() clears the timer ID
      * under the same mutex before freeing, so we either see a valid pointer
      * (cancel has not started) or NULL (cancel already ran). */
     xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
-    __timer_priv_data_t *timer_priv_data = __timer_priv_data_get(timer_handle);
+    esp_schedule_timer_priv_data_t *timer_priv_data = esp_schedule_timer_priv_data_get(timer_handle);
     if (timer_priv_data == NULL) {
         xSemaphoreGiveRecursive(s_cb_mutex);
         return;
@@ -188,7 +189,7 @@ static void __timer_common_cb(TimerHandle_t timer_handle)
          * full command queue would otherwise consume this slice of the delay
          * with no timer left running to serve it, and the schedule would
          * silently never fire. */
-        TickType_t period = __period_ticks(timer_priv_data->remaining_ticks);
+        TickType_t period = esp_schedule_period_ticks(timer_priv_data->remaining_ticks);
         if (xTimerChangePeriod(timer_handle, period, 0) == pdPASS) {
             timer_priv_data->remaining_ticks -= period;
         } else {
@@ -205,11 +206,11 @@ static void __timer_common_cb(TimerHandle_t timer_handle)
 
 bool esp_schedule_timer_start(esp_schedule_timer_handle_t *p_timer_handle, uint32_t delay_seconds, esp_schedule_timer_cb_t cb, void *priv_data)
 {
-    __ensure_cb_mutex();
+    esp_schedule_ensure_cb_mutex();
     TimerHandle_t timer_handle = (TimerHandle_t) * p_timer_handle;
 
-    uint64_t total_ticks = __ticks_from_seconds(delay_seconds);
-    TickType_t period = __period_ticks(total_ticks);
+    uint64_t total_ticks = esp_schedule_ticks_from_seconds(delay_seconds);
+    TickType_t period = esp_schedule_period_ticks(total_ticks);
     uint64_t remaining_ticks = (total_ticks > period) ? (total_ticks - period) : 0;
 
     if (timer_handle != NULL) {
@@ -229,7 +230,7 @@ bool esp_schedule_timer_start(esp_schedule_timer_handle_t *p_timer_handle, uint3
          * (cb, priv_data) pair. Re-arming from inside the fired callback takes
          * it recursively on the task that already owns it. */
         xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
-        __timer_priv_data_t *timer_priv_data = __timer_priv_data_get(timer_handle);
+        esp_schedule_timer_priv_data_t *timer_priv_data = esp_schedule_timer_priv_data_get(timer_handle);
         if (timer_priv_data == NULL) {
             /* A concurrent cancel() detached and is deleting this timer; there
              * is nothing safe to reuse. */
@@ -244,28 +245,28 @@ bool esp_schedule_timer_start(esp_schedule_timer_handle_t *p_timer_handle, uint3
         /* xTimerChangePeriod also (re)starts a dormant/expired timer. A dropped
          * command leaves the schedule disarmed, so report it rather than
          * claiming success. */
-        return xTimerChangePeriod(timer_handle, period, __cmd_block_ticks()) == pdPASS;
+        return xTimerChangePeriod(timer_handle, period, esp_schedule_cmd_block_ticks()) == pdPASS;
     }
 
-    __timer_priv_data_t *timer_priv_data = __timer_priv_data_create(cb, priv_data);
+    esp_schedule_timer_priv_data_t *timer_priv_data = esp_schedule_timer_priv_data_create(cb, priv_data);
     if (timer_priv_data == NULL) {
         return false;
     }
     timer_priv_data->remaining_ticks = remaining_ticks;
-    timer_handle = xTimerCreate("schedule", period, pdFALSE, timer_priv_data, __timer_common_cb);
+    timer_handle = xTimerCreate("schedule", period, pdFALSE, timer_priv_data, esp_schedule_timer_common_cb);
     if (timer_handle == NULL) {
-        free(timer_priv_data);
+        ESP_SCHEDULE_FREE(timer_priv_data);
         return false;
     }
     /* A trigger callback may create and enable a brand new schedule, so this
      * path is reachable from the daemon task too. */
-    if (xTimerStart(timer_handle, __cmd_block_ticks()) != pdPASS) {
+    if (xTimerStart(timer_handle, esp_schedule_cmd_block_ticks()) != pdPASS) {
         /* Detach before deleting: if the delete command itself cannot be queued
          * the timer outlives this call, and a later expiry must find a NULL ID
          * rather than the freed private data. */
         vTimerSetTimerID(timer_handle, NULL);
-        xTimerDelete(timer_handle, __cmd_block_ticks());
-        free(timer_priv_data);
+        xTimerDelete(timer_handle, esp_schedule_cmd_block_ticks());
+        ESP_SCHEDULE_FREE(timer_priv_data);
         return false;
     }
     *p_timer_handle = (esp_schedule_timer_handle_t) timer_handle;
@@ -277,7 +278,7 @@ void esp_schedule_timer_stop(esp_schedule_timer_handle_t timer_handle)
     if (timer_handle == NULL) {
         return;
     }
-    xTimerStop((TimerHandle_t) timer_handle, __cmd_block_ticks());
+    xTimerStop((TimerHandle_t) timer_handle, esp_schedule_cmd_block_ticks());
 }
 
 void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle)
@@ -286,12 +287,12 @@ void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle)
         return;
     }
     TimerHandle_t timer_handle = (TimerHandle_t) * p_timer_handle;
-    __ensure_cb_mutex();
+    esp_schedule_ensure_cb_mutex();
 
     /* Reachable from the user trigger callback (a one-shot schedule that
      * deletes itself when it fires), so the timer command queue must not be
      * blocked on when running on the daemon task. */
-    TickType_t block_ticks = __cmd_block_ticks();
+    TickType_t block_ticks = esp_schedule_cmd_block_ticks();
 
     /* Stop the timer so no new expiry is dispatched. */
     if (xTimerIsTimerActive(timer_handle) == pdTRUE) {
@@ -306,7 +307,7 @@ void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle)
      * nothing to barrier against. The mutex is released before the
      * xTimerDelete()/free() so a full timer-command queue cannot deadlock the
      * daemon against this task. */
-    __timer_priv_data_t *priv_data = __timer_priv_data_get(timer_handle);
+    esp_schedule_timer_priv_data_t *priv_data = esp_schedule_timer_priv_data_get(timer_handle);
     xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
     if (priv_data != NULL) {
         vTimerSetTimerID(timer_handle, NULL);
@@ -315,7 +316,7 @@ void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle)
 
     xTimerDelete(timer_handle, block_ticks);
     if (priv_data != NULL) {
-        free(priv_data);
+        ESP_SCHEDULE_FREE(priv_data);
     }
     *p_timer_handle = NULL;
 }

--- a/esp_schedule/glue/esp/timer.c
+++ b/esp_schedule/glue/esp/timer.c
@@ -1,0 +1,296 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file esp_timer.c
+ * @brief ESP Timer implementation.
+ */
+
+#include "glue_timer.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/timers.h"
+#include "freertos/semphr.h"
+
+/* Types **********************************************************************/
+
+/* xTimerCreate()/xTimerChangePeriod() take a 32-bit TickType_t, so a period
+ * derived from a delay beyond ~49.7 days (at CONFIG_FREERTOS_HZ=1000) would
+ * truncate and fire early. Cap a single hardware period to a safe value and
+ * split longer delays across several periods, re-arming without invoking the
+ * user callback until the full delay has elapsed. portMAX_DELAY/2 leaves
+ * headroom and avoids the portMAX_DELAY "block forever" sentinel. */
+#define ESP_SCHEDULE_TIMER_MAX_TICKS ((TickType_t)(portMAX_DELAY / 2))
+
+/**
+ * @brief Timer private data.
+ */
+typedef struct {
+    esp_schedule_timer_cb_t cb;
+    void *priv_data;
+    uint64_t remaining_ticks; /* ticks still to wait after the current period */
+} __timer_priv_data_t;
+
+/* Callback serialization ******************************************************
+ *
+ * FreeRTOS software-timer callbacks run in the timer service (daemon) task,
+ * while esp_schedule_timer_cancel() runs in the caller's (app) task. xTimerStop
+ * only prevents FUTURE expiries; it does not wait for a callback that is already
+ * executing. Without synchronization, cancel() would free() the priv_data (and
+ * the caller then frees the schedule) while __timer_common_cb is still
+ * dereferencing them in the daemon task -> use-after-free.
+ *
+ * A single global mutex serializes the callback body against cancel(). The
+ * callback holds it while running (including across the user trigger callback);
+ * cancel() waits on it as a barrier so any in-flight callback has fully
+ * completed before priv_data is freed. cancel() never holds the mutex while
+ * calling a blocking timer API, so a full timer-command queue cannot deadlock
+ * the daemon against the app task.
+ *
+ * The mutex is non-recursive. A repeating schedule re-arms itself from inside
+ * its own trigger callback (the daemon task) where the mutex is ALREADY held;
+ * esp_schedule_timer_start()'s re-arm path must therefore NOT re-take it there
+ * (that would self-deadlock). It skips the take when already on the daemon task
+ * and takes it only from an app task, where a concurrent callback could
+ * otherwise observe a half-updated (cb, priv_data) pair. See
+ * esp_schedule_timer_start(). */
+static portMUX_TYPE s_cb_mutex_init_lock = portMUX_INITIALIZER_UNLOCKED;
+static StaticSemaphore_t s_cb_mutex_buf;
+static SemaphoreHandle_t s_cb_mutex = NULL;
+
+static void __ensure_cb_mutex(void)
+{
+    if (s_cb_mutex != NULL) {
+        return;
+    }
+    /* Static allocation performs no heap work, so it is safe inside a critical
+     * section; the lock makes first-time creation race-free. */
+    portENTER_CRITICAL(&s_cb_mutex_init_lock);
+    if (s_cb_mutex == NULL) {
+        s_cb_mutex = xSemaphoreCreateMutexStatic(&s_cb_mutex_buf);
+    }
+    portEXIT_CRITICAL(&s_cb_mutex_init_lock);
+}
+
+/**
+ * @brief Whether the caller is running in the FreeRTOS timer daemon task.
+ *
+ * On the re-arm-from-callback path we are already in the daemon task holding
+ * the callback mutex, so the reuse path must neither re-take it nor block on
+ * the timer command queue (both would deadlock the daemon against itself).
+ */
+static bool __in_timer_daemon(void)
+{
+    return xTaskGetCurrentTaskHandle() == xTimerGetTimerDaemonTaskHandle();
+}
+
+/* Private functions **********************************************************/
+
+/**
+ * @brief Convert a delay in seconds to timer ticks (64-bit to avoid overflow).
+ */
+static uint64_t __ticks_from_seconds(uint32_t delay_seconds)
+{
+    return (((uint64_t) delay_seconds) * 1000) / portTICK_PERIOD_MS;
+}
+
+/**
+ * @brief Clamp a 64-bit tick count to a valid single timer period (>0).
+ */
+static TickType_t __period_ticks(uint64_t total_ticks)
+{
+    if (total_ticks == 0) {
+        return 1; /* a timer period must be strictly greater than 0 */
+    }
+    if (total_ticks > ESP_SCHEDULE_TIMER_MAX_TICKS) {
+        return ESP_SCHEDULE_TIMER_MAX_TICKS;
+    }
+    return (TickType_t) total_ticks;
+}
+
+/**
+ * @brief Create a new timer private data.
+ *
+ * @param[in] cb Callback function.
+ * @param[in] priv_data Private data.
+ *
+ * @return Pointer to the timer private data.
+ */
+static __timer_priv_data_t *__timer_priv_data_create(esp_schedule_timer_cb_t cb, void *priv_data)
+{
+    __timer_priv_data_t *data = calloc(1, sizeof(__timer_priv_data_t));
+    if (data == NULL) {
+        return NULL;
+    }
+    data->cb = cb;
+    data->priv_data = priv_data;
+    return data;
+}
+
+/**
+ * @brief Get the timer private data from the timer handle.
+ *
+ * @param[in] timer_handle Timer handle.
+ *
+ * @return Pointer to the timer private data.
+ */
+static __timer_priv_data_t *__timer_priv_data_get(esp_schedule_timer_handle_t timer_handle)
+{
+    return (__timer_priv_data_t *) pvTimerGetTimerID(timer_handle);
+}
+
+/**
+ * @brief Common timer callback. Runs in the FreeRTOS timer daemon task.
+ *
+ * @param[in] timer_handle Timer handle.
+ */
+static void __timer_common_cb(TimerHandle_t timer_handle)
+{
+    __ensure_cb_mutex();
+    /* Hold the mutex for the whole callback so cancel() can barrier against it.
+     * priv_data is read AFTER acquiring the mutex: cancel() clears the timer ID
+     * under the same mutex before freeing, so we either see a valid pointer
+     * (cancel has not started) or NULL (cancel already ran). */
+    xSemaphoreTake(s_cb_mutex, portMAX_DELAY);
+    __timer_priv_data_t *timer_priv_data = __timer_priv_data_get(timer_handle);
+    if (timer_priv_data == NULL) {
+        xSemaphoreGive(s_cb_mutex);
+        return;
+    }
+    if (timer_priv_data->remaining_ticks > 0) {
+        /* A long delay split across multiple periods: keep counting down and
+         * re-arm without invoking the user callback yet. A timer callback must
+         * never block on the timer command queue, so use a zero block time. */
+        TickType_t period = __period_ticks(timer_priv_data->remaining_ticks);
+        timer_priv_data->remaining_ticks -= period;
+        xTimerChangePeriod(timer_handle, period, 0);
+        xSemaphoreGive(s_cb_mutex);
+        return;
+    }
+    timer_priv_data->cb(timer_priv_data->priv_data);
+    xSemaphoreGive(s_cb_mutex);
+}
+
+/* Public functions ************************************************************/
+
+bool esp_schedule_timer_start(esp_schedule_timer_handle_t *p_timer_handle, uint32_t delay_seconds, esp_schedule_timer_cb_t cb, void *priv_data)
+{
+    __ensure_cb_mutex();
+    TimerHandle_t timer_handle = (TimerHandle_t) * p_timer_handle;
+
+    uint64_t total_ticks = __ticks_from_seconds(delay_seconds);
+    TickType_t period = __period_ticks(total_ticks);
+    uint64_t remaining_ticks = (total_ticks > period) ? (total_ticks - period) : 0;
+
+    if (timer_handle != NULL) {
+        /* Reuse the existing timer rather than cancel + recreate. A repeating
+         * schedule re-arms from inside its own fired callback (daemon task);
+         * routing that through esp_schedule_timer_cancel() would re-take the
+         * callback mutex the daemon already holds -> self-deadlock of the whole
+         * timer service on the first re-arm. It would also delete the timer
+         * that is currently executing and free the priv_data the callback is
+         * still using.
+         *
+         * Instead, rebind the private data in place: this honors the start()
+         * contract (the caller-provided cb and priv_data are set explicitly,
+         * not assumed unchanged) without freeing anything the running callback
+         * references, and avoids per-fire create/delete churn.
+         *
+         * Mutex handling depends on the calling context:
+         *  - On the daemon task (re-arm from inside the fired callback) the
+         *    callback mutex is already held; re-taking it would self-deadlock,
+         *    and no one else can touch this priv_data while we hold it, so no
+         *    take is needed.
+         *  - From an app task a callback may be running concurrently on the
+         *    daemon and could read a half-updated (cb, priv_data) pair, so take
+         *    the mutex to serialize the rebind against it. */
+        bool on_daemon = __in_timer_daemon();
+        if (!on_daemon) {
+            xSemaphoreTake(s_cb_mutex, portMAX_DELAY);
+        }
+        __timer_priv_data_t *timer_priv_data = __timer_priv_data_get(timer_handle);
+        if (timer_priv_data == NULL) {
+            /* A concurrent cancel() detached and is deleting this timer; there
+             * is nothing safe to reuse. */
+            if (!on_daemon) {
+                xSemaphoreGive(s_cb_mutex);
+            }
+            return false;
+        }
+        timer_priv_data->cb = cb;
+        timer_priv_data->priv_data = priv_data;
+        timer_priv_data->remaining_ticks = remaining_ticks;
+        if (!on_daemon) {
+            xSemaphoreGive(s_cb_mutex);
+        }
+
+        /* xTimerChangePeriod also (re)starts a dormant/expired timer. On the
+         * daemon task the block time MUST be zero; from an app task it may
+         * block on the command queue. */
+        xTimerChangePeriod(timer_handle, period, on_daemon ? 0 : portMAX_DELAY);
+        return true;
+    }
+
+    __timer_priv_data_t *timer_priv_data = __timer_priv_data_create(cb, priv_data);
+    if (timer_priv_data == NULL) {
+        return false;
+    }
+    timer_priv_data->remaining_ticks = remaining_ticks;
+    timer_handle = xTimerCreate("schedule", period, pdFALSE, timer_priv_data, __timer_common_cb);
+    if (timer_handle == NULL) {
+        free(timer_priv_data);
+        return false;
+    }
+    xTimerStart(timer_handle, portMAX_DELAY);
+    *p_timer_handle = (esp_schedule_timer_handle_t) timer_handle;
+    return true;
+}
+
+void esp_schedule_timer_stop(esp_schedule_timer_handle_t timer_handle)
+{
+    if (timer_handle == NULL) {
+        return;
+    }
+    xTimerStop((TimerHandle_t) timer_handle, portMAX_DELAY);
+}
+
+void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle)
+{
+    if (p_timer_handle == NULL || *p_timer_handle == NULL) {
+        return;
+    }
+    TimerHandle_t timer_handle = (TimerHandle_t) * p_timer_handle;
+    __ensure_cb_mutex();
+
+    /* Stop the timer so no new expiry is dispatched. */
+    if (xTimerIsTimerActive(timer_handle) == pdTRUE) {
+        xTimerStop(timer_handle, portMAX_DELAY);
+    }
+
+    /* Detach the private data under the callback mutex. Taking the mutex is the
+     * barrier: any callback already executing runs to completion before we
+     * proceed, and any callback dispatched afterwards will read a NULL timer ID
+     * and return without touching the freed data. The mutex is released before
+     * the blocking xTimerDelete()/free() so a full timer-command queue cannot
+     * deadlock the daemon against this task. */
+    __timer_priv_data_t *priv_data = __timer_priv_data_get(timer_handle);
+    xSemaphoreTake(s_cb_mutex, portMAX_DELAY);
+    if (priv_data != NULL) {
+        vTimerSetTimerID(timer_handle, NULL);
+    }
+    xSemaphoreGive(s_cb_mutex);
+
+    xTimerDelete(timer_handle, portMAX_DELAY);
+    if (priv_data != NULL) {
+        free(priv_data);
+    }
+    *p_timer_handle = NULL;
+}

--- a/esp_schedule/glue/esp/timer.c
+++ b/esp_schedule/glue/esp/timer.c
@@ -10,6 +10,7 @@
  */
 
 #include "glue_timer.h"
+#include "glue_log.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -19,6 +20,8 @@
 #include "freertos/task.h"
 #include "freertos/timers.h"
 #include "freertos/semphr.h"
+
+static const char *TAG = "esp_schedule_timer";
 
 /* Types **********************************************************************/
 
@@ -55,13 +58,14 @@ typedef struct {
  * calling a blocking timer API, so a full timer-command queue cannot deadlock
  * the daemon against the app task.
  *
- * The mutex is non-recursive. A repeating schedule re-arms itself from inside
- * its own trigger callback (the daemon task) where the mutex is ALREADY held;
- * esp_schedule_timer_start()'s re-arm path must therefore NOT re-take it there
- * (that would self-deadlock). It skips the take when already on the daemon task
- * and takes it only from an app task, where a concurrent callback could
- * otherwise observe a half-updated (cb, priv_data) pair. See
- * esp_schedule_timer_start(). */
+ * The mutex is RECURSIVE. The user trigger callback runs with it held, and from
+ * there the user may legitimately re-enter this layer on the same task: a
+ * repeating schedule re-arms itself via esp_schedule_timer_start(), and a
+ * one-shot schedule that deletes itself reaches esp_schedule_timer_cancel().
+ * With a non-recursive mutex either re-entry would block the daemon task on a
+ * mutex the daemon itself holds, freezing every software timer in the system.
+ * Recursive ownership makes the nested take a no-op for the owning task while
+ * still serializing app tasks against an in-flight callback. */
 static portMUX_TYPE s_cb_mutex_init_lock = portMUX_INITIALIZER_UNLOCKED;
 static StaticSemaphore_t s_cb_mutex_buf;
 static SemaphoreHandle_t s_cb_mutex = NULL;
@@ -75,21 +79,31 @@ static void __ensure_cb_mutex(void)
      * section; the lock makes first-time creation race-free. */
     portENTER_CRITICAL(&s_cb_mutex_init_lock);
     if (s_cb_mutex == NULL) {
-        s_cb_mutex = xSemaphoreCreateMutexStatic(&s_cb_mutex_buf);
+        s_cb_mutex = xSemaphoreCreateRecursiveMutexStatic(&s_cb_mutex_buf);
     }
     portEXIT_CRITICAL(&s_cb_mutex_init_lock);
 }
 
 /**
  * @brief Whether the caller is running in the FreeRTOS timer daemon task.
- *
- * On the re-arm-from-callback path we are already in the daemon task holding
- * the callback mutex, so the reuse path must neither re-take it nor block on
- * the timer command queue (both would deadlock the daemon against itself).
  */
 static bool __in_timer_daemon(void)
 {
     return xTaskGetCurrentTaskHandle() == xTimerGetTimerDaemonTaskHandle();
+}
+
+/**
+ * @brief Block time to use for a timer command queue operation.
+ *
+ * FreeRTOS forbids a non-zero block time on the timer command queue from within
+ * a timer callback: if the queue is full the daemon task would end up waiting
+ * for itself to drain it. Every entry point here is reachable from the daemon
+ * task via the user trigger callback, so the block time must be chosen from the
+ * calling context rather than hardcoded.
+ */
+static TickType_t __cmd_block_ticks(void)
+{
+    return __in_timer_daemon() ? 0 : portMAX_DELAY;
 }
 
 /* Private functions **********************************************************/
@@ -159,24 +173,32 @@ static void __timer_common_cb(TimerHandle_t timer_handle)
      * priv_data is read AFTER acquiring the mutex: cancel() clears the timer ID
      * under the same mutex before freeing, so we either see a valid pointer
      * (cancel has not started) or NULL (cancel already ran). */
-    xSemaphoreTake(s_cb_mutex, portMAX_DELAY);
+    xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
     __timer_priv_data_t *timer_priv_data = __timer_priv_data_get(timer_handle);
     if (timer_priv_data == NULL) {
-        xSemaphoreGive(s_cb_mutex);
+        xSemaphoreGiveRecursive(s_cb_mutex);
         return;
     }
     if (timer_priv_data->remaining_ticks > 0) {
         /* A long delay split across multiple periods: keep counting down and
          * re-arm without invoking the user callback yet. A timer callback must
-         * never block on the timer command queue, so use a zero block time. */
+         * never block on the timer command queue, so use a zero block time.
+         *
+         * Only commit the countdown once the re-arm has actually been queued: a
+         * full command queue would otherwise consume this slice of the delay
+         * with no timer left running to serve it, and the schedule would
+         * silently never fire. */
         TickType_t period = __period_ticks(timer_priv_data->remaining_ticks);
-        timer_priv_data->remaining_ticks -= period;
-        xTimerChangePeriod(timer_handle, period, 0);
-        xSemaphoreGive(s_cb_mutex);
+        if (xTimerChangePeriod(timer_handle, period, 0) == pdPASS) {
+            timer_priv_data->remaining_ticks -= period;
+        } else {
+            ESP_SCHEDULE_LOGE(TAG, "Failed to re-arm timer; schedule is now disarmed");
+        }
+        xSemaphoreGiveRecursive(s_cb_mutex);
         return;
     }
     timer_priv_data->cb(timer_priv_data->priv_data);
-    xSemaphoreGive(s_cb_mutex);
+    xSemaphoreGiveRecursive(s_cb_mutex);
 }
 
 /* Public functions ************************************************************/
@@ -193,50 +215,36 @@ bool esp_schedule_timer_start(esp_schedule_timer_handle_t *p_timer_handle, uint3
     if (timer_handle != NULL) {
         /* Reuse the existing timer rather than cancel + recreate. A repeating
          * schedule re-arms from inside its own fired callback (daemon task);
-         * routing that through esp_schedule_timer_cancel() would re-take the
-         * callback mutex the daemon already holds -> self-deadlock of the whole
-         * timer service on the first re-arm. It would also delete the timer
-         * that is currently executing and free the priv_data the callback is
-         * still using.
+         * routing that through esp_schedule_timer_cancel() would delete the
+         * timer that is currently executing and free the priv_data the callback
+         * is still using.
          *
          * Instead, rebind the private data in place: this honors the start()
          * contract (the caller-provided cb and priv_data are set explicitly,
          * not assumed unchanged) without freeing anything the running callback
          * references, and avoids per-fire create/delete churn.
          *
-         * Mutex handling depends on the calling context:
-         *  - On the daemon task (re-arm from inside the fired callback) the
-         *    callback mutex is already held; re-taking it would self-deadlock,
-         *    and no one else can touch this priv_data while we hold it, so no
-         *    take is needed.
-         *  - From an app task a callback may be running concurrently on the
-         *    daemon and could read a half-updated (cb, priv_data) pair, so take
-         *    the mutex to serialize the rebind against it. */
-        bool on_daemon = __in_timer_daemon();
-        if (!on_daemon) {
-            xSemaphoreTake(s_cb_mutex, portMAX_DELAY);
-        }
+         * The mutex serializes the rebind against a callback running
+         * concurrently on the daemon, which could otherwise read a half-updated
+         * (cb, priv_data) pair. Re-arming from inside the fired callback takes
+         * it recursively on the task that already owns it. */
+        xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
         __timer_priv_data_t *timer_priv_data = __timer_priv_data_get(timer_handle);
         if (timer_priv_data == NULL) {
             /* A concurrent cancel() detached and is deleting this timer; there
              * is nothing safe to reuse. */
-            if (!on_daemon) {
-                xSemaphoreGive(s_cb_mutex);
-            }
+            xSemaphoreGiveRecursive(s_cb_mutex);
             return false;
         }
         timer_priv_data->cb = cb;
         timer_priv_data->priv_data = priv_data;
         timer_priv_data->remaining_ticks = remaining_ticks;
-        if (!on_daemon) {
-            xSemaphoreGive(s_cb_mutex);
-        }
+        xSemaphoreGiveRecursive(s_cb_mutex);
 
-        /* xTimerChangePeriod also (re)starts a dormant/expired timer. On the
-         * daemon task the block time MUST be zero; from an app task it may
-         * block on the command queue. */
-        xTimerChangePeriod(timer_handle, period, on_daemon ? 0 : portMAX_DELAY);
-        return true;
+        /* xTimerChangePeriod also (re)starts a dormant/expired timer. A dropped
+         * command leaves the schedule disarmed, so report it rather than
+         * claiming success. */
+        return xTimerChangePeriod(timer_handle, period, __cmd_block_ticks()) == pdPASS;
     }
 
     __timer_priv_data_t *timer_priv_data = __timer_priv_data_create(cb, priv_data);
@@ -249,7 +257,17 @@ bool esp_schedule_timer_start(esp_schedule_timer_handle_t *p_timer_handle, uint3
         free(timer_priv_data);
         return false;
     }
-    xTimerStart(timer_handle, portMAX_DELAY);
+    /* A trigger callback may create and enable a brand new schedule, so this
+     * path is reachable from the daemon task too. */
+    if (xTimerStart(timer_handle, __cmd_block_ticks()) != pdPASS) {
+        /* Detach before deleting: if the delete command itself cannot be queued
+         * the timer outlives this call, and a later expiry must find a NULL ID
+         * rather than the freed private data. */
+        vTimerSetTimerID(timer_handle, NULL);
+        xTimerDelete(timer_handle, __cmd_block_ticks());
+        free(timer_priv_data);
+        return false;
+    }
     *p_timer_handle = (esp_schedule_timer_handle_t) timer_handle;
     return true;
 }
@@ -259,7 +277,7 @@ void esp_schedule_timer_stop(esp_schedule_timer_handle_t timer_handle)
     if (timer_handle == NULL) {
         return;
     }
-    xTimerStop((TimerHandle_t) timer_handle, portMAX_DELAY);
+    xTimerStop((TimerHandle_t) timer_handle, __cmd_block_ticks());
 }
 
 void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle)
@@ -270,25 +288,32 @@ void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle)
     TimerHandle_t timer_handle = (TimerHandle_t) * p_timer_handle;
     __ensure_cb_mutex();
 
+    /* Reachable from the user trigger callback (a one-shot schedule that
+     * deletes itself when it fires), so the timer command queue must not be
+     * blocked on when running on the daemon task. */
+    TickType_t block_ticks = __cmd_block_ticks();
+
     /* Stop the timer so no new expiry is dispatched. */
     if (xTimerIsTimerActive(timer_handle) == pdTRUE) {
-        xTimerStop(timer_handle, portMAX_DELAY);
+        xTimerStop(timer_handle, block_ticks);
     }
 
     /* Detach the private data under the callback mutex. Taking the mutex is the
-     * barrier: any callback already executing runs to completion before we
-     * proceed, and any callback dispatched afterwards will read a NULL timer ID
-     * and return without touching the freed data. The mutex is released before
-     * the blocking xTimerDelete()/free() so a full timer-command queue cannot
-     * deadlock the daemon against this task. */
+     * barrier: any callback already executing on another task runs to
+     * completion before we proceed, and any callback dispatched afterwards will
+     * read a NULL timer ID and return without touching the freed data. When the
+     * caller IS the running callback the mutex is taken recursively and there is
+     * nothing to barrier against. The mutex is released before the
+     * xTimerDelete()/free() so a full timer-command queue cannot deadlock the
+     * daemon against this task. */
     __timer_priv_data_t *priv_data = __timer_priv_data_get(timer_handle);
-    xSemaphoreTake(s_cb_mutex, portMAX_DELAY);
+    xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
     if (priv_data != NULL) {
         vTimerSetTimerID(timer_handle, NULL);
     }
-    xSemaphoreGive(s_cb_mutex);
+    xSemaphoreGiveRecursive(s_cb_mutex);
 
-    xTimerDelete(timer_handle, portMAX_DELAY);
+    xTimerDelete(timer_handle, block_ticks);
     if (priv_data != NULL) {
         free(priv_data);
     }

--- a/esp_schedule/glue/glue_log.h
+++ b/esp_schedule/glue/glue_log.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file glue_log.h
+ * @brief Glue layer for logging.
+ */
+
+#ifndef __GLUE_LOG_H__
+#define __GLUE_LOG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The default "glue_log_impl.h" is provided for ESP-IDF under glue/esp.
+ * If you wish to use a different implementation, you can create your own "glue_log_impl.h" file and not include the default one.
+ * - The following logging function macros MUST be defined:
+ *   - ESP_SCHEDULE_LOGE(tag, fmt, ...) : Log an error message.
+ *   - ESP_SCHEDULE_LOGW(tag, fmt, ...) : Log a warning message.
+ *   - ESP_SCHEDULE_LOGI(tag, fmt, ...) : Log an info message.
+ *   - ESP_SCHEDULE_LOGD(tag, fmt, ...) : Log a debug message.
+ *   - ESP_SCHEDULE_LOGV(tag, fmt, ...) : Log a verbose message.
+ */
+#include "glue_log_impl.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __GLUE_LOG_H__ */

--- a/esp_schedule/glue/glue_log.h
+++ b/esp_schedule/glue/glue_log.h
@@ -9,12 +9,7 @@
  * @brief Glue layer for logging.
  */
 
-#ifndef __GLUE_LOG_H__
-#define __GLUE_LOG_H__
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#pragma once
 
 /**
  * The default "glue_log_impl.h" is provided for ESP-IDF under glue/esp.
@@ -25,11 +20,11 @@ extern "C" {
  *   - ESP_SCHEDULE_LOGI(tag, fmt, ...) : Log an info message.
  *   - ESP_SCHEDULE_LOGD(tag, fmt, ...) : Log a debug message.
  *   - ESP_SCHEDULE_LOGV(tag, fmt, ...) : Log a verbose message.
+ *
+ * This header contributes macros only, so it needs no extern "C" block. The
+ * implementation header must not be wrapped in one either: it may pull in
+ * system headers of its own, and forcing C linkage on those breaks a C++
+ * consumer.
  */
 #include "glue_log_impl.h"
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* __GLUE_LOG_H__ */

--- a/esp_schedule/glue/glue_mem.h
+++ b/esp_schedule/glue/glue_mem.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file glue_mem.h
+ * @brief Memory interface for the esp_schedule component
+ */
+
+#ifndef __GLUE_MEM_H__
+#define __GLUE_MEM_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The default "glue_mem_impl.h" is provided for ESP-IDF under glue/esp.
+ * If you wish to use a different implementation, you can create your own "glue_mem_impl.h" file and not include the default one.
+ * - The following memory allocation macros MUST be defined:
+ *   - ESP_SCHEDULE_MALLOC(size) : malloc implementation.
+ *   - ESP_SCHEDULE_CALLOC(num, size) : calloc implementation.
+ *   - ESP_SCHEDULE_REALLOC(ptr, size) : realloc implementation.
+ *   - ESP_SCHEDULE_FREE(ptr) : free implementation.
+ */
+#include "glue_mem_impl.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __GLUE_MEM_H__ */

--- a/esp_schedule/glue/glue_mem.h
+++ b/esp_schedule/glue/glue_mem.h
@@ -9,12 +9,7 @@
  * @brief Memory interface for the esp_schedule component
  */
 
-#ifndef __GLUE_MEM_H__
-#define __GLUE_MEM_H__
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#pragma once
 
 /**
  * The default "glue_mem_impl.h" is provided for ESP-IDF under glue/esp.
@@ -24,11 +19,11 @@ extern "C" {
  *   - ESP_SCHEDULE_CALLOC(num, size) : calloc implementation.
  *   - ESP_SCHEDULE_REALLOC(ptr, size) : realloc implementation.
  *   - ESP_SCHEDULE_FREE(ptr) : free implementation.
+ *
+ * This header contributes macros only, so it needs no extern "C" block. The
+ * implementation header must not be wrapped in one either: it may pull in
+ * system headers of its own, and forcing C linkage on those breaks a C++
+ * consumer.
  */
 #include "glue_mem_impl.h"
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* __GLUE_MEM_H__ */

--- a/esp_schedule/glue/glue_nvs.h
+++ b/esp_schedule/glue/glue_nvs.h
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file glue_nvs.h
+ * @brief NVS interface for the esp_schedule component
+ */
+
+#ifndef __GLUE_NVS_H__
+#define __GLUE_NVS_H__
+
+/* Includes **********************************************************************/
+#include <stddef.h>
+#include <stdint.h>
+
+/* Types **********************************************************************/
+
+/**
+ * @brief Handle to the NVS partition.
+ */
+typedef void *esp_schedule_nvs_handle_t;
+
+/**
+ * @brief Iterator to the NVS partition.
+ */
+typedef void *esp_schedule_nvs_iterator_t;
+
+/**
+ * @brief Open mode for the NVS partition.
+ */
+typedef enum {
+    ESP_SCHEDULE_NVS_OPEN_READONLY = 0,
+    ESP_SCHEDULE_NVS_OPEN_READWRITE = 1,
+} esp_schedule_nvs_open_mode_t;
+
+typedef enum {
+    ESP_SCHEDULE_NVS_ERROR = -1,
+    ESP_SCHEDULE_NVS_OK = 0,
+    ESP_SCHEDULE_NVS_NOT_FOUND = 1,
+    ESP_SCHEDULE_NVS_NO_MEM = 2,
+} esp_schedule_nvs_error_t;
+
+/* Functions ******************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Open the NVS partition from the given partition label and name space.
+ *
+ * @param[in] partition_label The label of the partition to open.
+ * @param[in] name_space The name space to open.
+ * @param[in] mode The open mode to use.
+ * @param[out] p_handle The handle to the NVS partition.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_open_from_partition(const char *partition_label, const char *name_space, esp_schedule_nvs_open_mode_t mode, esp_schedule_nvs_handle_t *p_handle);
+
+/**
+ * @brief Close the NVS partition.
+ *
+ * @param[in] handle The handle to the NVS partition.
+ */
+void esp_schedule_nvs_close(esp_schedule_nvs_handle_t handle);
+
+/**
+ * @brief Commit the changes to the NVS partition.
+ *
+ * @param[in] handle The handle to the NVS partition.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_commit(esp_schedule_nvs_handle_t handle);
+
+
+/**
+ * @brief Erase a key from the NVS partition.
+ *
+ * @param[in] handle The handle to the NVS partition.
+ * @param[in] key The key to erase.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_erase_key(esp_schedule_nvs_handle_t handle, const char *key);
+
+/**
+ * @brief Erase all keys from the NVS partition.
+ *
+ * @param[in] handle The handle to the NVS partition.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_erase_all(esp_schedule_nvs_handle_t handle);
+
+/**
+ * @brief Set a blob in the NVS partition.
+ *
+ * @param[in] handle The handle to the NVS partition.
+ * @param[in] key The key to set.
+ * @param[in] value The value to set.
+ * @param[in] value_len The length of the value.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_set_blob(esp_schedule_nvs_handle_t handle, const char *key, const void *value, size_t value_len);
+
+/**
+ * @brief Get a blob from the NVS partition.
+ *
+ * @param[in] handle The handle to the NVS partition.
+ * @param[in] key The key to get.
+ * @param[out] value The value to get. If value is NULL, the length of the value will be returned in p_value_len.
+ * @param[out] p_value_len The length of the value.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_get_blob(esp_schedule_nvs_handle_t handle, const char *key, void *value, size_t *p_value_len);
+
+/**
+ * @brief Set a u8 in the NVS partition.
+ *
+ * @param[in] handle The handle to the NVS partition.
+ * @param[in] key The key to set.
+ * @param[in] value The value to set.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_set_u8(esp_schedule_nvs_handle_t handle, const char *key, uint8_t value);
+
+/**
+ * @brief Get a u8 from the NVS partition.
+ *
+ * @param[in] handle The handle to the NVS partition.
+ * @param[in] key The key to get.
+ * @param[out] value The value to get.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_get_u8(esp_schedule_nvs_handle_t handle, const char *key, uint8_t *value);
+
+/**
+ * @brief Find the blobs in the NVS partition.
+ *
+ * @param[in] partition_label The label of the partition to find the blobs in.
+ * @param[in] name_space The name space to find the blobs in.
+ * @param[out] iterator The iterator to the NVS partition.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_entry_find_blobs(const char *partition_label, const char *name_space, esp_schedule_nvs_iterator_t *iterator);
+
+/**
+ * @brief Get the information about the next entry in the NVS partition.
+ *
+ * @param[in] iterator The iterator to the NVS partition.
+ * @param[out] p_key Pointer at which to store the key of the next entry. *p_key needs to be freed by the caller.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code. If the key is not found, the pointer will be NULL.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_entry_get_key(esp_schedule_nvs_iterator_t iterator, char **p_key);
+
+/**
+ * @brief Move the iterator to the next entry in the NVS partition.
+ *
+ * @param[in] iterator The iterator to the NVS partition.
+ * @return ESP_SCHEDULE_NVS_OK on success, otherwise error code.
+ */
+esp_schedule_nvs_error_t esp_schedule_nvs_entry_next(esp_schedule_nvs_iterator_t *iterator);
+
+/**
+ * @brief Release the iterator.
+ *
+ * @param[in] iterator The iterator to the NVS partition.
+ */
+void esp_schedule_nvs_release_iterator(esp_schedule_nvs_iterator_t iterator);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __GLUE_NVS_H__

--- a/esp_schedule/glue/glue_nvs.h
+++ b/esp_schedule/glue/glue_nvs.h
@@ -9,8 +9,7 @@
  * @brief NVS interface for the esp_schedule component
  */
 
-#ifndef __GLUE_NVS_H__
-#define __GLUE_NVS_H__
+#pragma once
 
 /* Includes **********************************************************************/
 #include <stddef.h>
@@ -171,4 +170,3 @@ void esp_schedule_nvs_release_iterator(esp_schedule_nvs_iterator_t iterator);
 }
 #endif
 
-#endif // __GLUE_NVS_H__

--- a/esp_schedule/glue/glue_time.h
+++ b/esp_schedule/glue/glue_time.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file glue_time.h
+ * @brief Time interface for the esp_schedule component
+ */
+
+#ifndef __GLUE_TIME_H__
+#define __GLUE_TIME_H__
+
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Get the current time.
+ * @param[out] p_time Pointer to a time_t variable to store the current time.
+ * @return The current time.
+ */
+time_t esp_schedule_get_time(time_t *p_time);
+
+/**
+ * @brief Initialize the timesync.
+ */
+void esp_schedule_timesync_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __GLUE_TIME_H__ */

--- a/esp_schedule/glue/glue_time.h
+++ b/esp_schedule/glue/glue_time.h
@@ -9,8 +9,7 @@
  * @brief Time interface for the esp_schedule component
  */
 
-#ifndef __GLUE_TIME_H__
-#define __GLUE_TIME_H__
+#pragma once
 
 #include <time.h>
 
@@ -34,4 +33,3 @@ void esp_schedule_timesync_init(void);
 }
 #endif
 
-#endif /* __GLUE_TIME_H__ */

--- a/esp_schedule/glue/glue_timer.h
+++ b/esp_schedule/glue/glue_timer.h
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file glue_timer.h
+ * @brief Timer interface for the esp_schedule component
+ */
+
+#ifndef __GLUE_TIMER_H__
+#define __GLUE_TIMER_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Types **********************************************************************/
+
+/**
+ * @brief Timer handle.
+ */
+typedef void *esp_schedule_timer_handle_t;
+
+/**
+ * @brief Timer callback.
+ *
+ * @param[in] priv_data Pointer to the private data of the timer when created.
+ */
+typedef void (*esp_schedule_timer_cb_t)(void *priv_data);
+
+/* Functions ******************************************************************/
+
+/**
+ * @brief Start a timer for a schedule.
+ *
+ * @param[in,out] p_timer_handle Pointer to the timer handle. If NULL, a new timer will be created, else change the period of the existing timer.
+ * @param[in] delay_seconds Delay in seconds.
+ *
+ * @return true if the timer was armed, false if it could not be created (e.g. out of memory).
+ */
+bool esp_schedule_timer_start(esp_schedule_timer_handle_t *p_timer_handle, uint32_t delay_seconds, esp_schedule_timer_cb_t cb, void *priv_data);
+
+/**
+ * @brief Stop a timer for a schedule.
+ *
+ * @param[in] timer_handle Timer handle.
+ */
+void esp_schedule_timer_stop(esp_schedule_timer_handle_t timer_handle);
+
+/**
+ * @brief Cancel a timer for a schedule, i.e., stop and delete the timer.
+ *
+ * @param[in,out] p_timer_handle Pointer to the timer handle. Will be set to NULL, and the underlying timer will be deleted.
+ */
+void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __GLUE_TIMER_H__

--- a/esp_schedule/glue/glue_timer.h
+++ b/esp_schedule/glue/glue_timer.h
@@ -9,8 +9,7 @@
  * @brief Timer interface for the esp_schedule component
  */
 
-#ifndef __GLUE_TIMER_H__
-#define __GLUE_TIMER_H__
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -63,4 +62,3 @@ void esp_schedule_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle);
 }
 #endif
 
-#endif // __GLUE_TIMER_H__

--- a/esp_schedule/idf_component.yml
+++ b/esp_schedule/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.4.0"
+version: "1.4.1"
 description: Task scheduling based on periodic and one-time events
 url: https://github.com/espressif/idf-extra-components/tree/master/components/esp_schedule
 repository: https://github.com/espressif/idf-extra-components.git

--- a/esp_schedule/include/common/esp_schedule_untyped.h
+++ b/esp_schedule/include/common/esp_schedule_untyped.h
@@ -4,13 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file esp_schedule_untyped.h
+ * @brief Untyped (platform-agnostic) interface for the esp_schedule component.
+ *
+ * @note Do not include this header directly. Include a typed binding (e.g.
+ *       include/esp/esp_schedule.h) that defines ESP_SCHEDULE_RETURN_TYPE and the
+ *       return-value macros, then includes this file:
+ *       - ESP_SCHEDULE_RETURN_TYPE            : the API return type (e.g. esp_err_t)
+ *       - ESP_SCHEDULE_RET_OK / _FAIL / _NO_MEM / _INVALID_ARG / _INVALID_STATE
+ */
+
 #pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
-#include "esp_err.h"
-#include "sdkconfig.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -194,7 +203,7 @@ esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config
  * @return ESP_OK on success.
  * @return error in case of failure.
  */
-esp_err_t esp_schedule_delete(esp_schedule_handle_t handle);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_delete(esp_schedule_handle_t handle);
 
 /** Edit Schedule
  *
@@ -211,7 +220,7 @@ esp_err_t esp_schedule_delete(esp_schedule_handle_t handle);
  * @return ESP_OK on success.
  * @return error in case of failure.
  */
-esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config);
 
 /** Enable Schedule
  *
@@ -224,7 +233,7 @@ esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t 
  * @return ESP_OK on success.
  * @return error in case of failure.
  */
-esp_err_t esp_schedule_enable(esp_schedule_handle_t handle);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_enable(esp_schedule_handle_t handle);
 
 /** Disable Schedule
  *
@@ -237,7 +246,7 @@ esp_err_t esp_schedule_enable(esp_schedule_handle_t handle);
  * @return ESP_OK on success.
  * @return error in case of failure.
  */
-esp_err_t esp_schedule_disable(esp_schedule_handle_t handle);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_disable(esp_schedule_handle_t handle);
 
 /** Get Schedule
  *
@@ -250,7 +259,7 @@ esp_err_t esp_schedule_disable(esp_schedule_handle_t handle);
  * @return ESP_OK on success.
  * @return error in case of failure.
  */
-esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config);
 
 #ifdef __cplusplus
 }

--- a/esp_schedule/include/esp/esp_schedule.h
+++ b/esp_schedule/include/esp/esp_schedule.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** This is the default include file for the esp_schedule component. */
+#pragma once
+
+/** Use ESP_SCHEDULE_RETURN_TYPE as the return type for the esp_schedule component. */
+#include "esp_err.h"
+#define ESP_SCHEDULE_RETURN_TYPE esp_err_t
+#define ESP_SCHEDULE_RET_OK ESP_OK
+#define ESP_SCHEDULE_RET_FAIL ESP_FAIL
+#define ESP_SCHEDULE_RET_NO_MEM ESP_ERR_NO_MEM
+#define ESP_SCHEDULE_RET_INVALID_ARG ESP_ERR_INVALID_ARG
+#define ESP_SCHEDULE_RET_INVALID_STATE ESP_ERR_INVALID_STATE
+
+#include "esp_schedule_untyped.h"

--- a/esp_schedule/include/esp/esp_schedule.h
+++ b/esp_schedule/include/esp/esp_schedule.h
@@ -7,6 +7,14 @@
 /** This is the default include file for the esp_schedule component. */
 #pragma once
 
+/* esp_schedule_untyped.h gates public struct members on
+ * CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT, so sdkconfig.h must be visible before it
+ * is included. Without it the macro is silently 0 and the application disagrees
+ * with the library about sizeof(esp_schedule_config_t) - no diagnostic, just a
+ * write past the caller's struct. Relying on esp_err.h to pull it in
+ * incidentally would leave that guarantee undocumented. */
+#include "sdkconfig.h"
+
 /** Use ESP_SCHEDULE_RETURN_TYPE as the return type for the esp_schedule component. */
 #include "esp_err.h"
 #define ESP_SCHEDULE_RETURN_TYPE esp_err_t

--- a/esp_schedule/src/esp_schedule.c
+++ b/esp_schedule/src/esp_schedule.c
@@ -8,8 +8,9 @@
 #include <stdbool.h>
 #include <time.h>
 #include <inttypes.h>
-#include "esp_log.h"
-#include "esp_sntp.h"
+#include "glue_time.h"
+#include "glue_log.h"
+#include "glue_mem.h"
 #include "esp_daylight.h"
 #include "esp_schedule_internal.h"
 
@@ -66,7 +67,7 @@ static const char *TAG = "esp_schedule";
 static bool init_done = false;
 
 // Forward declarations for static functions
-static void esp_schedule_common_timer_cb(TimerHandle_t timer);
+static void esp_schedule_common_timer_cb(void *priv_data);
 
 /*
  * Unified date-based next occurrence calculation.
@@ -309,10 +310,10 @@ time_t esp_schedule_calc_solar_time_for_time_utc(bool is_sunrise, time_t time_ut
 
     bool calc_ok = esp_daylight_calc_sunrise_sunset_utc(year, month, day, latitude, longitude, &sunrise_utc, &sunset_utc);
     if (!calc_ok) {
-        ESP_LOGW(TAG, "Failed to calculate %s for date %04d-%02d-%02d at latitude %.5f, longitude %.5f (likely polar night/day condition)",
-                 is_sunrise ? "sunrise" : "sunset",
-                 year, month, day, latitude, longitude
-                );
+        ESP_SCHEDULE_LOGW(TAG, "Failed to calculate %s for date %04d-%02d-%02d at latitude %.5f, longitude %.5f (likely polar night/day condition)",
+                          is_sunrise ? "sunrise" : "sunset",
+                          year, month, day, latitude, longitude
+                         );
         return 0;
     }
     time_t solar_time = is_sunrise ? sunrise_utc : sunset_utc;
@@ -344,7 +345,7 @@ time_t esp_schedule_get_next_valid_solar_time(time_t now, const esp_schedule_tri
             // Outside validity window or not in the future -> advance to next valid day
         } else if (validity && validity->end_time && solar_time > validity->end_time) {
             // Past validity window -> return 0
-            ESP_LOGD(TAG, "Schedule %s: next solar event is past validity end_time.", schedule_name);
+            ESP_SCHEDULE_LOGD(TAG, "Schedule %s: next solar event is past validity end_time.", schedule_name);
             return 0;
         } else {
             return solar_time;
@@ -352,11 +353,11 @@ time_t esp_schedule_get_next_valid_solar_time(time_t now, const esp_schedule_tri
 
         // Advance anchor to next day
         if (!esp_schedule_get_next_date_time(day_end + 1, MINUTES_IN_DAY - 1, trigger->day.repeat_days, trigger->date.day, trigger->date.repeat_months, match_year, validity, &day_end)) {
-            ESP_LOGD(TAG, "Schedule %s: no further day matches the date/day-of-week arm.", schedule_name);
+            ESP_SCHEDULE_LOGD(TAG, "Schedule %s: no further day matches the date/day-of-week arm.", schedule_name);
             return 0;
         }
     }
-    ESP_LOGD(TAG, "Schedule %s: no solar event found within 370 candidate days.", schedule_name);
+    ESP_SCHEDULE_LOGD(TAG, "Schedule %s: no solar event found within 370 candidate days.", schedule_name);
     return 0;
 }
 #endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
@@ -380,24 +381,24 @@ static bool esp_schedule_date_arm_is_valid(const esp_schedule_trigger_t *trigger
     /* V3: a months mask with no day-of-month would mean every day of those
      * months, which is never the intended schedule. */
     if (trigger->date.day == 0 && trigger->date.repeat_months != 0) {
-        ESP_LOGE(TAG, "Schedule %s: date.repeat_months is set but date.day is 0. Set date.day.", schedule_name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule %s: date.repeat_months is set but date.day is 0. Set date.day.", schedule_name);
         return false;
     }
     /* V4: a recurrence or a year bound with no date pattern to apply it to. */
     if (trigger->date.day == 0 && trigger->date.repeat_months == 0 &&
             (trigger->date.year != 0 || trigger->date.repeat_every_year)) {
-        ESP_LOGE(TAG, "Schedule %s: date.year/date.repeat_every_year set with no date.day or date.repeat_months to apply it to.", schedule_name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule %s: date.year/date.repeat_every_year set with no date.day or date.repeat_months to apply it to.", schedule_name);
         return false;
     }
     /* V5: "only year N" and "every year" are contradictory. */
     if (trigger->date.year != 0 && trigger->date.repeat_every_year) {
-        ESP_LOGE(TAG, "Schedule %s: date.year and date.repeat_every_year are mutually exclusive.", schedule_name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule %s: date.year and date.repeat_every_year are mutually exclusive.", schedule_name);
         return false;
     }
     /* V6: repeat_every_year recurs *over the month set*, so with no mask it
      * would be inert. date.year is exempt: it still constrains the arm. */
     if (trigger->date.repeat_every_year && trigger->date.repeat_months == 0) {
-        ESP_LOGE(TAG, "Schedule %s: date.repeat_every_year needs date.repeat_months to recur over (use ESP_SCHEDULE_MONTH_ALL for every month).", schedule_name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule %s: date.repeat_every_year needs date.repeat_months to recur over (use ESP_SCHEDULE_MONTH_ALL for every month).", schedule_name);
         return false;
     }
     return true;
@@ -426,21 +427,21 @@ bool esp_schedule_trigger_is_valid(const esp_schedule_trigger_t *trigger, const 
          * or before the base time, so the arm path would find nothing to fire and
          * the schedule would silently never run. */
         if (trigger->relative_seconds <= 0) {
-            ESP_LOGE(TAG, "Schedule %s: relative_seconds must be > 0, got %d.", schedule_name, trigger->relative_seconds);
+            ESP_SCHEDULE_LOGE(TAG, "Schedule %s: relative_seconds must be > 0, got %d.", schedule_name, trigger->relative_seconds);
             return false;
         }
         return true;
     case ESP_SCHEDULE_TYPE_DAYS_OF_WEEK:
         /* V1: this type reads only day.repeat_days. */
         if (esp_schedule_date_arm_present(trigger)) {
-            ESP_LOGE(TAG, "Schedule %s: DAYS_OF_WEEK reads only day.repeat_days, but a date.* field is set.", schedule_name);
+            ESP_SCHEDULE_LOGE(TAG, "Schedule %s: DAYS_OF_WEEK reads only day.repeat_days, but a date.* field is set.", schedule_name);
             return false;
         }
         return true;
     case ESP_SCHEDULE_TYPE_DATE:
         /* V2: DATE has no day-of-week arm. */
         if (trigger->day.repeat_days != 0) {
-            ESP_LOGE(TAG, "Schedule %s: DATE reads only date.*, but day.repeat_days is set. Use DAYS_OF_WEEK instead.", schedule_name);
+            ESP_SCHEDULE_LOGE(TAG, "Schedule %s: DATE reads only date.*, but day.repeat_days is set. Use DAYS_OF_WEEK instead.", schedule_name);
             return false;
         }
         return esp_schedule_date_arm_is_valid(trigger, schedule_name);
@@ -452,7 +453,7 @@ bool esp_schedule_trigger_is_valid(const esp_schedule_trigger_t *trigger, const 
          * populated is ambiguous, not a union. */
         if (trigger->day.repeat_days != 0) {
             if (esp_schedule_date_arm_present(trigger)) {
-                ESP_LOGE(TAG, "Schedule %s: solar day.repeat_days and date.* are mutually exclusive arms; only one may be set.", schedule_name);
+                ESP_SCHEDULE_LOGE(TAG, "Schedule %s: solar day.repeat_days and date.* are mutually exclusive arms; only one may be set.", schedule_name);
                 return false;
             }
             return true; /* day-of-week arm */
@@ -541,7 +542,7 @@ static bool esp_schedule_set_next_scheduled_time_utc(const char *schedule_name, 
     time_t now;
 
     /* Get current time */
-    time(&now);
+    esp_schedule_get_time(&now);
     /* Always recompute the next occurrence for repeating date/day-of-week/solar
      * triggers instead of reusing a stored next_scheduled_time_utc. This keeps
      * the fire time correct after a timezone change (picked up on the next arm)
@@ -582,7 +583,7 @@ static bool esp_schedule_set_next_scheduled_time_utc(const char *schedule_name, 
     if (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE || trigger->type == ESP_SCHEDULE_TYPE_SUNSET) {
         time_t solar_time = esp_schedule_get_next_valid_solar_time(now, trigger, validity, schedule_name);
         if (solar_time == 0) {
-            ESP_LOGW(TAG, "Solar schedule %s has no next occurrence (no sunrise/sunset at this location/date, no remaining matching day, or past the validity window). Enable debug logs for the cause.", schedule_name);
+            ESP_SCHEDULE_LOGW(TAG, "Solar schedule %s has no next occurrence (no sunrise/sunset at this location/date, no remaining matching day, or past the validity window). Enable debug logs for the cause.", schedule_name);
             return false;
         }
 
@@ -617,7 +618,7 @@ static bool esp_schedule_set_next_scheduled_time_utc(const char *schedule_name, 
 static uint32_t esp_schedule_get_next_schedule_time_diff(esp_schedule_t *schedule)
 {
     time_t now;
-    time(&now);
+    esp_schedule_get_time(&now);
 
     if (!esp_schedule_set_next_scheduled_time_utc(schedule->name, &schedule->trigger, &schedule->validity)) {
         schedule->trigger.next_scheduled_time_utc = 0;
@@ -633,7 +634,7 @@ static uint32_t esp_schedule_get_next_schedule_time_diff(esp_schedule_t *schedul
     localtime_r(&schedule->trigger.next_scheduled_time_utc, &schedule_time);
     memset(time_str, 0, sizeof(time_str));
     strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
-    ESP_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule->name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule->name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
 
     /* Clamp before the uint32_t cast: casting a double outside uint32_t range is
      * undefined behavior. */
@@ -648,39 +649,30 @@ static uint32_t esp_schedule_get_next_schedule_time_diff(esp_schedule_t *schedul
 
 static void esp_schedule_stop_timer(esp_schedule_t *schedule)
 {
-    xTimerStop(schedule->timer, portMAX_DELAY);
+    esp_schedule_timer_stop(schedule->timer);
 }
 
 /*
- * Arm the FreeRTOS software timer for the given number of seconds. The period
- * is computed in 64-bit and clamped so that a large seconds value cannot
- * overflow the 32-bit tick math ((seconds * 1000) used to overflow for diffs
- * beyond ~49 days). If the requested delay exceeds what a single TickType_t
- * period can represent, it is clamped; esp_schedule_common_timer_cb re-arms for
- * the remaining time when it detects an early expiry.
+ * Arm the schedule timer for the given number of seconds. The underlying timer is
+ * created on the first arm and reused on every later arm. The glue layer owns the
+ * conversion to its native period and splits a delay too long to be represented
+ * in one period across several of them; esp_schedule_common_timer_cb also re-arms
+ * for the remaining time if it ever detects an early expiry.
  */
 static void esp_schedule_arm_timer(esp_schedule_t *schedule, uint32_t seconds)
 {
-    uint64_t ticks = ((uint64_t)seconds * 1000ULL) / (uint64_t)portTICK_PERIOD_MS;
-    if (ticks == 0) {
-        ticks = 1;
+    if (!esp_schedule_timer_start(&schedule->timer, seconds, esp_schedule_common_timer_cb, (void *)schedule)) {
+        ESP_SCHEDULE_LOGE(TAG, "Failed to arm timer for schedule %s", schedule->name);
+        schedule->trigger.next_scheduled_time_utc = 0;
     }
-    /* portMAX_DELAY is the maximum representable period. Clamp to one below it so
-     * it is never confused with the "block forever" sentinel. */
-    const uint64_t max_ticks = (uint64_t)portMAX_DELAY - 1;
-    if (ticks > max_ticks) {
-        ticks = max_ticks;
-    }
-    xTimerStop(schedule->timer, portMAX_DELAY);
-    xTimerChangePeriod(schedule->timer, (TickType_t)ticks, portMAX_DELAY);
 }
 
 static void esp_schedule_start_timer(esp_schedule_t *schedule)
 {
     time_t current_time = 0;
-    time(&current_time);
+    esp_schedule_get_time(&current_time);
     if (current_time < SECONDS_TILL_2020) {
-        ESP_LOGE(TAG, "Time is not updated");
+        ESP_SCHEDULE_LOGE(TAG, "Time is not updated");
         /* Time is no longer valid (e.g. RTC lost). Stop any already-armed timer
          * and clear the chosen time so we don't keep firing on a stale diff. It
          * will be recomputed once time is synced and the schedule re-enabled. */
@@ -695,7 +687,7 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
 
     /* Check if schedule calculation failed (returns 0) */
     if (schedule->next_scheduled_time_diff == 0) {
-        ESP_LOGW(TAG, "Schedule %s calculation failed or returned invalid time. Skipping timer creation.", schedule->name);
+        ESP_SCHEDULE_LOGW(TAG, "Schedule %s calculation failed or returned invalid time. Skipping timer creation.", schedule->name);
         /* Stop any already-armed timer so a stale diff cannot still fire, then
          * reset timestamp to indicate schedule is not active */
         if (schedule->timer) {
@@ -705,7 +697,7 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
         return;
     }
 
-    ESP_LOGI(TAG, "Starting a timer for %"PRIu32" seconds for schedule %s", schedule->next_scheduled_time_diff, schedule->name);
+    ESP_SCHEDULE_LOGI(TAG, "Starting a timer for %"PRIu32" seconds for schedule %s", schedule->next_scheduled_time_diff, schedule->name);
 
     if (schedule->timestamp_cb) {
         schedule->timestamp_cb((esp_schedule_handle_t)schedule, (uint32_t)schedule->trigger.next_scheduled_time_utc, schedule->priv_data);
@@ -714,12 +706,8 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
     esp_schedule_arm_timer(schedule, schedule->next_scheduled_time_diff);
 }
 
-static void esp_schedule_common_timer_cb(TimerHandle_t timer)
+static void esp_schedule_common_timer_cb(void *priv_data)
 {
-    void *priv_data = pvTimerGetTimerID(timer);
-    if (priv_data == NULL) {
-        return;
-    }
     esp_schedule_t *schedule = (esp_schedule_t *)priv_data;
 
     /* Guard against a premature timer expiry: if the scheduled instant has not
@@ -728,9 +716,9 @@ static void esp_schedule_common_timer_cb(TimerHandle_t timer)
      * esp_schedule_start_timer recomputes the diff from the still-future
      * next_scheduled_time_utc, so it re-arms for what remains. */
     time_t now = 0;
-    time(&now);
+    esp_schedule_get_time(&now);
     if (schedule->trigger.next_scheduled_time_utc > now) {
-        ESP_LOGW(TAG, "Schedule %s fired early; rescheduling for the remaining time", schedule->name);
+        ESP_SCHEDULE_LOGW(TAG, "Schedule %s fired early; rescheduling for the remaining time", schedule->name);
         esp_schedule_start_timer(schedule);
         return;
     }
@@ -741,12 +729,12 @@ static void esp_schedule_common_timer_cb(TimerHandle_t timer)
      * that is now outside the window; the re-arm below will find no further
      * valid occurrence and leave the schedule disarmed. */
     if (schedule->validity.end_time != 0 && now > schedule->validity.end_time) {
-        ESP_LOGW(TAG, "Schedule %s expired before dispatch; suppressing out-of-window trigger", schedule->name);
+        ESP_SCHEDULE_LOGW(TAG, "Schedule %s expired before dispatch; suppressing out-of-window trigger", schedule->name);
         esp_schedule_start_timer(schedule);
         return;
     }
 
-    ESP_LOGI(TAG, "Schedule %s triggered", schedule->name);
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s triggered", schedule->name);
     if (schedule->trigger_cb) {
         schedule->trigger_cb((esp_schedule_handle_t)schedule, schedule->priv_data);
     }
@@ -756,10 +744,10 @@ static void esp_schedule_common_timer_cb(TimerHandle_t timer)
 
 static void esp_schedule_delete_timer(esp_schedule_t *schedule)
 {
-    xTimerDelete(schedule->timer, portMAX_DELAY);
+    esp_schedule_timer_cancel(&schedule->timer);
 }
 
-static void esp_schedule_create_timer(esp_schedule_t *schedule)
+static void esp_schedule_prepare_timer(esp_schedule_t *schedule)
 {
     /* RELATIVE only: computing the diff here anchors the absolute target at
      * create time (the target is computed once and then reused, see
@@ -771,18 +759,15 @@ static void esp_schedule_create_timer(esp_schedule_t *schedule)
     if (schedule->trigger.type == ESP_SCHEDULE_TYPE_RELATIVE && esp_schedule_nvs_is_enabled()) {
         schedule->next_scheduled_time_diff = esp_schedule_get_next_schedule_time_diff(schedule);
     }
-
-    /* Temporarily setting the timer for 1 (anything greater than 0) tick. This will get changed when xTimerChangePeriod() is called. */
-    schedule->timer = xTimerCreate("schedule", 1, pdFALSE, (void *)schedule, esp_schedule_common_timer_cb);
 }
 
-esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config)
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config)
 {
     if (schedule_config == NULL) {
-        return ESP_ERR_INVALID_ARG;
+        return ESP_SCHEDULE_RET_INVALID_ARG;
     }
     if (handle == NULL) {
-        return ESP_ERR_INVALID_ARG;
+        return ESP_SCHEDULE_RET_INVALID_ARG;
     }
     esp_schedule_t *schedule = (esp_schedule_t *)handle;
 
@@ -819,13 +804,13 @@ esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *
     schedule_config->timestamp_cb = schedule->timestamp_cb;
     schedule_config->priv_data = schedule->priv_data;
     schedule_config->validity = schedule->validity;
-    return ESP_OK;
+    return ESP_SCHEDULE_RET_OK;
 }
 
-esp_err_t esp_schedule_enable(esp_schedule_handle_t handle)
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_enable(esp_schedule_handle_t handle)
 {
     if (handle == NULL) {
-        return ESP_ERR_INVALID_ARG;
+        return ESP_SCHEDULE_RET_INVALID_ARG;
     }
     esp_schedule_t *schedule = (esp_schedule_t *)handle;
     esp_schedule_start_timer(schedule);
@@ -837,13 +822,13 @@ esp_err_t esp_schedule_enable(esp_schedule_handle_t handle)
     if (schedule->trigger.next_scheduled_time_utc > 0 && esp_schedule_trigger_is_one_shot(&schedule->trigger)) {
         esp_schedule_nvs_add(schedule);
     }
-    return ESP_OK;
+    return ESP_SCHEDULE_RET_OK;
 }
 
-esp_err_t esp_schedule_disable(esp_schedule_handle_t handle)
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_disable(esp_schedule_handle_t handle)
 {
     if (handle == NULL) {
-        return ESP_ERR_INVALID_ARG;
+        return ESP_SCHEDULE_RET_INVALID_ARG;
     }
     esp_schedule_t *schedule = (esp_schedule_t *)handle;
     esp_schedule_stop_timer(schedule);
@@ -851,7 +836,7 @@ esp_err_t esp_schedule_disable(esp_schedule_handle_t handle)
      * It would be re-computed after enabling.
      */
     schedule->trigger.next_scheduled_time_utc = 0;
-    return ESP_OK;
+    return ESP_SCHEDULE_RET_OK;
 }
 
 /*
@@ -867,7 +852,7 @@ static bool esp_schedule_config_time_of_day_is_valid(const esp_schedule_config_t
     return (schedule_config->trigger.hours < 24 && schedule_config->trigger.minutes < 60);
 }
 
-static esp_err_t esp_schedule_set(esp_schedule_t *schedule, esp_schedule_config_t *schedule_config)
+static ESP_SCHEDULE_RETURN_TYPE esp_schedule_set(esp_schedule_t *schedule, esp_schedule_config_t *schedule_config)
 {
     /* Setting everything apart from name. */
     schedule->trigger.type = schedule_config->trigger.type;
@@ -906,28 +891,28 @@ static esp_err_t esp_schedule_set(esp_schedule_t *schedule, esp_schedule_config_
     schedule->priv_data = schedule_config->priv_data;
     schedule->validity = schedule_config->validity;
     esp_schedule_nvs_add(schedule);
-    return ESP_OK;
+    return ESP_SCHEDULE_RET_OK;
 }
 
-esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config)
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config)
 {
     if (handle == NULL || schedule_config == NULL) {
-        return ESP_ERR_INVALID_ARG;
+        return ESP_SCHEDULE_RET_INVALID_ARG;
     }
     esp_schedule_t *schedule = (esp_schedule_t *)handle;
     if (strncmp(schedule->name, schedule_config->name, sizeof(schedule->name)) != 0) {
-        ESP_LOGE(TAG, "Schedule name mismatch. Expected: %s, Passed: %s", schedule->name, schedule_config->name);
-        return ESP_FAIL;
+        ESP_SCHEDULE_LOGE(TAG, "Schedule name mismatch. Expected: %s, Passed: %s", schedule->name, schedule_config->name);
+        return ESP_SCHEDULE_RET_FAIL;
     }
 
     if (!esp_schedule_config_time_of_day_is_valid(schedule_config)) {
-        ESP_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
-                 schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
-        return ESP_ERR_INVALID_ARG;
+        ESP_SCHEDULE_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
+                          schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
+        return ESP_SCHEDULE_RET_INVALID_ARG;
     }
 
     if (!esp_schedule_trigger_is_valid(&schedule_config->trigger, schedule_config->name)) {
-        return ESP_ERR_INVALID_ARG;
+        return ESP_SCHEDULE_RET_INVALID_ARG;
     }
 
     /* Editing a schedule with relative time should also reset it. */
@@ -935,24 +920,24 @@ esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t 
         schedule->trigger.next_scheduled_time_utc = 0;
     }
     esp_schedule_set(schedule, schedule_config);
-    ESP_LOGD(TAG, "Schedule %s edited", schedule->name);
-    return ESP_OK;
+    ESP_SCHEDULE_LOGD(TAG, "Schedule %s edited", schedule->name);
+    return ESP_SCHEDULE_RET_OK;
 }
 
-esp_err_t esp_schedule_delete(esp_schedule_handle_t handle)
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_delete(esp_schedule_handle_t handle)
 {
     if (handle == NULL) {
-        return ESP_ERR_INVALID_ARG;
+        return ESP_SCHEDULE_RET_INVALID_ARG;
     }
     esp_schedule_t *schedule = (esp_schedule_t *)handle;
-    ESP_LOGI(TAG, "Deleting schedule %s", schedule->name);
+    ESP_SCHEDULE_LOGI(TAG, "Deleting schedule %s", schedule->name);
     if (schedule->timer) {
         esp_schedule_stop_timer(schedule);
         esp_schedule_delete_timer(schedule);
     }
     esp_schedule_nvs_remove(schedule);
-    free(schedule);
-    return ESP_OK;
+    ESP_SCHEDULE_FREE(schedule);
+    return ESP_SCHEDULE_RET_OK;
 }
 
 esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config)
@@ -961,18 +946,18 @@ esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config
         return NULL;
     }
     if (strlen(schedule_config->name) <= 0) {
-        ESP_LOGE(TAG, "Set schedule failed. Please enter a unique valid name for the schedule.");
+        ESP_SCHEDULE_LOGE(TAG, "Set schedule failed. Please enter a unique valid name for the schedule.");
         return NULL;
     }
 
     if (schedule_config->trigger.type == ESP_SCHEDULE_TYPE_INVALID) {
-        ESP_LOGE(TAG, "Schedule type is invalid.");
+        ESP_SCHEDULE_LOGE(TAG, "Schedule type is invalid.");
         return NULL;
     }
 
     if (!esp_schedule_config_time_of_day_is_valid(schedule_config)) {
-        ESP_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
-                 schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
+        ESP_SCHEDULE_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
+                          schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
         return NULL;
     }
 
@@ -980,35 +965,30 @@ esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config
         return NULL;
     }
 
-    esp_schedule_t *schedule = (esp_schedule_t *)MEM_CALLOC_EXTRAM(1, sizeof(esp_schedule_t));
+    esp_schedule_t *schedule = (esp_schedule_t *)ESP_SCHEDULE_CALLOC(1, sizeof(esp_schedule_t));
     if (schedule == NULL) {
-        ESP_LOGE(TAG, "Could not allocate handle");
+        ESP_SCHEDULE_LOGE(TAG, "Could not allocate handle");
         return NULL;
     }
     strlcpy(schedule->name, schedule_config->name, sizeof(schedule->name));
 
     esp_schedule_set(schedule, schedule_config);
 
-    esp_schedule_create_timer(schedule);
-    ESP_LOGD(TAG, "Schedule %s created", schedule->name);
+    esp_schedule_prepare_timer(schedule);
+    ESP_SCHEDULE_LOGD(TAG, "Schedule %s created", schedule->name);
     return (esp_schedule_handle_t)schedule;
 }
 
 esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, uint8_t *schedule_count)
 {
-    if (!esp_sntp_enabled()) {
-        ESP_LOGI(TAG, "Initializing SNTP");
-        esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
-        esp_sntp_setservername(0, "pool.ntp.org");
-        esp_sntp_init();
-    }
+    esp_schedule_timesync_init();
 
     if (!enable_nvs) {
         return NULL;
     }
 
     if (schedule_count == NULL) {
-        ESP_LOGE(TAG, "schedule_count cannot be NULL when NVS is enabled");
+        ESP_SCHEDULE_LOGE(TAG, "schedule_count cannot be NULL when NVS is enabled");
         return NULL;
     }
 
@@ -1022,10 +1002,10 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
     *schedule_count = 0;
     handle_list = esp_schedule_nvs_get_all(schedule_count);
     if (handle_list == NULL) {
-        ESP_LOGI(TAG, "No schedules found in NVS");
+        ESP_SCHEDULE_LOGI(TAG, "No schedules found in NVS");
         return NULL;
     }
-    ESP_LOGI(TAG, "Schedules found in NVS: %"PRIu8, *schedule_count);
+    ESP_SCHEDULE_LOGI(TAG, "Schedules found in NVS: %"PRIu8, *schedule_count);
     /* Start/Delete the schedules */
     esp_schedule_t *schedule = NULL;
     for (size_t handle_count = 0; handle_count < *schedule_count; handle_count++) {
@@ -1041,7 +1021,7 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
                           esp_schedule_set_next_scheduled_time_utc(schedule->name, &schedule->trigger, &schedule->validity);
         if (!has_future) {
             /* This schedule is invalid or has already expired. */
-            ESP_LOGI(TAG, "Schedule %s cannot be armed (invalid config, or does not repeat and has already expired). Deleting it.", schedule->name);
+            ESP_SCHEDULE_LOGI(TAG, "Schedule %s cannot be armed (invalid config, or does not repeat and has already expired). Deleting it.", schedule->name);
             esp_schedule_delete((esp_schedule_handle_t)schedule);
             /* Removing the schedule from the list */
             handle_list[handle_count] = handle_list[*schedule_count - 1];
@@ -1049,7 +1029,7 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
             handle_count--;
             continue;
         }
-        esp_schedule_create_timer(schedule);
+        esp_schedule_prepare_timer(schedule);
         esp_schedule_start_timer(schedule);
     }
     init_done = true;

--- a/esp_schedule/src/esp_schedule.c
+++ b/esp_schedule/src/esp_schedule.c
@@ -775,7 +775,7 @@ static void esp_schedule_delete_timer(esp_schedule_t *schedule)
     esp_schedule_timer_cancel(&schedule->timer);
 }
 
-static void esp_schedule_prepare_timer(esp_schedule_t *schedule)
+static void esp_schedule_prepare_relative_target(esp_schedule_t *schedule)
 {
     /* RELATIVE only: computing the diff here anchors the absolute target at
      * create time (the target is computed once and then reused, see
@@ -1010,7 +1010,7 @@ esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config
 
     esp_schedule_set(schedule, schedule_config);
 
-    esp_schedule_prepare_timer(schedule);
+    esp_schedule_prepare_relative_target(schedule);
     ESP_SCHEDULE_LOGD(TAG, "Schedule %s created", schedule->name);
     return (esp_schedule_handle_t)schedule;
 }
@@ -1065,7 +1065,7 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
             handle_count--;
             continue;
         }
-        esp_schedule_prepare_timer(schedule);
+        esp_schedule_prepare_relative_target(schedule);
         esp_schedule_start_timer(schedule);
     }
     init_done = true;

--- a/esp_schedule/src/esp_schedule.c
+++ b/esp_schedule/src/esp_schedule.c
@@ -706,6 +706,23 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
     esp_schedule_arm_timer(schedule, schedule->next_scheduled_time_diff);
 }
 
+/* Self-deletion from a trigger callback ***************************************
+ *
+ * esp_schedule_delete() called from inside trigger_cb would free the schedule
+ * that esp_schedule_common_timer_cb is still holding on its stack and re-arms
+ * below -> use-after-free. A one-shot schedule that deletes itself when it fires
+ * is a natural pattern, so the free is deferred instead: delete() tears down the
+ * timer and the NVS entry as usual but leaves the allocation to the callback,
+ * which returns without re-arming.
+ *
+ * The two flags below need no lock. The timer glue serializes every callback body
+ * under one mutex, so at most one dispatch is in flight at a time, and delete()
+ * only consults them AFTER esp_schedule_delete_timer() has barriered against any
+ * callback running on another task. Reaching that point with s_dispatching still
+ * equal to this schedule therefore means the caller IS its running callback. */
+static esp_schedule_t *s_dispatching = NULL;
+static bool s_dispatch_deleted = false;
+
 static void esp_schedule_common_timer_cb(void *priv_data)
 {
     esp_schedule_t *schedule = (esp_schedule_t *)priv_data;
@@ -736,7 +753,18 @@ static void esp_schedule_common_timer_cb(void *priv_data)
 
     ESP_SCHEDULE_LOGI(TAG, "Schedule %s triggered", schedule->name);
     if (schedule->trigger_cb) {
+        s_dispatching = schedule;
+        s_dispatch_deleted = false;
         schedule->trigger_cb((esp_schedule_handle_t)schedule, schedule->priv_data);
+        bool deleted = s_dispatch_deleted;
+        s_dispatching = NULL;
+        s_dispatch_deleted = false;
+        if (deleted) {
+            /* The callback deleted this schedule; complete the deferred free and
+             * do not touch it again. */
+            ESP_SCHEDULE_FREE(schedule);
+            return;
+        }
     }
 
     esp_schedule_start_timer(schedule);
@@ -936,6 +964,14 @@ ESP_SCHEDULE_RETURN_TYPE esp_schedule_delete(esp_schedule_handle_t handle)
         esp_schedule_delete_timer(schedule);
     }
     esp_schedule_nvs_remove(schedule);
+    /* Checked only after the timer teardown above, which barriers against a
+     * callback dispatching this schedule on another task. Still being the
+     * dispatched schedule here means this is a self-delete from its own
+     * trigger_cb, whose stack frame outlives us; hand the free back to it. */
+    if (schedule == s_dispatching) {
+        s_dispatch_deleted = true;
+        return ESP_SCHEDULE_RET_OK;
+    }
     ESP_SCHEDULE_FREE(schedule);
     return ESP_SCHEDULE_RET_OK;
 }

--- a/esp_schedule/src/esp_schedule_internal.h
+++ b/esp_schedule/src/esp_schedule_internal.h
@@ -6,28 +6,14 @@
 
 #pragma once
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/timers.h"
+#include "glue_timer.h"
 #include "esp_schedule.h"
-#include "esp_heap_caps.h"
-
-/** Memory allocation macros for external RAM */
-#if ((CONFIG_SPIRAM || CONFIG_SPIRAM_SUPPORT) && \
-        (CONFIG_SPIRAM_USE_CAPS_ALLOC || CONFIG_SPIRAM_USE_MALLOC))
-#define MEM_ALLOC_EXTRAM(size)         heap_caps_malloc_prefer(size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
-#define MEM_CALLOC_EXTRAM(num, size)   heap_caps_calloc_prefer(num, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
-#define MEM_REALLOC_EXTRAM(ptr, size)  heap_caps_realloc_prefer(ptr, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
-#else
-#define MEM_ALLOC_EXTRAM(size)         malloc(size)
-#define MEM_CALLOC_EXTRAM(num, size)   calloc(num, size)
-#define MEM_REALLOC_EXTRAM(ptr, size)  realloc(ptr, size)
-#endif
 
 typedef struct esp_schedule {
     char name[MAX_SCHEDULE_NAME_LEN + 1];
     esp_schedule_trigger_t trigger;
     uint32_t next_scheduled_time_diff;
-    TimerHandle_t timer;
+    esp_schedule_timer_handle_t timer;
     esp_schedule_trigger_cb_t trigger_cb;
     esp_schedule_timestamp_cb_t timestamp_cb;
     void *priv_data;
@@ -38,12 +24,12 @@ typedef struct esp_schedule {
 extern "C" {
 #endif
 
-esp_err_t esp_schedule_nvs_add(esp_schedule_t *schedule);
-esp_err_t esp_schedule_nvs_remove(esp_schedule_t *schedule);
-esp_err_t esp_schedule_nvs_remove_all(void);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_add(esp_schedule_t *schedule);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_remove(esp_schedule_t *schedule);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_remove_all(void);
 esp_schedule_handle_t *esp_schedule_nvs_get_all(uint8_t *schedule_count);
 bool esp_schedule_nvs_is_enabled(void);
-esp_err_t esp_schedule_nvs_init(char *nvs_partition);
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_init(char *nvs_partition);
 
 /* Returns true if the trigger configuration is valid, i.e. it sets no field its
  * type does not read and no combination without a coherent reading. Logs the

--- a/esp_schedule/src/esp_schedule_nvs.c
+++ b/esp_schedule/src/esp_schedule_nvs.c
@@ -14,9 +14,10 @@
 
 #include <string.h>
 #include <time.h>
-#include "esp_log.h"
-#include "nvs.h"
 #include "esp_schedule_internal.h"
+#include "glue_mem.h"
+#include "glue_nvs.h"
+#include "glue_log.h"
 
 static const char *TAG = "esp_schedule_nvs";
 
@@ -26,231 +27,249 @@ static const char *TAG = "esp_schedule_nvs";
 static char *esp_schedule_nvs_partition = NULL;
 static bool nvs_enabled = false;
 
-esp_err_t esp_schedule_nvs_add(esp_schedule_t *schedule)
+static ESP_SCHEDULE_RETURN_TYPE to_esp_schedule_return_type(esp_schedule_nvs_error_t err)
+{
+    switch (err) {
+    case ESP_SCHEDULE_NVS_OK:
+        return ESP_SCHEDULE_RET_OK;
+    case ESP_SCHEDULE_NVS_NOT_FOUND:
+        return ESP_SCHEDULE_RET_INVALID_STATE;
+    case ESP_SCHEDULE_NVS_NO_MEM:
+        return ESP_SCHEDULE_RET_NO_MEM;
+    default:
+        return ESP_SCHEDULE_RET_FAIL;
+    }
+}
+
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_add(esp_schedule_t *schedule)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not adding to NVS.");
-        return ESP_ERR_INVALID_STATE;
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not adding to NVS.");
+        return ESP_SCHEDULE_RET_INVALID_STATE;
     }
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
-        return err;
+    esp_schedule_nvs_handle_t nvs_handle;
+    esp_schedule_nvs_error_t err = esp_schedule_nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, ESP_SCHEDULE_NVS_OPEN_READWRITE, &nvs_handle);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
+        return to_esp_schedule_return_type(err);
     }
 
     /* Check if this is new schedule or editing an existing schedule */
     size_t buf_size;
     bool editing_schedule = true;
-    err = nvs_get_blob(nvs_handle, schedule->name, NULL, &buf_size);
-    if (err != ESP_OK) {
-        if (err == ESP_ERR_NVS_NOT_FOUND) {
+    err = esp_schedule_nvs_get_blob(nvs_handle, schedule->name, NULL, &buf_size);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        if (err == ESP_SCHEDULE_NVS_NOT_FOUND) {
             editing_schedule = false;
         } else {
-            ESP_LOGE(TAG, "NVS get failed with error %d", err);
-            nvs_close(nvs_handle);
-            return err;
+            ESP_SCHEDULE_LOGE(TAG, "NVS get failed with error %d", err);
+            esp_schedule_nvs_close(nvs_handle);
+            return to_esp_schedule_return_type(err);
         }
     } else {
-        ESP_LOGI(TAG, "Updating the existing schedule %s", schedule->name);
+        ESP_SCHEDULE_LOGI(TAG, "Updating the existing schedule %s", schedule->name);
     }
 
-    err = nvs_set_blob(nvs_handle, schedule->name, schedule, sizeof(esp_schedule_t));
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS set failed with error %d", err);
-        nvs_close(nvs_handle);
-        return err;
+    err = esp_schedule_nvs_set_blob(nvs_handle, schedule->name, schedule, sizeof(esp_schedule_t));
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS set failed with error %d", err);
+        esp_schedule_nvs_close(nvs_handle);
+        return to_esp_schedule_return_type(err);
     }
     if (editing_schedule == false) {
         uint8_t schedule_count;
-        err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
-        if (err != ESP_OK) {
-            if (err == ESP_ERR_NVS_NOT_FOUND) {
+        err = esp_schedule_nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
+        if (err != ESP_SCHEDULE_NVS_OK) {
+            if (err == ESP_SCHEDULE_NVS_NOT_FOUND) {
                 schedule_count = 0;
             } else {
-                ESP_LOGE(TAG, "NVS get failed with error %d", err);
-                nvs_close(nvs_handle);
-                return err;
+                ESP_SCHEDULE_LOGE(TAG, "NVS get failed with error %d", err);
+                esp_schedule_nvs_close(nvs_handle);
+                return to_esp_schedule_return_type(err);
             }
         }
         schedule_count++;
-        err = nvs_set_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, schedule_count);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "NVS set failed for schedule count with error %d", err);
-            nvs_close(nvs_handle);
-            return err;
+        err = esp_schedule_nvs_set_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, schedule_count);
+        if (err != ESP_SCHEDULE_NVS_OK) {
+            ESP_SCHEDULE_LOGE(TAG, "NVS set failed for schedule count with error %d", err);
+            esp_schedule_nvs_close(nvs_handle);
+            return to_esp_schedule_return_type(err);
         }
     }
-    nvs_commit(nvs_handle);
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "Schedule %s added in NVS", schedule->name);
-    return ESP_OK;
+    esp_schedule_nvs_commit(nvs_handle);
+    esp_schedule_nvs_close(nvs_handle);
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s added in NVS", schedule->name);
+    return ESP_SCHEDULE_RET_OK;
 }
 
-esp_err_t esp_schedule_nvs_remove_all(void)
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_remove_all(void)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
-        return ESP_ERR_INVALID_STATE;
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
+        return ESP_SCHEDULE_RET_INVALID_STATE;
     }
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
-        return err;
+    esp_schedule_nvs_handle_t nvs_handle;
+    esp_schedule_nvs_error_t err = esp_schedule_nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, ESP_SCHEDULE_NVS_OPEN_READWRITE, &nvs_handle);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
+        return to_esp_schedule_return_type(err);
     }
-    err = nvs_erase_all(nvs_handle);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS erase all keys failed with error %d", err);
-        nvs_close(nvs_handle);
-        return err;
+    err = esp_schedule_nvs_erase_all(nvs_handle);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS erase all keys failed with error %d", err);
+        esp_schedule_nvs_close(nvs_handle);
+        return to_esp_schedule_return_type(err);
     }
-    nvs_commit(nvs_handle);
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "All schedules removed from NVS");
-    return ESP_OK;
+    esp_schedule_nvs_commit(nvs_handle);
+    esp_schedule_nvs_close(nvs_handle);
+    ESP_SCHEDULE_LOGI(TAG, "All schedules removed from NVS");
+    return ESP_SCHEDULE_RET_OK;
 }
 
-esp_err_t esp_schedule_nvs_remove(esp_schedule_t *schedule)
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_remove(esp_schedule_t *schedule)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
-        return ESP_ERR_INVALID_STATE;
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
+        return ESP_SCHEDULE_RET_INVALID_STATE;
     }
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
-        return err;
+    esp_schedule_nvs_handle_t nvs_handle;
+    esp_schedule_nvs_error_t err = esp_schedule_nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, ESP_SCHEDULE_NVS_OPEN_READWRITE, &nvs_handle);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
+        return to_esp_schedule_return_type(err);
     }
-    err = nvs_erase_key(nvs_handle, schedule->name);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS erase key failed with error %d", err);
-        nvs_close(nvs_handle);
-        return err;
+    err = esp_schedule_nvs_erase_key(nvs_handle, schedule->name);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS erase key failed with error %d", err);
+        esp_schedule_nvs_close(nvs_handle);
+        return to_esp_schedule_return_type(err);
     }
     uint8_t schedule_count;
-    err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS get failed for schedule count with error %d", err);
-        nvs_close(nvs_handle);
-        return err;
+    err = esp_schedule_nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS get failed for schedule count with error %d", err);
+        esp_schedule_nvs_close(nvs_handle);
+        return to_esp_schedule_return_type(err);
     }
     schedule_count--;
-    err = nvs_set_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, schedule_count);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS set failed for schedule count with error %d", err);
-        nvs_close(nvs_handle);
-        return err;
+    err = esp_schedule_nvs_set_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, schedule_count);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS set failed for schedule count with error %d", err);
+        esp_schedule_nvs_close(nvs_handle);
+        return to_esp_schedule_return_type(err);
     }
-    nvs_commit(nvs_handle);
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "Schedule %s removed from NVS", schedule->name);
-    return ESP_OK;
+    esp_schedule_nvs_commit(nvs_handle);
+    esp_schedule_nvs_close(nvs_handle);
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s removed from NVS", schedule->name);
+    return ESP_SCHEDULE_RET_OK;
 }
 
 static uint8_t esp_schedule_nvs_get_count(void)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not getting count from NVS.");
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not getting count from NVS.");
         return 0;
     }
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READONLY, &nvs_handle);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+    esp_schedule_nvs_handle_t nvs_handle;
+    esp_schedule_nvs_error_t err = esp_schedule_nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, ESP_SCHEDULE_NVS_OPEN_READONLY, &nvs_handle);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
         return 0;
     }
     uint8_t schedule_count;
-    err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS get failed for schedule count with error %d", err);
-        nvs_close(nvs_handle);
+    err = esp_schedule_nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS get failed for schedule count with error %d", err);
+        esp_schedule_nvs_close(nvs_handle);
         return 0;
     }
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "Schedules in NVS: %d", schedule_count);
+    esp_schedule_nvs_close(nvs_handle);
+    ESP_SCHEDULE_LOGI(TAG, "Schedules in NVS: %d", schedule_count);
     return schedule_count;
 }
 
 static esp_schedule_handle_t esp_schedule_nvs_get(char *nvs_key)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not getting from NVS.");
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not getting from NVS.");
         return NULL;
     }
     size_t buf_size;
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READONLY, &nvs_handle);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+    esp_schedule_nvs_handle_t nvs_handle;
+    esp_schedule_nvs_error_t err = esp_schedule_nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, ESP_SCHEDULE_NVS_OPEN_READONLY, &nvs_handle);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
         return NULL;
     }
-    err = nvs_get_blob(nvs_handle, nvs_key, NULL, &buf_size);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS get failed with error %d", err);
-        nvs_close(nvs_handle);
+    err = esp_schedule_nvs_get_blob(nvs_handle, nvs_key, NULL, &buf_size);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS get failed with error %d", err);
+        esp_schedule_nvs_close(nvs_handle);
         return NULL;
     }
-    esp_schedule_t *schedule = (esp_schedule_t *)malloc(buf_size);
+    esp_schedule_t *schedule = (esp_schedule_t *)ESP_SCHEDULE_MALLOC(buf_size);
     if (schedule == NULL) {
-        ESP_LOGE(TAG, "Could not allocate handle");
-        nvs_close(nvs_handle);
+        ESP_SCHEDULE_LOGE(TAG, "Could not allocate handle");
+        esp_schedule_nvs_close(nvs_handle);
         return NULL;
     }
-    err = nvs_get_blob(nvs_handle, nvs_key, schedule, &buf_size);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS get failed with error %d", err);
-        nvs_close(nvs_handle);
-        free(schedule);
+    err = esp_schedule_nvs_get_blob(nvs_handle, nvs_key, schedule, &buf_size);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "NVS get failed with error %d", err);
+        esp_schedule_nvs_close(nvs_handle);
+        ESP_SCHEDULE_FREE(schedule);
         return NULL;
     }
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "Schedule %s found in NVS", schedule->name);
+    esp_schedule_nvs_close(nvs_handle);
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s found in NVS", schedule->name);
     return (esp_schedule_handle_t) schedule;
 }
 
 esp_schedule_handle_t *esp_schedule_nvs_get_all(uint8_t *schedule_count)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not Initialising NVS.");
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not Initialising NVS.");
         return NULL;
     }
 
     *schedule_count = esp_schedule_nvs_get_count();
     if (*schedule_count == 0) {
-        ESP_LOGI(TAG, "No Entries found in NVS");
+        ESP_SCHEDULE_LOGI(TAG, "No Entries found in NVS");
         return NULL;
     }
-    esp_schedule_handle_t *handle_list = (esp_schedule_handle_t *)malloc(sizeof(esp_schedule_handle_t) * (*schedule_count));
+    esp_schedule_handle_t *handle_list = (esp_schedule_handle_t *)ESP_SCHEDULE_MALLOC(sizeof(esp_schedule_handle_t) * (*schedule_count));
     if (handle_list == NULL) {
-        ESP_LOGE(TAG, "Could not allocate schedule list");
+        ESP_SCHEDULE_LOGE(TAG, "Could not allocate schedule list");
         *schedule_count = 0;
         return NULL;
     }
     int handle_count = 0;
 
-    nvs_entry_info_t nvs_entry;
-    nvs_iterator_t nvs_iterator = NULL;
-    esp_err_t err = nvs_entry_find(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_TYPE_BLOB, &nvs_iterator);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "No entry found in NVS");
-        free(handle_list);
+    esp_schedule_nvs_iterator_t nvs_iterator = NULL;
+    esp_schedule_nvs_error_t err = esp_schedule_nvs_entry_find_blobs(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, &nvs_iterator);
+    if (err != ESP_SCHEDULE_NVS_OK) {
+        ESP_SCHEDULE_LOGE(TAG, "No entry found in NVS");
+        ESP_SCHEDULE_FREE(handle_list);
         return NULL;
     }
-    while (err == ESP_OK) {
-        nvs_entry_info(nvs_iterator, &nvs_entry);
-        ESP_LOGI(TAG, "Found schedule in NVS with key: %s", nvs_entry.key);
-        handle_list[handle_count] = esp_schedule_nvs_get(nvs_entry.key);
+    while (err == ESP_SCHEDULE_NVS_OK) {
+        char *nvs_key = NULL;
+        esp_schedule_nvs_entry_get_key(nvs_iterator, &nvs_key);
+        if (nvs_key == NULL) {
+            break;
+        }
+        ESP_SCHEDULE_LOGI(TAG, "Found schedule in NVS with key: %s", nvs_key);
+        handle_list[handle_count] = esp_schedule_nvs_get(nvs_key);
         if (handle_list[handle_count] != NULL) {
             /* Increase count only if nvs_get was successful */
             handle_count++;
         }
-        err = nvs_entry_next(&nvs_iterator);
+        ESP_SCHEDULE_FREE(nvs_key);
+        err = esp_schedule_nvs_entry_next(&nvs_iterator);
     }
-    nvs_release_iterator(nvs_iterator);
+    esp_schedule_nvs_release_iterator(nvs_iterator);
     *schedule_count = handle_count;
-    ESP_LOGI(TAG, "Found %d schedules in NVS", *schedule_count);
+    ESP_SCHEDULE_LOGI(TAG, "Found %d schedules in NVS", *schedule_count);
     return handle_list;
 }
 
@@ -259,11 +278,11 @@ bool esp_schedule_nvs_is_enabled(void)
     return nvs_enabled;
 }
 
-esp_err_t esp_schedule_nvs_init(char *nvs_partition)
+ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_init(char *nvs_partition)
 {
     if (nvs_enabled) {
-        ESP_LOGI(TAG, "NVS already enabled");
-        return ESP_OK;
+        ESP_SCHEDULE_LOGI(TAG, "NVS already enabled");
+        return ESP_SCHEDULE_RET_OK;
     }
     if (nvs_partition) {
         esp_schedule_nvs_partition = strndup(nvs_partition, strlen(nvs_partition));
@@ -271,9 +290,9 @@ esp_err_t esp_schedule_nvs_init(char *nvs_partition)
         esp_schedule_nvs_partition = strndup("nvs", strlen("nvs"));
     }
     if (esp_schedule_nvs_partition == NULL) {
-        ESP_LOGE(TAG, "Could not allocate nvs_partition");
-        return ESP_ERR_NO_MEM;
+        ESP_SCHEDULE_LOGE(TAG, "Could not allocate nvs_partition");
+        return ESP_SCHEDULE_RET_NO_MEM;
     }
     nvs_enabled = true;
-    return ESP_OK;
+    return ESP_SCHEDULE_RET_OK;
 }

--- a/esp_schedule/src/esp_schedule_nvs.c
+++ b/esp_schedule/src/esp_schedule_nvs.c
@@ -284,10 +284,13 @@ ESP_SCHEDULE_RETURN_TYPE esp_schedule_nvs_init(char *nvs_partition)
         ESP_SCHEDULE_LOGI(TAG, "NVS already enabled");
         return ESP_SCHEDULE_RET_OK;
     }
-    if (nvs_partition) {
-        esp_schedule_nvs_partition = strndup(nvs_partition, strlen(nvs_partition));
-    } else {
-        esp_schedule_nvs_partition = strndup("nvs", strlen("nvs"));
+    /* Copied through the glue allocator rather than strdup() so a port that
+     * overrides ESP_SCHEDULE_MALLOC keeps every allocation on one heap. */
+    const char *partition = nvs_partition ? nvs_partition : "nvs";
+    size_t partition_len = strlen(partition);
+    esp_schedule_nvs_partition = (char *)ESP_SCHEDULE_MALLOC(partition_len + 1);
+    if (esp_schedule_nvs_partition != NULL) {
+        memcpy(esp_schedule_nvs_partition, partition, partition_len + 1);
     }
     if (esp_schedule_nvs_partition == NULL) {
         ESP_SCHEDULE_LOGE(TAG, "Could not allocate nvs_partition");

--- a/esp_schedule/test_app/main/CMakeLists.txt
+++ b/esp_schedule/test_app/main/CMakeLists.txt
@@ -1,9 +1,7 @@
-# The tests exercise the component's internal helpers (esp_schedule_internal.h),
-# so the component's private src/ directory is added to the include path. The
-# esp_schedule dependency itself is pulled in via main/idf_component.yml.
+include(${CMAKE_CURRENT_LIST_DIR}/../../esp_schedule_variables.cmake)
 set(_srcs "test_app_main.c" "test_esp_schedule.c")
 idf_component_register(SRCS ${_srcs}
-                    PRIV_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../src"
-                    PRIV_REQUIRES "esp_daylight" "unity" "nvs_flash" "esp_netif"
+                    PRIV_INCLUDE_DIRS ${ESP_SCHEDULE_PRIV_INCLUDE_DIRS}
+                    PRIV_REQUIRES ${ESP_SCHEDULE_PRIV_REQUIRES} "unity" "nvs_flash" "esp_netif"
                     WHOLE_ARCHIVE
                     )

--- a/esp_schedule/test_app/main/CMakeLists.txt
+++ b/esp_schedule/test_app/main/CMakeLists.txt
@@ -1,5 +1,8 @@
 include(${CMAKE_CURRENT_LIST_DIR}/../../esp_schedule_variables.cmake)
 set(_srcs "test_app_main.c" "test_esp_schedule.c")
+# The variables file covers the portable half only; the ESP glue directory holds
+# the *_impl.h headers that glue_log.h and glue_mem.h include.
+list(APPEND ESP_SCHEDULE_PRIV_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../glue/esp")
 idf_component_register(SRCS ${_srcs}
                     PRIV_INCLUDE_DIRS ${ESP_SCHEDULE_PRIV_INCLUDE_DIRS}
                     PRIV_REQUIRES ${ESP_SCHEDULE_PRIV_REQUIRES} "unity" "nvs_flash" "esp_netif"

--- a/esp_schedule/test_app/main/test_esp_schedule.c
+++ b/esp_schedule/test_app/main/test_esp_schedule.c
@@ -12,6 +12,9 @@
 #include "esp_err.h"
 #include "esp_netif.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/timers.h"
 #include "unity.h"
 #include "esp_schedule_internal.h"
 #if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
@@ -1573,6 +1576,91 @@ TEST_CASE("nvs restore drops invalid config", "[esp_schedule]")
     handle_list = esp_schedule_nvs_get_all(&count);
     TEST_ASSERT_EQUAL_MESSAGE(0, count, "invalid stored config must be deleted from NVS");
     free(handle_list);
+}
+
+/* --- a repeating schedule must re-arm from its own callback without deadlocking
+ * the FreeRTOS timer daemon ---
+ *
+ * Regression: the timer glue serializes the timer callback against cancel() with
+ * a non-recursive mutex, held across the whole callback body. Re-arming a
+ * repeating schedule runs inside that callback (in the timer daemon task) via
+ * trigger_cb -> esp_schedule_start_timer -> esp_schedule_arm_timer. If arm tore
+ * the timer down and recreated it (timer_cancel() re-takes the same mutex) the
+ * daemon would deadlock against itself on the first fire, freezing EVERY software
+ * timer in the system. esp_schedule_timer_start() instead rebinds an existing
+ * timer in place, which never re-takes the callback mutex on the daemon task.
+ *
+ * Detection: fire the schedule once, then confirm the daemon is still alive by
+ * checking that an INDEPENDENT software timer, armed to expire AFTER the re-arm,
+ * actually runs. Under the deadlock the daemon is stuck inside the schedule's
+ * callback and the canary never fires. (Checking next_scheduled_time_utc would
+ * NOT catch the bug: start_timer updates it before the deadlocking arm call.) */
+static volatile uint32_t s_rearm_fire_count = 0;
+static void rearm_trigger_cb(esp_schedule_handle_t handle, void *priv_data)
+{
+    (void)handle;
+    (void)priv_data;
+    s_rearm_fire_count++;
+}
+
+static volatile bool s_canary_fired = false;
+static void canary_timer_cb(TimerHandle_t t)
+{
+    (void)t;
+    s_canary_fired = true;
+}
+
+TEST_CASE("repeating schedule re-arms without deadlock", "[esp_schedule]")
+{
+    /* Pin the clock ~2s before a daily 12:00 slot so the first fire is quick.
+     * The engine works in local time; the default device TZ is UTC so a
+     * make_time_local() instant matches the UTC epoch fed to settimeofday(). */
+    time_t slot = make_time_local(2025, 6, 16, 12, 0, 0);
+    struct timeval tv = { .tv_sec = slot - 2, .tv_usec = 0 };
+    settimeofday(&tv, NULL);
+
+    esp_schedule_config_t config = {0};
+    strcpy(config.name, "rearm");
+    config.trigger.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+    config.trigger.hours = 12;
+    config.trigger.minutes = 0;
+    config.trigger.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+    config.validity.end_time = 2147483647;
+    config.trigger_cb = rearm_trigger_cb;
+
+    esp_schedule_handle_t handle = esp_schedule_create(&config);
+    TEST_ASSERT_NOT_NULL(handle);
+
+    s_rearm_fire_count = 0;
+    s_canary_fired = false;
+
+    /* Canary: an independent one-shot timer that expires ~1.5s AFTER the
+     * schedule fires (and re-arms). It shares the one timer daemon task, so it
+     * can only fire if that task did not deadlock. Ticks are wall-clock
+     * independent, so the pinned time does not affect it. */
+    TimerHandle_t canary = xTimerCreate("canary", pdMS_TO_TICKS(3500), pdFALSE, NULL, canary_timer_cb);
+    TEST_ASSERT_NOT_NULL_MESSAGE(canary, "failed to create canary timer");
+    TEST_ASSERT_EQUAL_MESSAGE(pdPASS, xTimerStart(canary, portMAX_DELAY), "failed to start canary timer");
+
+    TEST_ASSERT_EQUAL_INT(ESP_OK, (int)esp_schedule_enable(handle));
+
+    esp_schedule_t *sched = (esp_schedule_t *)handle;
+    TEST_ASSERT_TRUE_MESSAGE(sched->trigger.next_scheduled_time_utc == slot, "armed for the 2s-away slot");
+
+    /* vTaskDelay is driven by the tick ISR, not the timer daemon, so it returns
+     * even if the daemon has deadlocked. */
+    vTaskDelay(pdMS_TO_TICKS(6000));
+
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, s_rearm_fire_count, "repeating trigger must have fired exactly once");
+    TEST_ASSERT_TRUE_MESSAGE(s_canary_fired,
+                             "timer daemon must survive the re-arm (canary fired) -> no deadlock");
+    /* Fixed path also re-arms for the next occurrence (next day). */
+    TEST_ASSERT_TRUE_MESSAGE(sched->trigger.next_scheduled_time_utc >= slot + 23 * 3600,
+                             "schedule must have re-armed for the next day");
+
+    xTimerDelete(canary, portMAX_DELAY);
+    esp_schedule_delete(handle);
+    settimeofday(&tv, NULL);
 }
 
 /* Unity runs setUp()/tearDown() before/after every TEST_CASE. tearDown()

--- a/esp_schedule/test_app/main/test_esp_schedule.c
+++ b/esp_schedule/test_app/main/test_esp_schedule.c
@@ -1582,13 +1582,14 @@ TEST_CASE("nvs restore drops invalid config", "[esp_schedule]")
  * the FreeRTOS timer daemon ---
  *
  * Regression: the timer glue serializes the timer callback against cancel() with
- * a non-recursive mutex, held across the whole callback body. Re-arming a
- * repeating schedule runs inside that callback (in the timer daemon task) via
- * trigger_cb -> esp_schedule_start_timer -> esp_schedule_arm_timer. If arm tore
- * the timer down and recreated it (timer_cancel() re-takes the same mutex) the
- * daemon would deadlock against itself on the first fire, freezing EVERY software
- * timer in the system. esp_schedule_timer_start() instead rebinds an existing
- * timer in place, which never re-takes the callback mutex on the daemon task.
+ * a mutex held across the whole callback body. Re-arming a repeating schedule
+ * runs inside that callback (in the timer daemon task) via trigger_cb ->
+ * esp_schedule_start_timer -> esp_schedule_arm_timer. If arm tore the timer down
+ * and recreated it, timer_cancel() would re-take that mutex on the task that
+ * already holds it; with a non-recursive mutex the daemon deadlocks against
+ * itself on the first fire, freezing EVERY software timer in the system.
+ * esp_schedule_timer_start() instead rebinds an existing timer in place, and the
+ * mutex is recursive so the re-entrant paths cannot deadlock either way.
  *
  * Detection: fire the schedule once, then confirm the daemon is still alive by
  * checking that an INDEPENDENT software timer, armed to expire AFTER the re-arm,
@@ -1660,6 +1661,65 @@ TEST_CASE("repeating schedule re-arms without deadlock", "[esp_schedule]")
 
     xTimerDelete(canary, portMAX_DELAY);
     esp_schedule_delete(handle);
+    settimeofday(&tv, NULL);
+}
+
+/* --- a schedule must survive deleting itself from its own trigger callback ---
+ *
+ * Same daemon-freeze failure mode as above, reached the other way: trigger_cb ->
+ * esp_schedule_delete -> esp_schedule_delete_timer -> esp_schedule_timer_cancel,
+ * which takes the callback mutex the daemon already holds. cancel() had no
+ * daemon-task guard at all, so a non-recursive mutex blocked the daemon forever.
+ *
+ * The free is deferred to esp_schedule_common_timer_cb for the same reason: the
+ * callback still holds the schedule on its stack and would otherwise re-arm a
+ * freed allocation.
+ *
+ * Detection: the same independent-canary trick. A hang shows up as the canary
+ * never firing; a use-after-free shows up as a heap corruption abort. */
+static volatile uint32_t s_selfdel_fire_count = 0;
+static void selfdel_trigger_cb(esp_schedule_handle_t handle, void *priv_data)
+{
+    (void)priv_data;
+    s_selfdel_fire_count++;
+    TEST_ASSERT_EQUAL_INT(ESP_OK, (int)esp_schedule_delete(handle));
+}
+
+TEST_CASE("schedule deletes itself from its callback without deadlock", "[esp_schedule]")
+{
+    time_t slot = make_time_local(2025, 6, 16, 12, 0, 0);
+    struct timeval tv = { .tv_sec = slot - 2, .tv_usec = 0 };
+    settimeofday(&tv, NULL);
+
+    esp_schedule_config_t config = {0};
+    strcpy(config.name, "selfdel");
+    config.trigger.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+    config.trigger.hours = 12;
+    config.trigger.minutes = 0;
+    config.trigger.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+    config.validity.end_time = 2147483647;
+    config.trigger_cb = selfdel_trigger_cb;
+
+    esp_schedule_handle_t handle = esp_schedule_create(&config);
+    TEST_ASSERT_NOT_NULL(handle);
+
+    s_selfdel_fire_count = 0;
+    s_canary_fired = false;
+
+    TimerHandle_t canary = xTimerCreate("canary", pdMS_TO_TICKS(3500), pdFALSE, NULL, canary_timer_cb);
+    TEST_ASSERT_NOT_NULL_MESSAGE(canary, "failed to create canary timer");
+    TEST_ASSERT_EQUAL_MESSAGE(pdPASS, xTimerStart(canary, portMAX_DELAY), "failed to start canary timer");
+
+    TEST_ASSERT_EQUAL_INT(ESP_OK, (int)esp_schedule_enable(handle));
+
+    vTaskDelay(pdMS_TO_TICKS(6000));
+
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, s_selfdel_fire_count, "trigger must have fired exactly once");
+    TEST_ASSERT_TRUE_MESSAGE(s_canary_fired,
+                             "timer daemon must survive the self-delete (canary fired) -> no deadlock");
+
+    xTimerDelete(canary, portMAX_DELAY);
+    /* handle is already deleted; deleting again would be a double free. */
     settimeofday(&tv, NULL);
 }
 

--- a/esp_schedule/test_app/sdkconfig.defaults
+++ b/esp_schedule/test_app/sdkconfig.defaults
@@ -1,2 +1,8 @@
 # Disable watchdog
 CONFIG_ESP_TASK_WDT_INIT=n
+
+# A schedule re-arms from inside its own timer callback, which runs on the
+# FreeRTOS timer daemon task. That path formats the next fire time (strftime,
+# localtime_r) and runs the date engine, which does not fit in the 2048-byte
+# default on every IDF version.
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3072


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

Add glue layer to `esp_schedule` component
