### PR TITLE
refactor(esp_schedule): replace compile-time glue with a runtime port (IEC-570)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
         additional_dependencies:
             - "toml; python_version < '3.11'"
             - pyyaml
+    -   id: esp_schedule_port_isolation
+        name: esp_schedule default-port isolation
+        language: python
+        entry: python esp_schedule/check_port_isolation.py
+        pass_filenames: false
+        files: '^esp_schedule/(src|include|port)/.*\.[ch]$'
 -   repo: https://github.com/espressif/esp-idf-kconfig.git
     rev: v2.5.0
     hooks:

--- a/esp_schedule/CMakeLists.txt
+++ b/esp_schedule/CMakeLists.txt
@@ -1,7 +1,29 @@
-set(component_srcs "src/esp_schedule.c"
-                   "src/esp_schedule_nvs.c")
+include(${CMAKE_CURRENT_LIST_DIR}/esp_schedule_variables.cmake)
 
-idf_component_register(SRCS "${component_srcs}"
-                       INCLUDE_DIRS "include"
-                       PRIV_INCLUDE_DIRS "src"
-                       PRIV_REQUIRES nvs_flash esp_netif)
+# The ESP-IDF port. esp_schedule_default.c is what binds it to
+# esp_schedule_init(); the port/esp sources are reachable only from there.
+#
+# CONFIG_ESP_SCHEDULE_DISABLE_DEFAULT_PORT=y drops them from the build outright.
+# That is a stronger guarantee than the link-time one: with the default port
+# compiled in, an application that only calls esp_schedule_init_with_config()
+# still gets it stripped, but the objects are built either way.
+if(NOT CONFIG_ESP_SCHEDULE_DISABLE_DEFAULT_PORT)
+    list(APPEND ESP_SCHEDULE_SRCS "src/esp_schedule_default.c"
+                                  "port/esp/log.c"
+                                  "port/esp/mem.c"
+                                  "port/esp/nvs.c"
+                                  "port/esp/time.c"
+                                  "port/esp/timer.c")
+endif()
+
+# Declared unconditionally, unlike the sources above. ESP-IDF resolves component
+# requirements in an early expansion pass that runs before the configuration
+# exists, so a CONFIG_-guarded PRIV_REQUIRES is silently ignored and the port
+# sources fail to find their headers. Requiring these always is harmless: with
+# the default port disabled nothing references them, so nothing is linked.
+list(APPEND ESP_SCHEDULE_PRIV_REQUIRES "nvs_flash" "esp_netif")
+
+idf_component_register(SRCS ${ESP_SCHEDULE_SRCS}
+                       INCLUDE_DIRS ${ESP_SCHEDULE_INCLUDE_DIRS}
+                       PRIV_INCLUDE_DIRS ${ESP_SCHEDULE_PRIV_INCLUDE_DIRS}
+                       PRIV_REQUIRES ${ESP_SCHEDULE_PRIV_REQUIRES})

--- a/esp_schedule/Kconfig
+++ b/esp_schedule/Kconfig
@@ -1,5 +1,28 @@
 menu "ESP Schedule Configuration"
 
+    config ESP_SCHEDULE_DISABLE_DEFAULT_PORT
+        bool "Do not build the default ESP-IDF port"
+        default n
+        help
+            Exclude esp_schedule_init() and the ESP-IDF implementations of the
+            platform operations it installs - FreeRTOS software timers,
+            nvs_flash storage, SNTP time and esp_log logging - from the build.
+
+            Note that the default port runs schedule callbacks on the shared
+            FreeRTOS timer daemon task, which needs
+            CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH raised to at least 3072; see
+            "Timer Task Stack Requirement" in the component README. A port of
+            your own that dispatches on its own task avoids that.
+
+            You do not need this just to use your own port. The default port
+            already costs nothing at run time: it lives in its own object files,
+            referenced only by esp_schedule_init(), so an application calling
+            esp_schedule_init_with_config() never links it in the first place.
+
+            Enable this only when those sources must not be compiled at all.
+            esp_schedule_init() then does not exist, and
+            esp_schedule_init_with_config() becomes the only entry point.
+
     config ESP_SCHEDULE_ENABLE_DAYLIGHT
         bool "Enable Daylight (Sunrise/Sunset) Schedules"
         default y
@@ -16,5 +39,48 @@ menu "ESP Schedule Configuration"
 
             If disabled, ESP_SCHEDULE_TYPE_SUNRISE and ESP_SCHEDULE_TYPE_SUNSET
             will not be available.
+
+    config ESP_SCHEDULE_ENABLE_SNTP
+        bool "Start SNTP from esp_schedule_init()"
+        default y
+        help
+            Whether the default ESP-IDF port starts SNTP when esp_schedule_init()
+            installs it.
+
+            Disable this if the clock comes from somewhere else - an RTC, or a
+            time set by the application over a link with no internet access.
+            esp_schedule needs a valid wall clock but does not care who set it;
+            with this disabled it reads wall time and never touches the network.
+
+            Disabling also drops the esp_sntp dependency rather than leaving it
+            linked and unused.
+
+            Note that esp_schedule still refuses to arm a schedule until the
+            clock reads past 2020, so whatever sets the time must do so before
+            enabling schedules.
+
+    config ESP_SCHEDULE_LOG_LEVEL_OVERRIDE
+        bool "Set a log level for esp_schedule separate from the global one"
+        default n
+        help
+            By default esp_schedule follows CONFIG_LOG_MAXIMUM_LEVEL. Enable
+            this to give the component its own ceiling instead.
+
+            Calls above the ceiling are removed by the preprocessor, format
+            string included, so lowering it saves flash and - because schedule
+            callbacks run on the FreeRTOS timer daemon task - stack. See
+            "Timer Task Stack Requirement" in the component README.
+
+    config ESP_SCHEDULE_LOG_LEVEL
+        int "esp_schedule log level"
+        depends on ESP_SCHEDULE_LOG_LEVEL_OVERRIDE
+        range -1 4
+        default 2
+        help
+            Highest severity esp_schedule will emit: -1 none, 0 error, 1 warn,
+            2 info, 3 debug, 4 verbose.
+
+            This is esp_schedule_log_level_t, which starts at error = 0. It is
+            not esp_log_level_t, which reserves 0 for none.
 
 endmenu

--- a/esp_schedule/README.md
+++ b/esp_schedule/README.md
@@ -162,3 +162,97 @@ s3.solar.longitude = -122.4194;
 ```
 
 The day is selected first, then the actual sunrise/sunset instant for that day is computed for your location. Days with no solar event (polar night/day) are skipped.
+
+## Timer Task Stack Requirement
+
+> **Set `CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH` to at least 3072.** The 2048-byte default is not enough and overflows the timer daemon task on some IDF versions.
+
+With the default ESP-IDF port, a schedule is driven by a FreeRTOS software timer, so its callback runs on the shared timer daemon task (`Tmr Svc`). A repeating schedule re-arms itself from inside that callback, and the re-arm computes the next occurrence through the date engine and formats it for logging (`localtime_r`, `strftime`) — all on the daemon's stack.
+
+Logging costs one more frame than it looks: `esp_schedule_log()` formats into a 160-byte stack buffer before handing the finished string to `port->log`, and the default port's `ESP_LOGx` then formats a second time. Both frames land on the daemon stack alongside the work above. Lowering the log ceiling compiles those calls out and reclaims the stack with them: either globally via `CONFIG_LOG_MAXIMUM_LEVEL`, or for this component alone by enabling `CONFIG_ESP_SCHEDULE_LOG_LEVEL_OVERRIDE` and setting `CONFIG_ESP_SCHEDULE_LOG_LEVEL`.
+
+An overflow here is not local to your schedule: it takes down the one task that services **every** software timer in the application. It surfaces as
+
+```
+***ERROR*** A stack overflow in task Tmr Svc has been detected.
+```
+
+Add to `sdkconfig.defaults`:
+
+```
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3072
+```
+
+If you supply a [custom port](#custom-ports) that dispatches callbacks on its own task instead, size that task's stack for the same work.
+
+## Port Layer
+
+This component reaches the outside world only through the function pointers declared in [`include/esp_schedule.h`](include/esp_schedule.h):
+
+| Group | Type | Required | Provides |
+| --- | --- | --- | --- |
+| `timer` | `esp_schedule_timer_ops_t` | yes | one-shot relative timers |
+| `time_sync` | `esp_schedule_time_sync_ops_t` | `get_time` only | absolute wall-clock time, optional time sync |
+| `mem` | `esp_schedule_mem_ops_t` | yes | `malloc` / `calloc` / `free` |
+| `nvs` | `esp_schedule_nvs_ops_t` | no — all-NULL disables persistence | key/value storage |
+| `log` | `esp_schedule_log_fn_t` | no — NULL discards output | one pre-formatted line at a time |
+
+### As an ESP-IDF component
+
+`esp_schedule_init()` installs the ESP-IDF implementations, so nothing extra is needed:
+
+- Timers: `port/esp/timer.c` (FreeRTOS software timers)
+- Time: `port/esp/time.c` (`time()` and SNTP)
+- Memory: `port/esp/mem.c` (libc allocator)
+- Storage: `port/esp/nvs.c` (`nvs_flash`)
+- Logging: `port/esp/log.c` (`esp_log`)
+
+### Mixing the defaults with your own
+
+The default tables are public, in [`include/esp_schedule_esp_port.h`](include/esp_schedule_esp_port.h), so a port need not be written from scratch. Keep the groups you want and replace the rest:
+
+```c
+#include "esp_schedule_esp_port.h"
+
+esp_schedule_port_config_t port = {
+    .timer = esp_schedule_esp_timer_ops,
+    .nvs   = esp_schedule_esp_nvs_ops,
+    .time_sync  = esp_schedule_esp_time_sync_ops,
+    .mem   = esp_schedule_esp_mem_ops,
+    .log   = esp_schedule_esp_log,
+};
+
+port.time_sync.timesync_init = NULL;   /* keep time(), do not start SNTP */
+port.mem = my_pool_ops;           /* or swap a whole group out */
+
+uint8_t count = 0;
+esp_schedule_handle_t *restored = esp_schedule_init_with_config(&port, true, NULL, &count);
+```
+
+Individual members can be overridden like this, but only where the table says the member is optional — `time_sync.get_time` and every member of `timer` and `mem` are required, and `esp_schedule_init_with_config()` rejects a table missing one with `ESP_ERR_INVALID_ARG`.
+
+You pay for what you name: referencing a table links its implementation and that implementation's dependency. `test_app/main/test_app_main.c` uses exactly this pattern.
+
+> **SNTP:** nulling `timesync_init` stops SNTP being *started*, but naming `esp_schedule_esp_time_sync_ops` still links `port/esp/time.c` and with it `esp_sntp`. To remove the dependency rather than just the call, set `CONFIG_ESP_SCHEDULE_ENABLE_SNTP=n` — the default table then carries a NULL `timesync_init` on its own and `esp_sntp` is not referenced at all. Use that if the clock comes from an RTC or is set by the application.
+
+### Custom ports
+
+Fill in an `esp_schedule_port_config_t` and call `esp_schedule_init_with_config()` instead of `esp_schedule_init()`. No custom `CMakeLists.txt` is involved:
+
+```c
+static const esp_schedule_port_config_t port = {
+    .timer = { .start = my_timer_start, .stop = my_timer_stop, .cancel = my_timer_cancel },
+    .time_sync  = { .get_time = my_get_time },
+    .mem   = { .malloc = my_malloc, .calloc = my_calloc, .free = my_free },
+    .log   = my_log,   /* optional */
+    /* .nvs left zeroed: schedules live only for this run */
+};
+
+uint8_t count = 0;
+esp_schedule_handle_t *restored = esp_schedule_init_with_config(&port, false, NULL, &count);
+/* Allocated with port.mem.malloc, so release it with port.mem.free - not libc
+ * free(), unless your port happens to wrap the libc allocator. */
+my_free(restored);
+```
+
+The port is validated once at install time and copied by value, so it may be built on the stack. `esp_schedule_init()` is the only referrer of the ESP-IDF implementations, so an application that calls only `esp_schedule_init_with_config()` never links them — no FreeRTOS timer, `nvs_flash`, SNTP or `esp_log` dependency is pulled in on this component's behalf. Set `CONFIG_ESP_SCHEDULE_DISABLE_DEFAULT_PORT=y` to stop compiling them altogether.

--- a/esp_schedule/check_port_isolation.py
+++ b/esp_schedule/check_port_isolation.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Assert that the ESP-IDF default port stays strippable from the link.
+
+esp_schedule reaches the outside world through the function-pointer tables in
+include/esp_schedule.h. The ESP-IDF implementations live in port/esp/, and
+src/esp_schedule_default.c - which holds esp_schedule_init() and nothing else -
+is their only referrer.
+
+That is the whole link-strip guarantee. An application calling
+esp_schedule_init_with_config() and never esp_schedule_init() leaves
+esp_schedule_default.o unreferenced, so the linker never pulls it out of
+libesp_schedule.a, and the default port stays out of the image along with the
+FreeRTOS-timer, nvs_flash, esp_sntp and esp_log code it would have dragged in.
+It works at archive-member granularity, so it does not depend on --gc-sections.
+
+It is also fragile in a way no compiler warns about, and it has two halves:
+
+  1. No second referrer *inside the component*. Naming an esp_schedule_esp_*_ops
+     table from any other file here makes the tables reachable from an object
+     every caller already needs. Application code is free to name them - that is
+     what esp_schedule_esp_port.h is for, and it only links what it names. The
+     guarantee is that the component never forces the choice.
+
+  2. No second reason to link esp_schedule_default.o. The guarantee rests on
+     esp_schedule_init() being the *only* external symbol in that object. Adding
+     any other non-static function or variable to it - a version getter, a
+     helper, a counter - gives every caller of that symbol a reason to pull the
+     member in, and the default port comes with it.
+
+Half 1 is checked across the component; half 2 is checked in the one file.
+
+Checked at source level rather than with nm on a built ELF because demonstrating
+the strip needs an application that installs a non-ESP port: the component's own
+test_app calls esp_schedule_init(), so the default port is legitimately present
+in its image and nm would have nothing to assert.
+
+Known limits, so the next reader does not over-trust this:
+  - Half 2 relies on the repo's astyle formatting (definitions start at column
+    zero, OTBS braces). It is a lint, not a C parser. A definition written in an
+    unusual layout can slip past it.
+  - Neither half sees through macros. A reference assembled by token pasting is
+    not detected.
+  - Comments and string literals are stripped before matching, so discussing a
+    table name in prose is fine and quoting one is not a reference.
+
+Usage:
+    check_port_isolation.py [--root <component-dir>]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Referencing any of these forces the corresponding port/esp object into the link.
+PORT_SYMBOL_RE = re.compile(r'\besp_schedule_esp_(?:\w+_ops|log)\b')
+
+# The declaration site, and the one definition site permitted to name them.
+ALLOWED = {
+    Path('src/esp_schedule_default.c'),
+    Path('include/esp_schedule_esp_port.h'),
+}
+
+# port/esp/*.c each define their own table; that is the definition, not a
+# cross-reference, and those files are already inside the strippable set.
+ALLOWED_DIRS = {Path('port/esp')}
+
+SEARCH_DIRS = ('src', 'include', 'port')
+
+# The file whose external surface must stay at exactly one symbol, and that symbol.
+SOLE_REFERRER = Path('src/esp_schedule_default.c')
+SOLE_EXPORT = 'esp_schedule_init'
+
+# A definition at file scope: no leading whitespace, and not a continuation.
+# Deliberately conservative - see "Known limits" above.
+EXTERNAL_DEF_RE = re.compile(
+    r'''^(?!\s)                     # column zero
+        (?!static\b|extern\b|typedef\b)
+        (?P<decl>[A-Za-z_][^;{()]*?)   # return type / type and qualifiers
+        \b(?P<name>[A-Za-z_]\w*)\s*
+        (?:\((?P<params>[^;{]*)\)\s*\{ # function definition (body follows)
+          |=                           # or an initialised object definition
+        )''',
+    re.VERBOSE | re.MULTILINE)
+
+
+def strip_comments_and_strings(text):
+    """Blank out comments and string/char literals, preserving line structure.
+
+    Replacing rather than deleting keeps every line number intact, so a reported
+    line matches the file. Necessary because a naive "does the line start with a
+    comment marker" filter is wrong in both directions: it skips `*p = &table;`
+    as if it were a comment continuation, and it fails to skip a single-line
+    `/* table */`.
+    """
+    out = []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        two = text[i:i + 2]
+        if two == '/*':
+            j = text.find('*/', i + 2)
+            j = n if j < 0 else j + 2
+            out.append(''.join(c if c == '\n' else ' ' for c in text[i:j]))
+            i = j
+        elif two == '//':
+            j = text.find('\n', i)
+            j = n if j < 0 else j
+            out.append(' ' * (j - i))
+            i = j
+        elif ch in '"\'':
+            j = i + 1
+            while j < n and text[j] != ch:
+                j += 2 if text[j] == '\\' else 1
+            j = min(j + 1, n)
+            out.append(''.join(c if c == '\n' else ' ' for c in text[i:j]))
+            i = j
+        else:
+            out.append(ch)
+            i += 1
+    return ''.join(out)
+
+
+def check_no_second_referrer(root):
+    """Half 1: only the allowed files may name an esp_schedule_esp_*_ops table."""
+    offenders, checked = [], 0
+    for directory in SEARCH_DIRS:
+        for path in sorted((root / directory).rglob('*')):
+            if path.suffix not in ('.c', '.h') or not path.is_file():
+                continue
+            rel = path.relative_to(root)
+            checked += 1
+            if rel in ALLOWED or rel.parent in ALLOWED_DIRS:
+                continue
+            code = strip_comments_and_strings(path.read_text())
+            for lineno, line in enumerate(code.splitlines(), 1):
+                match = PORT_SYMBOL_RE.search(line)
+                if match:
+                    offenders.append((rel, lineno, match.group(0), line.strip()))
+    return offenders, checked
+
+
+def check_sole_export(root):
+    """Half 2: esp_schedule_default.c must define nothing but esp_schedule_init."""
+    path = root / SOLE_REFERRER
+    if not path.is_file():
+        return [(SOLE_REFERRER, 0, '<missing>', 'file not found')]
+    code = strip_comments_and_strings(path.read_text())
+    extras = []
+    for match in EXTERNAL_DEF_RE.finditer(code):
+        name = match.group('name')
+        if name == SOLE_EXPORT:
+            continue
+        lineno = code.count('\n', 0, match.start()) + 1
+        extras.append((SOLE_REFERRER, lineno, name, match.group(0).strip()))
+    return extras
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--root', default=Path(__file__).parent, type=Path,
+                    help="component directory (default: this script's directory)")
+    args = ap.parse_args()
+
+    offenders, checked = check_no_second_referrer(args.root)
+    extras = check_sole_export(args.root)
+
+    if not offenders and not extras:
+        print(f'PASS: only {SOLE_REFERRER} and port/esp/ name the default port tables,')
+        print(f'      and {SOLE_REFERRER} exports nothing but {SOLE_EXPORT}()')
+        print(f'      checked {checked} sources')
+        return 0
+
+    print('FAIL: the default ESP-IDF port is no longer strippable from the link')
+
+    if offenders:
+        print('\n  Referenced outside its single referrer:')
+        for rel, lineno, symbol, line in offenders:
+            print(f'    {rel}:{lineno}: {symbol}')
+            print(f'      {line}')
+        print('\n    Any such reference links the default port - and FreeRTOS')
+        print('    timers, nvs_flash, esp_sntp and esp_log - into every build,')
+        print('    including applications that only call')
+        print('    esp_schedule_init_with_config(). Keep the reference in')
+        print(f'    {SOLE_REFERRER}, or add the new file to ALLOWED here if it')
+        print('    is genuinely part of the default port.')
+
+    if extras:
+        print(f'\n  Extra external symbols in {SOLE_REFERRER}:')
+        for rel, lineno, name, line in extras:
+            print(f'    {rel}:{lineno}: {name}')
+            print(f'      {line}')
+        print(f'\n    {SOLE_REFERRER} must export only {SOLE_EXPORT}(). Any other')
+        print('    external symbol gives its callers a reason to pull this')
+        print('    object out of the archive, which links the default port even')
+        print('    into applications that never call esp_schedule_init(). Put')
+        print('    the new symbol in another file, or make it static.')
+
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/esp_schedule/esp_schedule_variables.cmake
+++ b/esp_schedule/esp_schedule_variables.cmake
@@ -1,0 +1,26 @@
+# Platform-independent half of the esp_schedule component.
+#
+# Everything listed here reaches the outside world only through the function
+# pointers in include/esp_schedule.h, so it builds anywhere. Include this
+# file and append your own port sources to build esp_schedule against a
+# platform other than ESP-IDF; see CMakeLists.txt for how the ESP-IDF port does
+# exactly that.
+#
+# Note that src/esp_schedule_default.c is deliberately NOT listed here. It is
+# the only referrer of the ESP-IDF port tables, and keeping it in a separate
+# object is what lets the linker drop the default port for anyone who calls
+# esp_schedule_init_with_config() instead of esp_schedule_init().
+
+# Source files
+set(ESP_SCHEDULE_SRCS "${CMAKE_CURRENT_LIST_DIR}/src/esp_schedule.c"
+                      "${CMAKE_CURRENT_LIST_DIR}/src/esp_schedule_nvs.c"
+                      "${CMAKE_CURRENT_LIST_DIR}/src/esp_schedule_port.c")
+
+# Include directories
+set(ESP_SCHEDULE_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/include")
+
+# Private include directories
+set(ESP_SCHEDULE_PRIV_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/src")
+
+# Private requirements
+set(ESP_SCHEDULE_PRIV_REQUIRES "esp_daylight")

--- a/esp_schedule/examples/get_started/main/idf_component.yml
+++ b/esp_schedule/examples/get_started/main/idf_component.yml
@@ -3,7 +3,7 @@ dependencies:
   idf:
     version: ">=5.1"
   espressif/esp_schedule:
-    version: "~1.4.0"
+    version: "~1.5.0"
     override_path: "../../../."
   espressif/network_provisioning:
     version: "~1.2.0"

--- a/esp_schedule/examples/get_started/sdkconfig.defaults
+++ b/esp_schedule/examples/get_started/sdkconfig.defaults
@@ -5,3 +5,10 @@ CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT=y
 
 # Example can become pretty big, so enable larger partition
 CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y
+
+# A schedule re-arms from inside its own timer callback, which runs on the
+# FreeRTOS timer daemon task. That path formats the next fire time (strftime,
+# localtime_r) and runs the date engine, which does not fit in the 2048-byte
+# default on every IDF version. See "Timer Task Stack Requirement" in the
+# component README.
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3072

--- a/esp_schedule/idf_component.yml
+++ b/esp_schedule/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
-version: "1.4.0"
+version: "1.5.0"
 description: Task scheduling based on periodic and one-time events
 url: https://github.com/espressif/idf-extra-components/tree/master/components/esp_schedule
 repository: https://github.com/espressif/idf-extra-components.git

--- a/esp_schedule/include/esp_schedule.h
+++ b/esp_schedule/include/esp_schedule.h
@@ -4,8 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file esp_schedule.h
+ * @brief The complete public interface of the esp_schedule component.
+ *
+ * Two halves, in this order: the scheduling API, then the porting interface.
+ *
+ * esp_schedule reaches the outside world - timers, storage, wall-clock time, the
+ * heap and the log - only through the function pointers in the second half.
+ * esp_schedule_init() installs the ESP-IDF implementations of all of them;
+ * esp_schedule_init_with_config() lets an integrator supply their own. Both are
+ * declared here, so there is one place to compare them.
+ *
+ * @note Anything that only calls esp_schedule_init_with_config() never
+ *       references esp_schedule_init(), which is the sole referrer of the
+ *       ESP-IDF implementations. They therefore stay out of the link entirely -
+ *       no FreeRTOS timer, nvs_flash or esp_log dependency is pulled in on
+ *       behalf of this component. See src/esp_schedule_default.c.
+ */
+
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
@@ -251,6 +271,207 @@ esp_err_t esp_schedule_disable(esp_schedule_handle_t handle);
  * @return error in case of failure.
  */
 esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config);
+
+/* Timer **********************************************************************/
+
+/** Opaque timer handle owned by the timer implementation. */
+typedef void *esp_schedule_timer_handle_t;
+
+/** Called by the timer implementation when a timer expires.
+ *
+ * @param[in] priv_data Private data given to esp_schedule_timer_ops_t::start.
+ */
+typedef void (*esp_schedule_timer_cb_t)(void *priv_data);
+
+/** One-shot timer operations. All members are required.
+ *
+ * @note Callback bodies must be serialized against each other: at most one
+ *       esp_schedule_timer_cb_t may be executing at any time, across all
+ *       timers. esp_schedule relies on this to detect a schedule deleting
+ *       itself from its own trigger callback, where the deletion has to be
+ *       deferred until the callback returns. A port that dispatched two
+ *       schedules concurrently on two tasks would defeat that detection and
+ *       free a schedule while its callback is still running.
+ *
+ *       Serializing under a single mutex held for the whole callback satisfies
+ *       both this and the @c cancel barrier below. It must be recursive, or
+ *       taken in a way that tolerates re-entry, because the callback may call
+ *       back into @c start or @c cancel on the same task.
+ */
+typedef struct esp_schedule_timer_ops {
+    /** Arm a one-shot timer for @c delay_seconds.
+     *
+     * Creates the timer on the first call for a given handle and reuses it on
+     * later calls. @c cb and @c priv_data are (re)bound on every call.
+     *
+     * The implementation must support delays longer than its native period can
+     * represent, and must tolerate being called from within @c cb.
+     *
+     * @param[in,out] p_timer_handle NULL-valued on first use; set to the created
+     *                               handle and reused thereafter.
+     * @return true if the timer is armed, false otherwise.
+     */
+    bool (*start)(esp_schedule_timer_handle_t *p_timer_handle, uint32_t delay_seconds,
+                  esp_schedule_timer_cb_t cb, void *priv_data);
+
+    /** Stop a timer without destroying it. Must tolerate a NULL handle. */
+    void (*stop)(esp_schedule_timer_handle_t timer_handle);
+
+    /** Stop and destroy a timer, then set @c *p_timer_handle to NULL.
+     *
+     * Must not return while a callback is still executing, and must tolerate
+     * being called from within that callback.
+     */
+    void (*cancel)(esp_schedule_timer_handle_t *p_timer_handle);
+} esp_schedule_timer_ops_t;
+
+/* Storage ********************************************************************/
+
+/** Opaque storage handle owned by the storage implementation. */
+typedef void *esp_schedule_store_handle_t;
+
+/** Callback for esp_schedule_nvs_ops_t::foreach_key.
+ *
+ * @return true to continue iterating, false to stop early.
+ */
+typedef bool (*esp_schedule_key_cb_t)(const char *key, void *ctx);
+
+/** Key/value storage operations.
+ *
+ * Leave every member NULL to build without persistence; schedules then live
+ * only for the lifetime of the process. If any member is set they must all be.
+ */
+typedef struct esp_schedule_nvs_ops {
+    /** Open @c name_space in @c partition. @c partition may be NULL for the
+     * implementation's default. */
+    esp_err_t (*open)(const char *partition, const char *name_space, bool readonly,
+                      esp_schedule_store_handle_t *p_handle);
+
+    /** Flush any pending writes and release the handle.
+     *
+     * @note This is the commit point. Writes made since open() need not be
+     *       durable until close() returns, which lets an implementation batch
+     *       them; esp_schedule never relies on a partial batch being visible.
+     */
+    void (*close)(esp_schedule_store_handle_t handle);
+
+    /** Read the value of @c key.
+     *
+     * With @c value NULL, set @c *p_value_len to the stored size and return
+     * ESP_OK. Otherwise read at most @c *p_value_len bytes and update it to the
+     * number read.
+     *
+     * @return ESP_ERR_NVS_NOT_FOUND (or ESP_ERR_NOT_FOUND) if @c key is absent.
+     */
+    esp_err_t (*read)(esp_schedule_store_handle_t handle, const char *key,
+                      void *value, size_t *p_value_len);
+
+    /** Write @c value_len bytes under @c key, replacing any existing value. */
+    esp_err_t (*write)(esp_schedule_store_handle_t handle, const char *key,
+                       const void *value, size_t value_len);
+
+    /** Erase @c key, or every key in the namespace when @c key is NULL. */
+    esp_err_t (*erase)(esp_schedule_store_handle_t handle, const char *key);
+
+    /** Invoke @c cb once per key in the namespace.
+     *
+     * Takes a partition/namespace rather than an open handle so the
+     * implementation is free to use whatever iteration primitive it has. The
+     * key passed to @c cb is owned by the implementation and need only stay
+     * valid for the duration of the call, which keeps iteration allocation-free.
+     */
+    esp_err_t (*foreach_key)(const char *partition, const char *name_space,
+                             esp_schedule_key_cb_t cb, void *ctx);
+} esp_schedule_nvs_ops_t;
+
+/* Time synchronization *******************************************************/
+
+/** Time synchronization operations. @c get_time is required. */
+typedef struct esp_schedule_time_sync_ops {
+    /** Current UTC time. Also stored to @c p_time when that is non-NULL. */
+    time_t (*get_time)(time_t *p_time);
+
+    /** Start time synchronisation, if the platform has any. May be NULL. */
+    void (*timesync_init)(void);
+} esp_schedule_time_sync_ops_t;
+
+/* Memory *********************************************************************/
+
+/** Heap operations. All members are required. */
+typedef struct esp_schedule_mem_ops {
+    void *(*malloc)(size_t size);
+    void *(*calloc)(size_t num, size_t size);
+    void (*free)(void *ptr);
+} esp_schedule_mem_ops_t;
+
+/* Log ************************************************************************/
+
+/** Log severity, ordered from most to least severe. */
+typedef enum esp_schedule_log_level {
+    ESP_SCHEDULE_LOG_ERROR = 0,
+    ESP_SCHEDULE_LOG_WARN,
+    ESP_SCHEDULE_LOG_INFO,
+    ESP_SCHEDULE_LOG_DEBUG,
+    ESP_SCHEDULE_LOG_VERBOSE,
+} esp_schedule_log_level_t;
+
+/** Emit one already-formatted log line. May be NULL, which discards all output.
+ *
+ * @c message is NUL-terminated and owned by the caller; it is only valid for
+ * the duration of the call, so an implementation that defers must copy it.
+ *
+ * Formatting happens before this is called, so a port needs no varargs printf
+ * of its own. It also keeps va_list handling entirely inside the component:
+ * were the list passed across this boundary, an implementation that called
+ * va_end() on it would double-end the caller's list, which is undefined.
+ *
+ * Calls above the compile-time ceiling are removed by the preprocessor and
+ * never reach this function. The ceiling is CONFIG_LOG_MAXIMUM_LEVEL, or
+ * CONFIG_ESP_SCHEDULE_LOG_LEVEL when CONFIG_ESP_SCHEDULE_LOG_LEVEL_OVERRIDE is
+ * enabled.
+ */
+typedef void (*esp_schedule_log_fn_t)(esp_schedule_log_level_t level, const char *tag,
+                                      const char *message);
+
+/* Port configuration *********************************************************/
+
+/** The complete set of operations esp_schedule needs from its environment.
+ *
+ * Copied by value during init, so a caller may build it on the stack.
+ */
+typedef struct esp_schedule_port_config {
+    esp_schedule_timer_ops_t timer;          /**< Required. */
+    esp_schedule_nvs_ops_t nvs;              /**< Optional; all-NULL disables persistence. */
+    esp_schedule_time_sync_ops_t time_sync;  /**< Required, but only get_time within it. */
+    esp_schedule_mem_ops_t mem;              /**< Required. */
+    esp_schedule_log_fn_t log;               /**< Optional; NULL discards all output. */
+} esp_schedule_port_config_t;
+
+/**
+ * @brief Initialize ESP Schedule against a caller-supplied port.
+ *
+ * Behaves exactly like esp_schedule_init(), except that the platform
+ * operations come from @c port instead of the built-in ESP-IDF ones. Using
+ * this entry point in place of esp_schedule_init() keeps the ESP-IDF
+ * implementations out of the binary.
+ *
+ * @param[in] port Operations to install. Copied; need not outlive the call.
+ *                 Persistence is unavailable if @c port->nvs is all-NULL,
+ *                 whatever @c enable_nvs says.
+ * @param[in] enable_nvs Whether to enable persistence.
+ * @param[in] nvs_partition (Optional) Partition to use, NULL for the default.
+ * @param[out] schedule_count Number of schedules restored from storage.
+ *
+ * @return Array of restored schedule handles, or NULL if there are none.
+ *
+ * @note The caller owns the returned array and must release it with the same
+ *       allocator it supplied - @c port->mem.free, not necessarily libc
+ *       free(). The array is allocated with @c port->mem.malloc. Only the array
+ *       itself is the caller's; the handles in it stay owned by the component.
+ */
+esp_schedule_handle_t *esp_schedule_init_with_config(const esp_schedule_port_config_t *port,
+        bool enable_nvs, char *nvs_partition,
+        uint8_t *schedule_count);
 
 #ifdef __cplusplus
 }

--- a/esp_schedule/include/esp_schedule_esp_port.h
+++ b/esp_schedule/include/esp_schedule_esp_port.h
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file esp_schedule_esp_port.h
+ * @brief The ESP-IDF implementations of the esp_schedule port operations.
+ *
+ * Exposed so a port can be assembled from these rather than written from
+ * scratch. Take the tables you want as-is, replace the ones you do not, and
+ * install the result with esp_schedule_init_with_config():
+ *
+ * @code
+ * esp_schedule_port_config_t port = {
+ *     .timer = esp_schedule_esp_timer_ops,
+ *     .nvs   = esp_schedule_esp_nvs_ops,
+ *     .time_sync  = esp_schedule_esp_time_sync_ops,
+ *     .mem   = esp_schedule_esp_mem_ops,
+ *     .log   = esp_schedule_esp_log,
+ * };
+ * port.time_sync.timesync_init = NULL;      // keep time(), skip starting SNTP
+ * port.mem = my_pool_ops;              // or replace a whole group
+ * esp_schedule_init_with_config(&port, true, NULL, &count);
+ * @endcode
+ *
+ * Individual members may be overridden as above, but only where the porting
+ * interface says the member is optional. @c time_sync.get_time and every member of
+ * @c timer and @c mem are required, and esp_schedule_init_with_config() rejects
+ * a table that is missing one.
+ *
+ * @note Including this header is harmless. Referencing a table pulls the
+ *       corresponding object under port/esp into the link, and with it that
+ *       implementation's dependency - FreeRTOS timers, nvs_flash, esp_sntp or
+ *       esp_log. That is the intended trade: you pay only for the tables you
+ *       name. An application that names none of them, and calls
+ *       esp_schedule_init_with_config() rather than esp_schedule_init(), links
+ *       none of the default port at all.
+ *
+ * @note To keep time() without starting SNTP across the whole build rather than
+ *       per-port, CONFIG_ESP_SCHEDULE_ENABLE_SNTP=n does it in the default
+ *       table and drops the esp_sntp dependency outright. Nulling
+ *       @c timesync_init stops the call but still links esp_sntp, because
+ *       naming @c esp_schedule_esp_time_sync_ops links port/esp/time.c.
+ */
+
+#pragma once
+
+#include "esp_schedule.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Timer operations backed by FreeRTOS software timers. See port/esp/timer.c. */
+extern const esp_schedule_timer_ops_t esp_schedule_esp_timer_ops;
+
+/** @brief Storage operations backed by nvs_flash. See port/esp/nvs.c. */
+extern const esp_schedule_nvs_ops_t esp_schedule_esp_nvs_ops;
+
+/** @brief Wall-clock operations backed by time()/SNTP. See port/esp/time.c. */
+extern const esp_schedule_time_sync_ops_t esp_schedule_esp_time_sync_ops;
+
+/** @brief Heap operations backed by the libc allocator. See port/esp/mem.c. */
+extern const esp_schedule_mem_ops_t esp_schedule_esp_mem_ops;
+
+/**
+ * @brief Emit one pre-formatted log line through esp_log.
+ *
+ * Maps @c level onto the matching ESP_LOGx macro. A plain function rather than
+ * an ops table because esp_schedule_log_fn_t is a bare function pointer.
+ *
+ * @param[in] level Severity of the line.
+ * @param[in] tag Log tag.
+ * @param[in] message NUL-terminated, already-formatted message.
+ */
+void esp_schedule_esp_log(esp_schedule_log_level_t level, const char *tag,
+                          const char *message);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp_schedule/port/esp/log.c
+++ b/esp_schedule/port/esp/log.c
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file log.c
+ * @brief esp_log implementation of esp_schedule_log_fn_t.
+ *
+ * @note Reached only through esp_schedule_esp_log, which only
+ *       esp_schedule_init() references. A build that installs its own port
+ *       never links this file, and with it never pulls in esp_log.
+ */
+
+#include "esp_schedule.h"
+#include "esp_schedule_esp_port.h"
+
+#include "esp_log.h"
+
+/* The message arrives already formatted, so this only has to pick the matching
+ * ESP_LOGx macro. Logging it as a single "%s" keeps the standard
+ * "E (123) tag:" banner without reaching for esp_log internals, whose shape has
+ * changed across IDF versions. */
+void esp_schedule_esp_log(esp_schedule_log_level_t level, const char *tag, const char *message)
+{
+    switch (level) {
+    case ESP_SCHEDULE_LOG_ERROR:
+        ESP_LOGE(tag, "%s", message);
+        break;
+    case ESP_SCHEDULE_LOG_WARN:
+        ESP_LOGW(tag, "%s", message);
+        break;
+    case ESP_SCHEDULE_LOG_INFO:
+        ESP_LOGI(tag, "%s", message);
+        break;
+    case ESP_SCHEDULE_LOG_DEBUG:
+        ESP_LOGD(tag, "%s", message);
+        break;
+    default:
+        ESP_LOGV(tag, "%s", message);
+        break;
+    }
+}

--- a/esp_schedule/port/esp/mem.c
+++ b/esp_schedule/port/esp/mem.c
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file mem.c
+ * @brief Heap implementation of esp_schedule_mem_ops_t.
+ *
+ * @note Reached only through esp_schedule_esp_mem_ops, which only
+ *       esp_schedule_init() references. A build that installs its own port
+ *       never links this file.
+ */
+
+#include "esp_schedule.h"
+#include "esp_schedule_esp_port.h"
+
+#include <stdlib.h>
+#include "esp_heap_caps.h"
+
+/* Prefer external RAM when the target has it configured, falling back to
+ * internal. Matches what the component did before the port layer existed. */
+#if ((CONFIG_SPIRAM || CONFIG_SPIRAM_SUPPORT) && \
+        (CONFIG_SPIRAM_USE_CAPS_ALLOC || CONFIG_SPIRAM_USE_MALLOC))
+
+static void *esp_mem_malloc(size_t size)
+{
+    return heap_caps_malloc_prefer(size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM,
+                                   MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
+}
+
+static void *esp_mem_calloc(size_t num, size_t size)
+{
+    return heap_caps_calloc_prefer(num, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM,
+                                   MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
+}
+
+#else
+
+static void *esp_mem_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+static void *esp_mem_calloc(size_t num, size_t size)
+{
+    return calloc(num, size);
+}
+
+#endif
+
+static void esp_mem_free(void *ptr)
+{
+    free(ptr);
+}
+
+/* Operations table ************************************************************
+ *
+ * The only exported symbol in this file. esp_schedule_init() is its sole
+ * referrer, so nothing here is linked into a build that installs its own port. */
+const esp_schedule_mem_ops_t esp_schedule_esp_mem_ops = {
+    .malloc = esp_mem_malloc,
+    .calloc = esp_mem_calloc,
+    .free = esp_mem_free,
+};

--- a/esp_schedule/port/esp/nvs.c
+++ b/esp_schedule/port/esp/nvs.c
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file nvs.c
+ * @brief nvs_flash implementation of esp_schedule_nvs_ops_t.
+ *
+ * @note Reached only through esp_schedule_esp_nvs_ops, which only
+ *       esp_schedule_init() references. A build that installs its own port
+ *       never links this file, and with it never pulls in nvs_flash.
+ */
+
+#include "esp_schedule.h"
+#include "esp_schedule_esp_port.h"
+
+#include <stdint.h>
+#include <string.h>
+#include "esp_log.h"
+#include "nvs_flash.h"
+
+static const char *TAG = "esp_schedule_nvs_port";
+
+/* nvs_handle_t is an integer, not a pointer, so round-trip it through uintptr_t
+ * rather than casting an integer straight to void *. */
+static nvs_handle_t to_nvs_handle(esp_schedule_store_handle_t handle)
+{
+    return (nvs_handle_t)(uintptr_t)handle;
+}
+
+static esp_err_t esp_nvs_open(const char *partition, const char *name_space, bool readonly,
+                              esp_schedule_store_handle_t *p_handle)
+{
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open_from_partition(partition, name_space,
+                                            readonly ? NVS_READONLY : NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        return err;
+    }
+    *p_handle = (esp_schedule_store_handle_t)(uintptr_t)handle;
+    return ESP_OK;
+}
+
+static void esp_nvs_close(esp_schedule_store_handle_t handle)
+{
+    /* close() is the commit point in the port contract: esp_schedule batches
+     * writes between open() and close() and expects them durable once close()
+     * returns. A failed commit is only worth logging here - the handle has to
+     * be released either way. */
+    esp_err_t err = nvs_commit(to_nvs_handle(handle));
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS commit failed with error %d", err);
+    }
+    nvs_close(to_nvs_handle(handle));
+}
+
+static esp_err_t esp_nvs_read(esp_schedule_store_handle_t handle, const char *key,
+                              void *value, size_t *p_value_len)
+{
+    return nvs_get_blob(to_nvs_handle(handle), key, value, p_value_len);
+}
+
+static esp_err_t esp_nvs_write(esp_schedule_store_handle_t handle, const char *key,
+                               const void *value, size_t value_len)
+{
+    return nvs_set_blob(to_nvs_handle(handle), key, value, value_len);
+}
+
+static esp_err_t esp_nvs_erase(esp_schedule_store_handle_t handle, const char *key)
+{
+    if (key == NULL) {
+        return nvs_erase_all(to_nvs_handle(handle));
+    }
+    return nvs_erase_key(to_nvs_handle(handle), key);
+}
+
+static esp_err_t esp_nvs_foreach_key(const char *partition, const char *name_space,
+                                     esp_schedule_key_cb_t cb, void *ctx)
+{
+    nvs_iterator_t it = NULL;
+    esp_err_t err = nvs_entry_find(partition, name_space, NVS_TYPE_BLOB, &it);
+    if (err != ESP_OK) {
+        /* An empty namespace is not an error to the caller, just an empty walk. */
+        return (err == ESP_ERR_NVS_NOT_FOUND) ? ESP_OK : err;
+    }
+    while (err == ESP_OK && it != NULL) {
+        nvs_entry_info_t info;
+        err = nvs_entry_info(it, &info);
+        if (err != ESP_OK) {
+            break;
+        }
+        /* info.key is a fixed array inside info, so it stays valid for the
+         * duration of the callback - exactly the lifetime the port contract
+         * promises, and it keeps iteration allocation-free. */
+        if (!cb(info.key, ctx)) {
+            break;
+        }
+        err = nvs_entry_next(&it);
+    }
+    nvs_release_iterator(it);
+    /* Running off the end of the namespace is the normal way to finish. */
+    return (err == ESP_OK || err == ESP_ERR_NVS_NOT_FOUND) ? ESP_OK : err;
+}
+
+/* Operations table ************************************************************
+ *
+ * The only exported symbol in this file. esp_schedule_init() is its sole
+ * referrer, so nothing here is linked into a build that installs its own port. */
+const esp_schedule_nvs_ops_t esp_schedule_esp_nvs_ops = {
+    .open = esp_nvs_open,
+    .close = esp_nvs_close,
+    .read = esp_nvs_read,
+    .write = esp_nvs_write,
+    .erase = esp_nvs_erase,
+    .foreach_key = esp_nvs_foreach_key,
+};

--- a/esp_schedule/port/esp/time.c
+++ b/esp_schedule/port/esp/time.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file time.c
+ * @brief SNTP implementation of esp_schedule_time_sync_ops_t.
+ *
+ * @note Reached only through esp_schedule_esp_time_sync_ops, which only
+ *       esp_schedule_init() references. A build that installs its own port
+ *       never links this file, and with it never pulls in esp_sntp.
+ */
+
+#include "esp_schedule.h"
+#include "esp_schedule_esp_port.h"
+
+#include <time.h>
+#if CONFIG_ESP_SCHEDULE_ENABLE_SNTP
+#include <esp_sntp.h>
+#endif
+
+static time_t esp_time_get(time_t *p_time)
+{
+    return time(p_time);
+}
+
+#if CONFIG_ESP_SCHEDULE_ENABLE_SNTP
+static void esp_time_sync_init(void)
+{
+    if (!esp_sntp_enabled()) {
+        esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
+        esp_sntp_setservername(0, "pool.ntp.org");
+        esp_sntp_init();
+    }
+}
+#endif
+
+/* Operations table ************************************************************
+ *
+ * The only exported symbol in this file. esp_schedule_init() is its sole
+ * referrer, so nothing here is linked into a build that installs its own port.
+ *
+ * timesync_init is NULL when CONFIG_ESP_SCHEDULE_ENABLE_SNTP is disabled, which
+ * the core treats as "this platform has no time sync" and skips. That is the
+ * supported way to run against an RTC or an externally set clock without
+ * writing a port. Compiling the function out with it also drops the esp_sntp
+ * reference, so the dependency goes away rather than merely going unused. */
+const esp_schedule_time_sync_ops_t esp_schedule_esp_time_sync_ops = {
+    .get_time = esp_time_get,
+#if CONFIG_ESP_SCHEDULE_ENABLE_SNTP
+    .timesync_init = esp_time_sync_init,
+#else
+    .timesync_init = NULL,
+#endif
+};

--- a/esp_schedule/port/esp/timer.c
+++ b/esp_schedule/port/esp/timer.c
@@ -1,0 +1,344 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file timer.c
+ * @brief FreeRTOS software-timer implementation of esp_schedule_timer_ops_t.
+ *
+ * @note Reached only through esp_schedule_esp_timer_ops, which only
+ *       esp_schedule_init() references. A build that installs its own port
+ *       never links this file, and with it never pulls in FreeRTOS timers.
+ */
+
+#include "esp_schedule.h"
+#include "esp_schedule_esp_port.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/timers.h"
+#include "freertos/semphr.h"
+
+static const char *TAG = "esp_schedule_timer";
+
+/* Types **********************************************************************/
+
+/* xTimerCreate()/xTimerChangePeriod() take a 32-bit TickType_t, so a period
+ * derived from a delay beyond ~49.7 days (at CONFIG_FREERTOS_HZ=1000) would
+ * truncate and fire early. Cap a single hardware period to a safe value and
+ * split longer delays across several periods, re-arming without invoking the
+ * user callback until the full delay has elapsed. portMAX_DELAY/2 leaves
+ * headroom and avoids the portMAX_DELAY "block forever" sentinel. */
+#define ESP_SCHEDULE_TIMER_MAX_TICKS ((TickType_t)(portMAX_DELAY / 2))
+
+/**
+ * @brief Timer private data.
+ */
+typedef struct {
+    esp_schedule_timer_cb_t cb;
+    void *priv_data;
+    uint64_t remaining_ticks; /* ticks still to wait after the current period */
+} esp_schedule_timer_priv_data_t;
+
+/* Callback serialization ******************************************************
+ *
+ * FreeRTOS software-timer callbacks run in the timer service (daemon) task,
+ * while esp_schedule_timer_cancel() runs in the caller's (app) task. xTimerStop
+ * only prevents FUTURE expiries; it does not wait for a callback that is already
+ * executing. Without synchronization, cancel() would free() the priv_data (and
+ * the caller then frees the schedule) while esp_schedule_timer_common_cb is still
+ * dereferencing them in the daemon task -> use-after-free.
+ *
+ * A single global mutex serializes the callback body against cancel(). The
+ * callback holds it while running (including across the user trigger callback);
+ * cancel() waits on it as a barrier so any in-flight callback has fully
+ * completed before priv_data is freed. cancel() never holds the mutex while
+ * calling a blocking timer API, so a full timer-command queue cannot deadlock
+ * the daemon against the app task.
+ *
+ * The mutex is RECURSIVE. The user trigger callback runs with it held, and from
+ * there the user may legitimately re-enter this layer on the same task: a
+ * repeating schedule re-arms itself via esp_schedule_timer_start(), a brand new
+ * schedule may be created and enabled, and a one-shot schedule that deletes
+ * itself reaches esp_schedule_timer_cancel(). With a non-recursive mutex either
+ * re-entry would block the daemon task on a mutex the daemon itself holds,
+ * freezing every software timer in the system. Recursive ownership makes the
+ * nested take a no-op for the owning task while still serializing app tasks
+ * against an in-flight callback.
+ *
+ * Those same re-entry paths make every entry point below reachable from the
+ * daemon task, which is why none of them may hardcode a block time on the timer
+ * command queue - see esp_schedule_cmd_block_ticks(). */
+static portMUX_TYPE s_cb_mutex_init_lock = portMUX_INITIALIZER_UNLOCKED;
+static StaticSemaphore_t s_cb_mutex_buf;
+static SemaphoreHandle_t s_cb_mutex = NULL;
+
+static void esp_schedule_ensure_cb_mutex(void)
+{
+    if (s_cb_mutex != NULL) {
+        return;
+    }
+    /* Static allocation performs no heap work, so it is safe inside a critical
+     * section; the lock makes first-time creation race-free. */
+    portENTER_CRITICAL(&s_cb_mutex_init_lock);
+    if (s_cb_mutex == NULL) {
+        s_cb_mutex = xSemaphoreCreateRecursiveMutexStatic(&s_cb_mutex_buf);
+    }
+    portEXIT_CRITICAL(&s_cb_mutex_init_lock);
+}
+
+/**
+ * @brief Whether the caller is running in the FreeRTOS timer daemon task.
+ */
+static bool esp_schedule_in_timer_daemon(void)
+{
+    return xTaskGetCurrentTaskHandle() == xTimerGetTimerDaemonTaskHandle();
+}
+
+/**
+ * @brief Block time to use for a timer command queue operation.
+ *
+ * FreeRTOS forbids a non-zero block time on the timer command queue from within
+ * a timer callback: if the queue is full the daemon task would end up waiting
+ * for itself to drain it. Hence the block time is chosen from the calling
+ * context rather than hardcoded.
+ */
+static TickType_t esp_schedule_cmd_block_ticks(void)
+{
+    return esp_schedule_in_timer_daemon() ? 0 : portMAX_DELAY;
+}
+
+/* Private functions **********************************************************/
+
+/**
+ * @brief Convert a delay in seconds to timer ticks (64-bit to avoid overflow).
+ */
+static uint64_t esp_schedule_ticks_from_seconds(uint32_t delay_seconds)
+{
+    return (((uint64_t) delay_seconds) * 1000) / portTICK_PERIOD_MS;
+}
+
+/**
+ * @brief Clamp a 64-bit tick count to a valid single timer period (>0).
+ */
+static TickType_t esp_schedule_period_ticks(uint64_t total_ticks)
+{
+    if (total_ticks == 0) {
+        return 1; /* a timer period must be strictly greater than 0 */
+    }
+    if (total_ticks > ESP_SCHEDULE_TIMER_MAX_TICKS) {
+        return ESP_SCHEDULE_TIMER_MAX_TICKS;
+    }
+    return (TickType_t) total_ticks;
+}
+
+/**
+ * @brief Create a new timer private data.
+ *
+ * @param[in] cb Callback function.
+ * @param[in] priv_data Private data.
+ *
+ * @return Pointer to the timer private data.
+ */
+static esp_schedule_timer_priv_data_t *esp_schedule_timer_priv_data_create(esp_schedule_timer_cb_t cb, void *priv_data)
+{
+    esp_schedule_timer_priv_data_t *data = calloc(1, sizeof(esp_schedule_timer_priv_data_t));
+    if (data == NULL) {
+        return NULL;
+    }
+    data->cb = cb;
+    data->priv_data = priv_data;
+    return data;
+}
+
+/**
+ * @brief Get the timer private data from the timer handle.
+ *
+ * @param[in] timer_handle Timer handle.
+ *
+ * @return Pointer to the timer private data.
+ */
+static esp_schedule_timer_priv_data_t *esp_schedule_timer_priv_data_get(esp_schedule_timer_handle_t timer_handle)
+{
+    return (esp_schedule_timer_priv_data_t *) pvTimerGetTimerID(timer_handle);
+}
+
+/**
+ * @brief Common timer callback. Runs in the FreeRTOS timer daemon task.
+ *
+ * @param[in] timer_handle Timer handle.
+ */
+static void esp_schedule_timer_common_cb(TimerHandle_t timer_handle)
+{
+    esp_schedule_ensure_cb_mutex();
+    /* Hold the mutex for the whole callback so cancel() can barrier against it.
+     * priv_data is read AFTER acquiring the mutex: cancel() clears the timer ID
+     * under the same mutex before freeing, so we either see a valid pointer
+     * (cancel has not started) or NULL (cancel already ran). */
+    xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
+    esp_schedule_timer_priv_data_t *timer_priv_data = esp_schedule_timer_priv_data_get(timer_handle);
+    if (timer_priv_data == NULL) {
+        xSemaphoreGiveRecursive(s_cb_mutex);
+        return;
+    }
+    if (timer_priv_data->remaining_ticks > 0) {
+        /* A long delay split across multiple periods: keep counting down and
+         * re-arm without invoking the user callback yet. A timer callback must
+         * never block on the timer command queue, so use a zero block time.
+         *
+         * Only commit the countdown once the re-arm has actually been queued: a
+         * full command queue would otherwise consume this slice of the delay
+         * with no timer left running to serve it, and the schedule would
+         * silently never fire. */
+        TickType_t period = esp_schedule_period_ticks(timer_priv_data->remaining_ticks);
+        if (xTimerChangePeriod(timer_handle, period, 0) == pdPASS) {
+            timer_priv_data->remaining_ticks -= period;
+        } else {
+            ESP_LOGE(TAG, "Failed to re-arm timer; schedule is now disarmed");
+        }
+        xSemaphoreGiveRecursive(s_cb_mutex);
+        return;
+    }
+    timer_priv_data->cb(timer_priv_data->priv_data);
+    xSemaphoreGiveRecursive(s_cb_mutex);
+}
+
+/* Public functions ************************************************************/
+
+static bool esp_timer_start(esp_schedule_timer_handle_t *p_timer_handle, uint32_t delay_seconds, esp_schedule_timer_cb_t cb, void *priv_data)
+{
+    esp_schedule_ensure_cb_mutex();
+    TimerHandle_t timer_handle = (TimerHandle_t) * p_timer_handle;
+
+    uint64_t total_ticks = esp_schedule_ticks_from_seconds(delay_seconds);
+    TickType_t period = esp_schedule_period_ticks(total_ticks);
+    uint64_t remaining_ticks = (total_ticks > period) ? (total_ticks - period) : 0;
+
+    if (timer_handle != NULL) {
+        /* Reuse the existing timer rather than cancel + recreate. A repeating
+         * schedule re-arms from inside its own fired callback (daemon task);
+         * routing that through esp_schedule_timer_cancel() would delete the
+         * timer that is currently executing and free the priv_data the callback
+         * is still using.
+         *
+         * Instead, rebind the private data in place: this honors the start()
+         * contract (the caller-provided cb and priv_data are set explicitly,
+         * not assumed unchanged) without freeing anything the running callback
+         * references, and avoids per-fire create/delete churn.
+         *
+         * The mutex serializes the rebind against a callback running
+         * concurrently on the daemon, which could otherwise read a half-updated
+         * (cb, priv_data) pair. Re-arming from inside the fired callback takes
+         * it recursively on the task that already owns it. */
+        xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
+        esp_schedule_timer_priv_data_t *timer_priv_data = esp_schedule_timer_priv_data_get(timer_handle);
+        if (timer_priv_data == NULL) {
+            /* A concurrent cancel() detached and is deleting this timer; there
+             * is nothing safe to reuse. */
+            xSemaphoreGiveRecursive(s_cb_mutex);
+            return false;
+        }
+        timer_priv_data->cb = cb;
+        timer_priv_data->priv_data = priv_data;
+        timer_priv_data->remaining_ticks = remaining_ticks;
+        xSemaphoreGiveRecursive(s_cb_mutex);
+
+        /* xTimerChangePeriod also (re)starts a dormant/expired timer. A dropped
+         * command leaves the schedule disarmed, so report it rather than
+         * claiming success. */
+        return xTimerChangePeriod(timer_handle, period, esp_schedule_cmd_block_ticks()) == pdPASS;
+    }
+
+    esp_schedule_timer_priv_data_t *timer_priv_data = esp_schedule_timer_priv_data_create(cb, priv_data);
+    if (timer_priv_data == NULL) {
+        return false;
+    }
+    timer_priv_data->remaining_ticks = remaining_ticks;
+    timer_handle = xTimerCreate("schedule", period, pdFALSE, timer_priv_data, esp_schedule_timer_common_cb);
+    if (timer_handle == NULL) {
+        free(timer_priv_data);
+        return false;
+    }
+    if (xTimerStart(timer_handle, esp_schedule_cmd_block_ticks()) != pdPASS) {
+        /* Detach before deleting: if the delete command itself cannot be queued
+         * the timer outlives this call, and a later expiry must find a NULL ID
+         * rather than the freed private data. */
+        vTimerSetTimerID(timer_handle, NULL);
+        xTimerDelete(timer_handle, esp_schedule_cmd_block_ticks());
+        free(timer_priv_data);
+        return false;
+    }
+    *p_timer_handle = (esp_schedule_timer_handle_t) timer_handle;
+    return true;
+}
+
+static void esp_timer_stop(esp_schedule_timer_handle_t timer_handle)
+{
+    if (timer_handle == NULL) {
+        return;
+    }
+    xTimerStop((TimerHandle_t) timer_handle, esp_schedule_cmd_block_ticks());
+}
+
+static void esp_timer_cancel(esp_schedule_timer_handle_t *p_timer_handle)
+{
+    if (p_timer_handle == NULL || *p_timer_handle == NULL) {
+        return;
+    }
+    TimerHandle_t timer_handle = (TimerHandle_t) * p_timer_handle;
+    esp_schedule_ensure_cb_mutex();
+
+    TickType_t block_ticks = esp_schedule_cmd_block_ticks();
+
+    /* Stop the timer so no new expiry is dispatched. */
+    if (xTimerIsTimerActive(timer_handle) == pdTRUE) {
+        xTimerStop(timer_handle, block_ticks);
+    }
+
+    /* Detach the private data under the callback mutex. Taking the mutex is the
+     * barrier: any callback already executing on another task runs to
+     * completion before we proceed, and any callback dispatched afterwards will
+     * read a NULL timer ID and return without touching the freed data. When the
+     * caller IS the running callback the mutex is taken recursively and there is
+     * nothing to barrier against. The mutex is released before the
+     * xTimerDelete()/free() so a full timer-command queue cannot deadlock the
+     * daemon against this task.
+     *
+     * The read must happen INSIDE the mutex, not before it: two tasks cancelling
+     * the same handle would otherwise both capture a non-NULL pointer and both go
+     * on to delete the timer and free the data. Clearing the ID under the lock
+     * makes the non-NULL read the single claim on the delete. */
+    xSemaphoreTakeRecursive(s_cb_mutex, portMAX_DELAY);
+    esp_schedule_timer_priv_data_t *priv_data = esp_schedule_timer_priv_data_get(timer_handle);
+    if (priv_data != NULL) {
+        vTimerSetTimerID(timer_handle, NULL);
+    }
+    xSemaphoreGiveRecursive(s_cb_mutex);
+
+    if (priv_data == NULL) {
+        /* Another cancel already claimed this timer and owns its deletion. */
+        *p_timer_handle = NULL;
+        return;
+    }
+
+    xTimerDelete(timer_handle, block_ticks);
+    free(priv_data);
+    *p_timer_handle = NULL;
+}
+
+/* Operations table ************************************************************
+ *
+ * The only exported symbol in this file. esp_schedule_init() is its sole
+ * referrer, so nothing here is linked into a build that installs its own port. */
+const esp_schedule_timer_ops_t esp_schedule_esp_timer_ops = {
+    .start = esp_timer_start,
+    .stop = esp_timer_stop,
+    .cancel = esp_timer_cancel,
+};

--- a/esp_schedule/src/esp_schedule.c
+++ b/esp_schedule/src/esp_schedule.c
@@ -8,8 +8,6 @@
 #include <stdbool.h>
 #include <time.h>
 #include <inttypes.h>
-#include "esp_log.h"
-#include "esp_sntp.h"
 #include "esp_daylight.h"
 #include "esp_schedule_internal.h"
 
@@ -63,10 +61,8 @@ static const char *TAG = "esp_schedule";
  */
 #define MAX_MASKED_MONTH_ATTEMPTS (1 + (MAX_LEAP_YEAR_GAP - 1) + 1)
 
-static bool init_done = false;
-
 // Forward declarations for static functions
-static void esp_schedule_common_timer_cb(TimerHandle_t timer);
+static void esp_schedule_common_timer_cb(void *priv_data);
 
 /*
  * Unified date-based next occurrence calculation.
@@ -309,10 +305,10 @@ time_t esp_schedule_calc_solar_time_for_time_utc(bool is_sunrise, time_t time_ut
 
     bool calc_ok = esp_daylight_calc_sunrise_sunset_utc(year, month, day, latitude, longitude, &sunrise_utc, &sunset_utc);
     if (!calc_ok) {
-        ESP_LOGW(TAG, "Failed to calculate %s for date %04d-%02d-%02d at latitude %.5f, longitude %.5f (likely polar night/day condition)",
-                 is_sunrise ? "sunrise" : "sunset",
-                 year, month, day, latitude, longitude
-                );
+        ESP_SCHEDULE_LOGW(TAG, "Failed to calculate %s for date %04d-%02d-%02d at latitude %.5f, longitude %.5f (likely polar night/day condition)",
+                          is_sunrise ? "sunrise" : "sunset",
+                          year, month, day, latitude, longitude
+                         );
         return 0;
     }
     time_t solar_time = is_sunrise ? sunrise_utc : sunset_utc;
@@ -344,7 +340,7 @@ time_t esp_schedule_get_next_valid_solar_time(time_t now, const esp_schedule_tri
             // Outside validity window or not in the future -> advance to next valid day
         } else if (validity && validity->end_time && solar_time > validity->end_time) {
             // Past validity window -> return 0
-            ESP_LOGD(TAG, "Schedule %s: next solar event is past validity end_time.", schedule_name);
+            ESP_SCHEDULE_LOGD(TAG, "Schedule %s: next solar event is past validity end_time.", schedule_name);
             return 0;
         } else {
             return solar_time;
@@ -352,11 +348,11 @@ time_t esp_schedule_get_next_valid_solar_time(time_t now, const esp_schedule_tri
 
         // Advance anchor to next day
         if (!esp_schedule_get_next_date_time(day_end + 1, MINUTES_IN_DAY - 1, trigger->day.repeat_days, trigger->date.day, trigger->date.repeat_months, match_year, validity, &day_end)) {
-            ESP_LOGD(TAG, "Schedule %s: no further day matches the date/day-of-week arm.", schedule_name);
+            ESP_SCHEDULE_LOGD(TAG, "Schedule %s: no further day matches the date/day-of-week arm.", schedule_name);
             return 0;
         }
     }
-    ESP_LOGD(TAG, "Schedule %s: no solar event found within 370 candidate days.", schedule_name);
+    ESP_SCHEDULE_LOGD(TAG, "Schedule %s: no solar event found within 370 candidate days.", schedule_name);
     return 0;
 }
 #endif /* CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT */
@@ -380,24 +376,24 @@ static bool esp_schedule_date_arm_is_valid(const esp_schedule_trigger_t *trigger
     /* V3: a months mask with no day-of-month would mean every day of those
      * months, which is never the intended schedule. */
     if (trigger->date.day == 0 && trigger->date.repeat_months != 0) {
-        ESP_LOGE(TAG, "Schedule %s: date.repeat_months is set but date.day is 0. Set date.day.", schedule_name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule %s: date.repeat_months is set but date.day is 0. Set date.day.", schedule_name);
         return false;
     }
     /* V4: a recurrence or a year bound with no date pattern to apply it to. */
     if (trigger->date.day == 0 && trigger->date.repeat_months == 0 &&
             (trigger->date.year != 0 || trigger->date.repeat_every_year)) {
-        ESP_LOGE(TAG, "Schedule %s: date.year/date.repeat_every_year set with no date.day or date.repeat_months to apply it to.", schedule_name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule %s: date.year/date.repeat_every_year set with no date.day or date.repeat_months to apply it to.", schedule_name);
         return false;
     }
     /* V5: "only year N" and "every year" are contradictory. */
     if (trigger->date.year != 0 && trigger->date.repeat_every_year) {
-        ESP_LOGE(TAG, "Schedule %s: date.year and date.repeat_every_year are mutually exclusive.", schedule_name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule %s: date.year and date.repeat_every_year are mutually exclusive.", schedule_name);
         return false;
     }
     /* V6: repeat_every_year recurs *over the month set*, so with no mask it
      * would be inert. date.year is exempt: it still constrains the arm. */
     if (trigger->date.repeat_every_year && trigger->date.repeat_months == 0) {
-        ESP_LOGE(TAG, "Schedule %s: date.repeat_every_year needs date.repeat_months to recur over (use ESP_SCHEDULE_MONTH_ALL for every month).", schedule_name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule %s: date.repeat_every_year needs date.repeat_months to recur over (use ESP_SCHEDULE_MONTH_ALL for every month).", schedule_name);
         return false;
     }
     return true;
@@ -426,21 +422,21 @@ bool esp_schedule_trigger_is_valid(const esp_schedule_trigger_t *trigger, const 
          * or before the base time, so the arm path would find nothing to fire and
          * the schedule would silently never run. */
         if (trigger->relative_seconds <= 0) {
-            ESP_LOGE(TAG, "Schedule %s: relative_seconds must be > 0, got %d.", schedule_name, trigger->relative_seconds);
+            ESP_SCHEDULE_LOGE(TAG, "Schedule %s: relative_seconds must be > 0, got %d.", schedule_name, trigger->relative_seconds);
             return false;
         }
         return true;
     case ESP_SCHEDULE_TYPE_DAYS_OF_WEEK:
         /* V1: this type reads only day.repeat_days. */
         if (esp_schedule_date_arm_present(trigger)) {
-            ESP_LOGE(TAG, "Schedule %s: DAYS_OF_WEEK reads only day.repeat_days, but a date.* field is set.", schedule_name);
+            ESP_SCHEDULE_LOGE(TAG, "Schedule %s: DAYS_OF_WEEK reads only day.repeat_days, but a date.* field is set.", schedule_name);
             return false;
         }
         return true;
     case ESP_SCHEDULE_TYPE_DATE:
         /* V2: DATE has no day-of-week arm. */
         if (trigger->day.repeat_days != 0) {
-            ESP_LOGE(TAG, "Schedule %s: DATE reads only date.*, but day.repeat_days is set. Use DAYS_OF_WEEK instead.", schedule_name);
+            ESP_SCHEDULE_LOGE(TAG, "Schedule %s: DATE reads only date.*, but day.repeat_days is set. Use DAYS_OF_WEEK instead.", schedule_name);
             return false;
         }
         return esp_schedule_date_arm_is_valid(trigger, schedule_name);
@@ -452,7 +448,7 @@ bool esp_schedule_trigger_is_valid(const esp_schedule_trigger_t *trigger, const 
          * populated is ambiguous, not a union. */
         if (trigger->day.repeat_days != 0) {
             if (esp_schedule_date_arm_present(trigger)) {
-                ESP_LOGE(TAG, "Schedule %s: solar day.repeat_days and date.* are mutually exclusive arms; only one may be set.", schedule_name);
+                ESP_SCHEDULE_LOGE(TAG, "Schedule %s: solar day.repeat_days and date.* are mutually exclusive arms; only one may be set.", schedule_name);
                 return false;
             }
             return true; /* day-of-week arm */
@@ -541,7 +537,7 @@ static bool esp_schedule_set_next_scheduled_time_utc(const char *schedule_name, 
     time_t now;
 
     /* Get current time */
-    time(&now);
+    ESP_SCHEDULE_GET_TIME(&now);
     /* Always recompute the next occurrence for repeating date/day-of-week/solar
      * triggers instead of reusing a stored next_scheduled_time_utc. This keeps
      * the fire time correct after a timezone change (picked up on the next arm)
@@ -582,7 +578,9 @@ static bool esp_schedule_set_next_scheduled_time_utc(const char *schedule_name, 
     if (trigger->type == ESP_SCHEDULE_TYPE_SUNRISE || trigger->type == ESP_SCHEDULE_TYPE_SUNSET) {
         time_t solar_time = esp_schedule_get_next_valid_solar_time(now, trigger, validity, schedule_name);
         if (solar_time == 0) {
-            ESP_LOGW(TAG, "Solar schedule %s has no next occurrence (no sunrise/sunset at this location/date, no remaining matching day, or past the validity window). Enable debug logs for the cause.", schedule_name);
+            /* Kept within ESP_SCHEDULE_LOG_BUF_LEN even with a full-length name;
+             * see the buffer comment in esp_schedule_port.c. */
+            ESP_SCHEDULE_LOGW(TAG, "Solar schedule %s has no next occurrence: no solar event at this location/date, no matching day left, or past validity. Enable debug logs.", schedule_name);
             return false;
         }
 
@@ -617,7 +615,7 @@ static bool esp_schedule_set_next_scheduled_time_utc(const char *schedule_name, 
 static uint32_t esp_schedule_get_next_schedule_time_diff(esp_schedule_t *schedule)
 {
     time_t now;
-    time(&now);
+    ESP_SCHEDULE_GET_TIME(&now);
 
     if (!esp_schedule_set_next_scheduled_time_utc(schedule->name, &schedule->trigger, &schedule->validity)) {
         schedule->trigger.next_scheduled_time_utc = 0;
@@ -633,7 +631,7 @@ static uint32_t esp_schedule_get_next_schedule_time_diff(esp_schedule_t *schedul
     localtime_r(&schedule->trigger.next_scheduled_time_utc, &schedule_time);
     memset(time_str, 0, sizeof(time_str));
     strftime(time_str, sizeof(time_str), "%c %z[%Z]", &schedule_time);
-    ESP_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule->name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s will be active on: %s. DST: %s", schedule->name, time_str, schedule_time.tm_isdst ? "Yes" : "No");
 
     /* Clamp before the uint32_t cast: casting a double outside uint32_t range is
      * undefined behavior. */
@@ -648,39 +646,40 @@ static uint32_t esp_schedule_get_next_schedule_time_diff(esp_schedule_t *schedul
 
 static void esp_schedule_stop_timer(esp_schedule_t *schedule)
 {
-    xTimerStop(schedule->timer, portMAX_DELAY);
+    g_esp_schedule_port.timer.stop(schedule->timer);
 }
 
 /*
- * Arm the FreeRTOS software timer for the given number of seconds. The period
- * is computed in 64-bit and clamped so that a large seconds value cannot
- * overflow the 32-bit tick math ((seconds * 1000) used to overflow for diffs
- * beyond ~49 days). If the requested delay exceeds what a single TickType_t
- * period can represent, it is clamped; esp_schedule_common_timer_cb re-arms for
- * the remaining time when it detects an early expiry.
+ * Arm the schedule timer for the given number of seconds. The underlying timer is
+ * created on the first arm and reused on every later arm. The glue layer owns the
+ * conversion to its native period and splits a delay too long to be represented
+ * in one period across several of them; esp_schedule_common_timer_cb also re-arms
+ * for the remaining time if it ever detects an early expiry.
  */
 static void esp_schedule_arm_timer(esp_schedule_t *schedule, uint32_t seconds)
 {
-    uint64_t ticks = ((uint64_t)seconds * 1000ULL) / (uint64_t)portTICK_PERIOD_MS;
-    if (ticks == 0) {
-        ticks = 1;
+    if (!g_esp_schedule_port.timer.start(&schedule->timer, seconds, esp_schedule_common_timer_cb, (void *)schedule)) {
+        ESP_SCHEDULE_LOGE(TAG, "Failed to arm timer for schedule %s", schedule->name);
+        /* A failed re-arm of an existing timer does not disarm it: start() may
+         * have been unable to apply the new period while the old one is still
+         * running, and it would then fire on a time we have just discarded.
+         * Stop it explicitly, the same way the two bail-outs in
+         * esp_schedule_start_timer() do. Best-effort: whatever made start()
+         * fail may well make this fail too, but leaving the stale period armed
+         * is strictly worse. */
+        if (schedule->timer != NULL) {
+            esp_schedule_stop_timer(schedule);
+        }
+        schedule->trigger.next_scheduled_time_utc = 0;
     }
-    /* portMAX_DELAY is the maximum representable period. Clamp to one below it so
-     * it is never confused with the "block forever" sentinel. */
-    const uint64_t max_ticks = (uint64_t)portMAX_DELAY - 1;
-    if (ticks > max_ticks) {
-        ticks = max_ticks;
-    }
-    xTimerStop(schedule->timer, portMAX_DELAY);
-    xTimerChangePeriod(schedule->timer, (TickType_t)ticks, portMAX_DELAY);
 }
 
 static void esp_schedule_start_timer(esp_schedule_t *schedule)
 {
     time_t current_time = 0;
-    time(&current_time);
+    ESP_SCHEDULE_GET_TIME(&current_time);
     if (current_time < SECONDS_TILL_2020) {
-        ESP_LOGE(TAG, "Time is not updated");
+        ESP_SCHEDULE_LOGE(TAG, "Time is not updated");
         /* Time is no longer valid (e.g. RTC lost). Stop any already-armed timer
          * and clear the chosen time so we don't keep firing on a stale diff. It
          * will be recomputed once time is synced and the schedule re-enabled. */
@@ -695,7 +694,7 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
 
     /* Check if schedule calculation failed (returns 0) */
     if (schedule->next_scheduled_time_diff == 0) {
-        ESP_LOGW(TAG, "Schedule %s calculation failed or returned invalid time. Skipping timer creation.", schedule->name);
+        ESP_SCHEDULE_LOGW(TAG, "Schedule %s calculation failed or returned invalid time. Skipping timer creation.", schedule->name);
         /* Stop any already-armed timer so a stale diff cannot still fire, then
          * reset timestamp to indicate schedule is not active */
         if (schedule->timer) {
@@ -705,7 +704,7 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
         return;
     }
 
-    ESP_LOGI(TAG, "Starting a timer for %"PRIu32" seconds for schedule %s", schedule->next_scheduled_time_diff, schedule->name);
+    ESP_SCHEDULE_LOGI(TAG, "Starting a timer for %"PRIu32" seconds for schedule %s", schedule->next_scheduled_time_diff, schedule->name);
 
     if (schedule->timestamp_cb) {
         schedule->timestamp_cb((esp_schedule_handle_t)schedule, (uint32_t)schedule->trigger.next_scheduled_time_utc, schedule->priv_data);
@@ -714,12 +713,37 @@ static void esp_schedule_start_timer(esp_schedule_t *schedule)
     esp_schedule_arm_timer(schedule, schedule->next_scheduled_time_diff);
 }
 
-static void esp_schedule_common_timer_cb(TimerHandle_t timer)
+/* Self-deletion from a trigger callback ***************************************
+ *
+ * esp_schedule_delete() called from inside trigger_cb would free the schedule
+ * that esp_schedule_common_timer_cb is still holding on its stack and re-arms
+ * below -> use-after-free. A one-shot schedule that deletes itself when it fires
+ * is a natural pattern, so the free is deferred instead: delete() tears down the
+ * timer and the NVS entry as usual but leaves the allocation to the callback,
+ * which returns without re-arming.
+ *
+ * The two flags below need no lock, but they do rely on a port property: the
+ * timer implementation must serialize callback bodies against each other, so at
+ * most one dispatch is in flight process-wide. esp_schedule_timer_ops_t requires
+ * this explicitly - see the note on the ops table in esp_schedule.h. Given
+ * that, and because delete() only consults the flags AFTER
+ * esp_schedule_delete_timer() has barriered against any callback running on
+ * another task, reaching that point with s_dispatching still equal to this
+ * schedule means the caller IS its running callback.
+ *
+ * A port that dispatched two schedules concurrently on two tasks would break
+ * this: the second dispatch overwrites s_dispatching, so the first schedule's
+ * self-delete would not be deferred and would free an allocation its own
+ * callback is still using. Making the state per-schedule instead of global would
+ * remove the requirement, but esp_schedule_t is persisted to NVS verbatim and
+ * esp_schedule_nvs_read_one() rejects any blob whose size does not match, so
+ * growing the struct would discard every schedule stored by an earlier build.
+ * The contract is the cheaper half of that trade for now. */
+static esp_schedule_t *s_dispatching = NULL;
+static bool s_dispatch_deleted = false;
+
+static void esp_schedule_common_timer_cb(void *priv_data)
 {
-    void *priv_data = pvTimerGetTimerID(timer);
-    if (priv_data == NULL) {
-        return;
-    }
     esp_schedule_t *schedule = (esp_schedule_t *)priv_data;
 
     /* Guard against a premature timer expiry: if the scheduled instant has not
@@ -728,9 +752,9 @@ static void esp_schedule_common_timer_cb(TimerHandle_t timer)
      * esp_schedule_start_timer recomputes the diff from the still-future
      * next_scheduled_time_utc, so it re-arms for what remains. */
     time_t now = 0;
-    time(&now);
+    ESP_SCHEDULE_GET_TIME(&now);
     if (schedule->trigger.next_scheduled_time_utc > now) {
-        ESP_LOGW(TAG, "Schedule %s fired early; rescheduling for the remaining time", schedule->name);
+        ESP_SCHEDULE_LOGW(TAG, "Schedule %s fired early; rescheduling for the remaining time", schedule->name);
         esp_schedule_start_timer(schedule);
         return;
     }
@@ -741,14 +765,25 @@ static void esp_schedule_common_timer_cb(TimerHandle_t timer)
      * that is now outside the window; the re-arm below will find no further
      * valid occurrence and leave the schedule disarmed. */
     if (schedule->validity.end_time != 0 && now > schedule->validity.end_time) {
-        ESP_LOGW(TAG, "Schedule %s expired before dispatch; suppressing out-of-window trigger", schedule->name);
+        ESP_SCHEDULE_LOGW(TAG, "Schedule %s expired before dispatch; suppressing out-of-window trigger", schedule->name);
         esp_schedule_start_timer(schedule);
         return;
     }
 
-    ESP_LOGI(TAG, "Schedule %s triggered", schedule->name);
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s triggered", schedule->name);
     if (schedule->trigger_cb) {
+        s_dispatching = schedule;
+        s_dispatch_deleted = false;
         schedule->trigger_cb((esp_schedule_handle_t)schedule, schedule->priv_data);
+        bool deleted = s_dispatch_deleted;
+        s_dispatching = NULL;
+        s_dispatch_deleted = false;
+        if (deleted) {
+            /* The callback deleted this schedule; complete the deferred free and
+             * do not touch it again. */
+            ESP_SCHEDULE_FREE(schedule);
+            return;
+        }
     }
 
     esp_schedule_start_timer(schedule);
@@ -756,10 +791,10 @@ static void esp_schedule_common_timer_cb(TimerHandle_t timer)
 
 static void esp_schedule_delete_timer(esp_schedule_t *schedule)
 {
-    xTimerDelete(schedule->timer, portMAX_DELAY);
+    g_esp_schedule_port.timer.cancel(&schedule->timer);
 }
 
-static void esp_schedule_create_timer(esp_schedule_t *schedule)
+static void esp_schedule_prepare_relative_target(esp_schedule_t *schedule)
 {
     /* RELATIVE only: computing the diff here anchors the absolute target at
      * create time (the target is computed once and then reused, see
@@ -771,13 +806,14 @@ static void esp_schedule_create_timer(esp_schedule_t *schedule)
     if (schedule->trigger.type == ESP_SCHEDULE_TYPE_RELATIVE && esp_schedule_nvs_is_enabled()) {
         schedule->next_scheduled_time_diff = esp_schedule_get_next_schedule_time_diff(schedule);
     }
-
-    /* Temporarily setting the timer for 1 (anything greater than 0) tick. This will get changed when xTimerChangePeriod() is called. */
-    schedule->timer = xTimerCreate("schedule", 1, pdFALSE, (void *)schedule, esp_schedule_common_timer_cb);
 }
 
 esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config)
 {
+    if (!esp_schedule_is_inited()) {
+        ESP_SCHEDULE_LOGE(TAG, "esp_schedule_init() must be called first");
+        return ESP_ERR_INVALID_STATE;
+    }
     if (schedule_config == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
@@ -824,6 +860,10 @@ esp_err_t esp_schedule_get(esp_schedule_handle_t handle, esp_schedule_config_t *
 
 esp_err_t esp_schedule_enable(esp_schedule_handle_t handle)
 {
+    if (!esp_schedule_is_inited()) {
+        ESP_SCHEDULE_LOGE(TAG, "esp_schedule_init() must be called first");
+        return ESP_ERR_INVALID_STATE;
+    }
     if (handle == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
@@ -842,6 +882,10 @@ esp_err_t esp_schedule_enable(esp_schedule_handle_t handle)
 
 esp_err_t esp_schedule_disable(esp_schedule_handle_t handle)
 {
+    if (!esp_schedule_is_inited()) {
+        ESP_SCHEDULE_LOGE(TAG, "esp_schedule_init() must be called first");
+        return ESP_ERR_INVALID_STATE;
+    }
     if (handle == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
@@ -911,18 +955,22 @@ static esp_err_t esp_schedule_set(esp_schedule_t *schedule, esp_schedule_config_
 
 esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t *schedule_config)
 {
+    if (!esp_schedule_is_inited()) {
+        ESP_SCHEDULE_LOGE(TAG, "esp_schedule_init() must be called first");
+        return ESP_ERR_INVALID_STATE;
+    }
     if (handle == NULL || schedule_config == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
     esp_schedule_t *schedule = (esp_schedule_t *)handle;
     if (strncmp(schedule->name, schedule_config->name, sizeof(schedule->name)) != 0) {
-        ESP_LOGE(TAG, "Schedule name mismatch. Expected: %s, Passed: %s", schedule->name, schedule_config->name);
+        ESP_SCHEDULE_LOGE(TAG, "Schedule name mismatch. Expected: %s, Passed: %s", schedule->name, schedule_config->name);
         return ESP_FAIL;
     }
 
     if (!esp_schedule_config_time_of_day_is_valid(schedule_config)) {
-        ESP_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
-                 schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
+        ESP_SCHEDULE_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
+                          schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -935,44 +983,60 @@ esp_err_t esp_schedule_edit(esp_schedule_handle_t handle, esp_schedule_config_t 
         schedule->trigger.next_scheduled_time_utc = 0;
     }
     esp_schedule_set(schedule, schedule_config);
-    ESP_LOGD(TAG, "Schedule %s edited", schedule->name);
+    ESP_SCHEDULE_LOGD(TAG, "Schedule %s edited", schedule->name);
     return ESP_OK;
 }
 
 esp_err_t esp_schedule_delete(esp_schedule_handle_t handle)
 {
+    if (!esp_schedule_is_inited()) {
+        ESP_SCHEDULE_LOGE(TAG, "esp_schedule_init() must be called first");
+        return ESP_ERR_INVALID_STATE;
+    }
     if (handle == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
     esp_schedule_t *schedule = (esp_schedule_t *)handle;
-    ESP_LOGI(TAG, "Deleting schedule %s", schedule->name);
+    ESP_SCHEDULE_LOGI(TAG, "Deleting schedule %s", schedule->name);
     if (schedule->timer) {
         esp_schedule_stop_timer(schedule);
         esp_schedule_delete_timer(schedule);
     }
     esp_schedule_nvs_remove(schedule);
-    free(schedule);
+    /* Checked only after the timer teardown above, which barriers against a
+     * callback dispatching this schedule on another task. Still being the
+     * dispatched schedule here means this is a self-delete from its own
+     * trigger_cb, whose stack frame outlives us; hand the free back to it. */
+    if (schedule == s_dispatching) {
+        s_dispatch_deleted = true;
+        return ESP_OK;
+    }
+    ESP_SCHEDULE_FREE(schedule);
     return ESP_OK;
 }
 
 esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config)
 {
+    if (!esp_schedule_is_inited()) {
+        ESP_SCHEDULE_LOGE(TAG, "esp_schedule_init() must be called first");
+        return NULL;
+    }
     if (schedule_config == NULL) {
         return NULL;
     }
     if (strlen(schedule_config->name) <= 0) {
-        ESP_LOGE(TAG, "Set schedule failed. Please enter a unique valid name for the schedule.");
+        ESP_SCHEDULE_LOGE(TAG, "Set schedule failed. Please enter a unique valid name for the schedule.");
         return NULL;
     }
 
     if (schedule_config->trigger.type == ESP_SCHEDULE_TYPE_INVALID) {
-        ESP_LOGE(TAG, "Schedule type is invalid.");
+        ESP_SCHEDULE_LOGE(TAG, "Schedule type is invalid.");
         return NULL;
     }
 
     if (!esp_schedule_config_time_of_day_is_valid(schedule_config)) {
-        ESP_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
-                 schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
+        ESP_SCHEDULE_LOGE(TAG, "Invalid time of day for schedule %s: %u:%u. Expected hours in [0,23] and minutes in [0,59].",
+                          schedule_config->name, (unsigned int)schedule_config->trigger.hours, (unsigned int)schedule_config->trigger.minutes);
         return NULL;
     }
 
@@ -980,27 +1044,41 @@ esp_schedule_handle_t esp_schedule_create(esp_schedule_config_t *schedule_config
         return NULL;
     }
 
-    esp_schedule_t *schedule = (esp_schedule_t *)MEM_CALLOC_EXTRAM(1, sizeof(esp_schedule_t));
+    esp_schedule_t *schedule = (esp_schedule_t *)ESP_SCHEDULE_CALLOC(1, sizeof(esp_schedule_t));
     if (schedule == NULL) {
-        ESP_LOGE(TAG, "Could not allocate handle");
+        ESP_SCHEDULE_LOGE(TAG, "Could not allocate handle");
         return NULL;
     }
     strlcpy(schedule->name, schedule_config->name, sizeof(schedule->name));
 
     esp_schedule_set(schedule, schedule_config);
 
-    esp_schedule_create_timer(schedule);
-    ESP_LOGD(TAG, "Schedule %s created", schedule->name);
+    esp_schedule_prepare_relative_target(schedule);
+    ESP_SCHEDULE_LOGD(TAG, "Schedule %s created", schedule->name);
     return (esp_schedule_handle_t)schedule;
 }
 
-esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, uint8_t *schedule_count)
+esp_schedule_handle_t *esp_schedule_init_with_config(const esp_schedule_port_config_t *port,
+        bool enable_nvs, char *nvs_partition,
+        uint8_t *schedule_count)
 {
-    if (!esp_sntp_enabled()) {
-        ESP_LOGI(TAG, "Initializing SNTP");
-        esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
-        esp_sntp_setservername(0, "pool.ntp.org");
-        esp_sntp_init();
+    /* Clear the out-parameter up front so every early return below reports zero
+     * restored schedules rather than leaving the caller's variable untouched.
+     * Doing it here rather than per-return is what keeps them all consistent. */
+    if (schedule_count != NULL) {
+        *schedule_count = 0;
+    }
+
+    esp_err_t err = esp_schedule_port_install(port);
+    if (err != ESP_OK) {
+        /* Nothing is usable without a port, so there is no partial success to
+         * report here: the caller gets no schedules and every later API call
+         * will refuse with ESP_ERR_INVALID_STATE. */
+        return NULL;
+    }
+
+    if (g_esp_schedule_port.time_sync.timesync_init != NULL) {
+        g_esp_schedule_port.time_sync.timesync_init();
     }
 
     if (!enable_nvs) {
@@ -1008,24 +1086,26 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
     }
 
     if (schedule_count == NULL) {
-        ESP_LOGE(TAG, "schedule_count cannot be NULL when NVS is enabled");
+        ESP_SCHEDULE_LOGE(TAG, "schedule_count cannot be NULL when NVS is enabled");
         return NULL;
     }
 
     /* Wait for time to be updated here */
 
     /* Below this is initialising schedules from NVS */
-    esp_schedule_nvs_init(nvs_partition);
-
-    /* Get handle list from NVS */
-    esp_schedule_handle_t *handle_list = NULL;
-    *schedule_count = 0;
-    handle_list = esp_schedule_nvs_get_all(schedule_count);
-    if (handle_list == NULL) {
-        ESP_LOGI(TAG, "No schedules found in NVS");
+    if (esp_schedule_nvs_init(nvs_partition) != ESP_OK) {
+        /* Either the port has no storage or the partition name could not be
+         * copied. Schedules still work, they just will not persist. */
         return NULL;
     }
-    ESP_LOGI(TAG, "Schedules found in NVS: %"PRIu8, *schedule_count);
+
+    /* Get handle list from NVS */
+    esp_schedule_handle_t *handle_list = esp_schedule_nvs_get_all(schedule_count);
+    if (handle_list == NULL) {
+        ESP_SCHEDULE_LOGI(TAG, "No schedules found in NVS");
+        return NULL;
+    }
+    ESP_SCHEDULE_LOGI(TAG, "Schedules found in NVS: %"PRIu8, *schedule_count);
     /* Start/Delete the schedules */
     esp_schedule_t *schedule = NULL;
     for (size_t handle_count = 0; handle_count < *schedule_count; handle_count++) {
@@ -1041,7 +1121,7 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
                           esp_schedule_set_next_scheduled_time_utc(schedule->name, &schedule->trigger, &schedule->validity);
         if (!has_future) {
             /* This schedule is invalid or has already expired. */
-            ESP_LOGI(TAG, "Schedule %s cannot be armed (invalid config, or does not repeat and has already expired). Deleting it.", schedule->name);
+            ESP_SCHEDULE_LOGI(TAG, "Schedule %s cannot be armed (invalid config, or does not repeat and has already expired). Deleting it.", schedule->name);
             esp_schedule_delete((esp_schedule_handle_t)schedule);
             /* Removing the schedule from the list */
             handle_list[handle_count] = handle_list[*schedule_count - 1];
@@ -1049,9 +1129,8 @@ esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, u
             handle_count--;
             continue;
         }
-        esp_schedule_create_timer(schedule);
+        esp_schedule_prepare_relative_target(schedule);
         esp_schedule_start_timer(schedule);
     }
-    init_done = true;
     return handle_list;
 }

--- a/esp_schedule/src/esp_schedule_default.c
+++ b/esp_schedule/src/esp_schedule_default.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file esp_schedule_default.c
+ * @brief esp_schedule_init() - the default, ESP-IDF-backed entry point.
+ *
+ * @warning This file must contain esp_schedule_init() and nothing else, and it
+ *          must be the only file IN THIS COMPONENT that names the
+ *          esp_schedule_esp_*_ops tables. Application code may name them
+ *          freely - esp_schedule_esp_port.h is public so a port can be
+ *          assembled from the defaults - and pays for exactly what it names.
+ *          The rule here is what stops the component charging everyone for
+ *          them.
+ *
+ *          That is what makes the port swappable at zero cost. A program that
+ *          calls only esp_schedule_init_with_config() never references
+ *          esp_schedule_init(), so the linker never pulls this object out of
+ *          libesp_schedule.a, so it never pulls the port/esp objects either -
+ *          and the FreeRTOS timer, nvs_flash, esp_sntp and esp_log
+ *          dependencies come with them. This works at archive-member
+ *          granularity and therefore
+ *          does not depend on -ffunction-sections or --gc-sections.
+ *
+ *          Merging this function into esp_schedule.c, or referencing any
+ *          esp_schedule_esp_*_ops from another file, silently undoes all of
+ *          that: the tables become reachable from an object every caller needs,
+ *          and the default port is linked into every build. check_port_isolation.py
+ *          is the regression test for both mistakes; it runs from pre-commit.
+ */
+
+#include "esp_schedule.h"
+#include "esp_schedule_esp_port.h"
+
+esp_schedule_handle_t *esp_schedule_init(bool enable_nvs, char *nvs_partition, uint8_t *schedule_count)
+{
+    const esp_schedule_port_config_t port = {
+        .timer = esp_schedule_esp_timer_ops,
+        .nvs = esp_schedule_esp_nvs_ops,
+        .time_sync = esp_schedule_esp_time_sync_ops,
+        .mem = esp_schedule_esp_mem_ops,
+        .log = esp_schedule_esp_log,
+    };
+    return esp_schedule_init_with_config(&port, enable_nvs, nvs_partition, schedule_count);
+}

--- a/esp_schedule/src/esp_schedule_internal.h
+++ b/esp_schedule/src/esp_schedule_internal.h
@@ -6,28 +6,14 @@
 
 #pragma once
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/timers.h"
 #include "esp_schedule.h"
-#include "esp_heap_caps.h"
-
-/** Memory allocation macros for external RAM */
-#if ((CONFIG_SPIRAM || CONFIG_SPIRAM_SUPPORT) && \
-        (CONFIG_SPIRAM_USE_CAPS_ALLOC || CONFIG_SPIRAM_USE_MALLOC))
-#define MEM_ALLOC_EXTRAM(size)         heap_caps_malloc_prefer(size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
-#define MEM_CALLOC_EXTRAM(num, size)   heap_caps_calloc_prefer(num, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
-#define MEM_REALLOC_EXTRAM(ptr, size)  heap_caps_realloc_prefer(ptr, size, 2, MALLOC_CAP_DEFAULT | MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL)
-#else
-#define MEM_ALLOC_EXTRAM(size)         malloc(size)
-#define MEM_CALLOC_EXTRAM(num, size)   calloc(num, size)
-#define MEM_REALLOC_EXTRAM(ptr, size)  realloc(ptr, size)
-#endif
+#include "esp_schedule.h"
 
 typedef struct esp_schedule {
     char name[MAX_SCHEDULE_NAME_LEN + 1];
     esp_schedule_trigger_t trigger;
     uint32_t next_scheduled_time_diff;
-    TimerHandle_t timer;
+    esp_schedule_timer_handle_t timer;
     esp_schedule_trigger_cb_t trigger_cb;
     esp_schedule_timestamp_cb_t timestamp_cb;
     void *priv_data;
@@ -37,6 +23,63 @@ typedef struct esp_schedule {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Platform access ************************************************************
+ *
+ * Every call out of this component goes through this one table. It is written
+ * once by esp_schedule_port_install() during init and is read-only afterwards,
+ * so no locking is needed. install() rejects a config with any required member
+ * missing, which is what lets the call sites below dereference these pointers
+ * unconditionally instead of NULL-checking on every use. */
+extern esp_schedule_port_config_t g_esp_schedule_port;
+
+/* Installs @c port after validating it. Returns ESP_ERR_INVALID_ARG if a
+ * required operation is missing, ESP_ERR_INVALID_STATE if already installed. */
+esp_err_t esp_schedule_port_install(const esp_schedule_port_config_t *port);
+
+/* True once a port is installed. Public entry points refuse to run before
+ * that, because there would be no timer or heap to work with. */
+bool esp_schedule_is_inited(void);
+
+#define ESP_SCHEDULE_MALLOC(size)      (g_esp_schedule_port.mem.malloc(size))
+#define ESP_SCHEDULE_CALLOC(num, size) (g_esp_schedule_port.mem.calloc((num), (size)))
+#define ESP_SCHEDULE_FREE(ptr)         (g_esp_schedule_port.mem.free(ptr))
+
+#define ESP_SCHEDULE_GET_TIME(p_time)  (g_esp_schedule_port.time_sync.get_time(p_time))
+
+/* Logging ********************************************************************
+ *
+ * Routed through the port so a non-ESP-IDF build never references esp_log.
+ * The ceiling below is a compile-time constant, so the comparison folds away
+ * and the dead call - including its format string - is dropped by the
+ * optimizer. Writing it as a real `if` rather than #if keeps -Wformat checking
+ * alive for the levels that are compiled out. */
+#if defined(CONFIG_ESP_SCHEDULE_LOG_LEVEL)
+#define ESP_SCHEDULE_LOG_CEILING (CONFIG_ESP_SCHEDULE_LOG_LEVEL)
+#elif defined(CONFIG_LOG_MAXIMUM_LEVEL)
+/* esp_log_level_t counts NONE as 0 and ERROR as 1; ours starts at ERROR. */
+#define ESP_SCHEDULE_LOG_CEILING (CONFIG_LOG_MAXIMUM_LEVEL - 1)
+#else
+#define ESP_SCHEDULE_LOG_CEILING (ESP_SCHEDULE_LOG_INFO)
+#endif
+
+void esp_schedule_log(esp_schedule_log_level_t level, const char *tag, const char *format, ...)
+__attribute__((format(printf, 3, 4)));
+
+#define ESP_SCHEDULE_LOG_AT(level, tag, format, ...)                   \
+    do {                                                               \
+        if ((int)(level) <= (int)(ESP_SCHEDULE_LOG_CEILING)) {         \
+            esp_schedule_log((level), (tag), (format), ##__VA_ARGS__); \
+        }                                                              \
+    } while (0)
+
+#define ESP_SCHEDULE_LOGE(tag, format, ...) ESP_SCHEDULE_LOG_AT(ESP_SCHEDULE_LOG_ERROR, tag, format, ##__VA_ARGS__)
+#define ESP_SCHEDULE_LOGW(tag, format, ...) ESP_SCHEDULE_LOG_AT(ESP_SCHEDULE_LOG_WARN, tag, format, ##__VA_ARGS__)
+#define ESP_SCHEDULE_LOGI(tag, format, ...) ESP_SCHEDULE_LOG_AT(ESP_SCHEDULE_LOG_INFO, tag, format, ##__VA_ARGS__)
+#define ESP_SCHEDULE_LOGD(tag, format, ...) ESP_SCHEDULE_LOG_AT(ESP_SCHEDULE_LOG_DEBUG, tag, format, ##__VA_ARGS__)
+#define ESP_SCHEDULE_LOGV(tag, format, ...) ESP_SCHEDULE_LOG_AT(ESP_SCHEDULE_LOG_VERBOSE, tag, format, ##__VA_ARGS__)
+
+/* Storage ********************************************************************/
 
 esp_err_t esp_schedule_nvs_add(esp_schedule_t *schedule);
 esp_err_t esp_schedule_nvs_remove(esp_schedule_t *schedule);

--- a/esp_schedule/src/esp_schedule_nvs.c
+++ b/esp_schedule/src/esp_schedule_nvs.c
@@ -14,243 +14,235 @@
 
 #include <string.h>
 #include <time.h>
-#include "esp_log.h"
-#include "nvs.h"
 #include "esp_schedule_internal.h"
 
 static const char *TAG = "esp_schedule_nvs";
 
 #define ESP_SCHEDULE_NVS_NAMESPACE "schd"
-#define ESP_SCHEDULE_COUNT_KEY "schd_count"
+
+/* Written by releases up to v1.4.x to track how many schedules were stored.
+ * No longer maintained: the count is now derived by walking the namespace,
+ * which cannot drift from reality and removes the underflow the old decrement
+ * had. The key is still recognised here so a device upgrading from an older
+ * build does not mistake the leftover value for a schedule. */
+#define ESP_SCHEDULE_LEGACY_COUNT_KEY "schd_count"
 
 static char *esp_schedule_nvs_partition = NULL;
 static bool nvs_enabled = false;
 
+#define NVS_OPS() (&g_esp_schedule_port.nvs)
+
+static bool esp_schedule_nvs_is_reserved_key(const char *key)
+{
+    return strcmp(key, ESP_SCHEDULE_LEGACY_COUNT_KEY) == 0;
+}
+
 esp_err_t esp_schedule_nvs_add(esp_schedule_t *schedule)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not adding to NVS.");
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not adding to NVS.");
         return ESP_ERR_INVALID_STATE;
     }
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    esp_schedule_store_handle_t handle;
+    esp_err_t err = NVS_OPS()->open(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, false, &handle);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
         return err;
     }
 
-    /* Check if this is new schedule or editing an existing schedule */
-    size_t buf_size;
-    bool editing_schedule = true;
-    err = nvs_get_blob(nvs_handle, schedule->name, NULL, &buf_size);
-    if (err != ESP_OK) {
-        if (err == ESP_ERR_NVS_NOT_FOUND) {
-            editing_schedule = false;
-        } else {
-            ESP_LOGE(TAG, "NVS get failed with error %d", err);
-            nvs_close(nvs_handle);
-            return err;
-        }
-    } else {
-        ESP_LOGI(TAG, "Updating the existing schedule %s", schedule->name);
-    }
+    /* The in-memory timer handle means nothing in the next boot, and storing a
+     * live pointer would leave the restored schedule referencing freed memory.
+     * Persist the struct with that one field cleared.
+     *
+     * Write from a copy rather than clearing the field on the live object for
+     * the duration of the write. A timer expiring inside that window reaches
+     * esp_schedule_arm_timer() -> timer.start(&schedule->timer, ...), which
+     * would see the NULL handle, take the create branch and install a second
+     * timer - then be overwritten when the field was restored, leaking that
+     * timer and leaving two of them dispatching the same schedule.
+     *
+     * priv_data goes the same way, and for the same reason as timer: it is the
+     * caller's pointer into this boot's heap, meaningless in the next one, and
+     * esp_schedule_get() hands it straight back to the application. Keeping it
+     * out of flash means a restored schedule cannot carry a wild pointer. */
+    esp_schedule_t stored = *schedule;
+    stored.timer = NULL;
+    stored.priv_data = NULL;
+    err = NVS_OPS()->write(handle, schedule->name, &stored, sizeof(stored));
 
-    err = nvs_set_blob(nvs_handle, schedule->name, schedule, sizeof(esp_schedule_t));
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS set failed with error %d", err);
-        nvs_close(nvs_handle);
+        ESP_SCHEDULE_LOGE(TAG, "NVS write failed with error %d", err);
+        NVS_OPS()->close(handle);
         return err;
     }
-    if (editing_schedule == false) {
-        uint8_t schedule_count;
-        err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
-        if (err != ESP_OK) {
-            if (err == ESP_ERR_NVS_NOT_FOUND) {
-                schedule_count = 0;
-            } else {
-                ESP_LOGE(TAG, "NVS get failed with error %d", err);
-                nvs_close(nvs_handle);
-                return err;
-            }
-        }
-        schedule_count++;
-        err = nvs_set_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, schedule_count);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "NVS set failed for schedule count with error %d", err);
-            nvs_close(nvs_handle);
-            return err;
-        }
-    }
-    nvs_commit(nvs_handle);
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "Schedule %s added in NVS", schedule->name);
+    NVS_OPS()->close(handle);
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s added in NVS", schedule->name);
     return ESP_OK;
 }
 
 esp_err_t esp_schedule_nvs_remove_all(void)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
         return ESP_ERR_INVALID_STATE;
     }
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    esp_schedule_store_handle_t handle;
+    esp_err_t err = NVS_OPS()->open(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, false, &handle);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
         return err;
     }
-    err = nvs_erase_all(nvs_handle);
+    err = NVS_OPS()->erase(handle, NULL);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS erase all keys failed with error %d", err);
-        nvs_close(nvs_handle);
+        ESP_SCHEDULE_LOGE(TAG, "NVS erase all keys failed with error %d", err);
+        NVS_OPS()->close(handle);
         return err;
     }
-    nvs_commit(nvs_handle);
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "All schedules removed from NVS");
+    NVS_OPS()->close(handle);
+    ESP_SCHEDULE_LOGI(TAG, "All schedules removed from NVS");
     return ESP_OK;
 }
 
 esp_err_t esp_schedule_nvs_remove(esp_schedule_t *schedule)
 {
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not removing from NVS.");
         return ESP_ERR_INVALID_STATE;
     }
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    esp_schedule_store_handle_t handle;
+    esp_err_t err = NVS_OPS()->open(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, false, &handle);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
         return err;
     }
-    err = nvs_erase_key(nvs_handle, schedule->name);
+    err = NVS_OPS()->erase(handle, schedule->name);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS erase key failed with error %d", err);
-        nvs_close(nvs_handle);
+        ESP_SCHEDULE_LOGE(TAG, "NVS erase key failed with error %d", err);
+        NVS_OPS()->close(handle);
         return err;
     }
-    uint8_t schedule_count;
-    err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS get failed for schedule count with error %d", err);
-        nvs_close(nvs_handle);
-        return err;
-    }
-    schedule_count--;
-    err = nvs_set_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, schedule_count);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS set failed for schedule count with error %d", err);
-        nvs_close(nvs_handle);
-        return err;
-    }
-    nvs_commit(nvs_handle);
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "Schedule %s removed from NVS", schedule->name);
+    NVS_OPS()->close(handle);
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s removed from NVS", schedule->name);
     return ESP_OK;
 }
 
-static uint8_t esp_schedule_nvs_get_count(void)
+/* Reads one stored schedule into a freshly allocated handle. */
+static esp_schedule_handle_t esp_schedule_nvs_read_one(esp_schedule_store_handle_t handle, const char *key)
 {
-    if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not getting count from NVS.");
-        return 0;
-    }
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READONLY, &nvs_handle);
+    size_t buf_size = 0;
+    esp_err_t err = NVS_OPS()->read(handle, key, NULL, &buf_size);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
-        return 0;
+        ESP_SCHEDULE_LOGE(TAG, "NVS read of %s failed with error %d", key, err);
+        return NULL;
     }
-    uint8_t schedule_count;
-    err = nvs_get_u8(nvs_handle, ESP_SCHEDULE_COUNT_KEY, &schedule_count);
+    /* Reject anything that is not exactly one esp_schedule_t. The blob is cast
+     * straight to the struct, so a size written by a different build - a
+     * changed Kconfig, another component version - would otherwise be misparsed
+     * field for field with no diagnostic at all. */
+    if (buf_size != sizeof(esp_schedule_t)) {
+        ESP_SCHEDULE_LOGE(TAG, "Stored schedule %s is %u bytes, expected %u; ignoring it",
+                          key, (unsigned)buf_size, (unsigned)sizeof(esp_schedule_t));
+        return NULL;
+    }
+    esp_schedule_t *schedule = (esp_schedule_t *)ESP_SCHEDULE_MALLOC(buf_size);
+    if (schedule == NULL) {
+        ESP_SCHEDULE_LOGE(TAG, "Could not allocate handle");
+        return NULL;
+    }
+    err = NVS_OPS()->read(handle, key, schedule, &buf_size);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS get failed for schedule count with error %d", err);
-        nvs_close(nvs_handle);
-        return 0;
+        ESP_SCHEDULE_LOGE(TAG, "NVS read of %s failed with error %d", key, err);
+        ESP_SCHEDULE_FREE(schedule);
+        return NULL;
     }
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "Schedules in NVS: %d", schedule_count);
-    return schedule_count;
+    /* Defensive: blobs written before the store began clearing these fields
+     * carry pointers from a previous boot. Clearing on the write side only
+     * protects blobs written after the upgrade; anything already in flash still
+     * has to be cleaned up here. priv_data matters most, since esp_schedule_get()
+     * hands it straight back to the application. */
+    schedule->timer = NULL;
+    schedule->priv_data = NULL;
+    ESP_SCHEDULE_LOGI(TAG, "Schedule %s found in NVS", schedule->name);
+    return (esp_schedule_handle_t)schedule;
 }
 
-static esp_schedule_handle_t esp_schedule_nvs_get(char *nvs_key)
+/* First pass over the namespace: how many schedules are actually stored. */
+static bool esp_schedule_nvs_count_cb(const char *key, void *ctx)
 {
-    if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not getting from NVS.");
-        return NULL;
+    if (!esp_schedule_nvs_is_reserved_key(key)) {
+        (*(uint8_t *)ctx)++;
     }
-    size_t buf_size;
-    nvs_handle_t nvs_handle;
-    esp_err_t err = nvs_open_from_partition(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_READONLY, &nvs_handle);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS open failed with error %d", err);
-        return NULL;
+    return true;
+}
+
+typedef struct {
+    esp_schedule_handle_t *list;
+    esp_schedule_store_handle_t store;
+    uint8_t capacity;
+    uint8_t count;
+} esp_schedule_nvs_load_ctx_t;
+
+/* Second pass: load each stored schedule into the array the first pass sized. */
+static bool esp_schedule_nvs_load_cb(const char *key, void *ctx)
+{
+    esp_schedule_nvs_load_ctx_t *load = (esp_schedule_nvs_load_ctx_t *)ctx;
+    if (esp_schedule_nvs_is_reserved_key(key)) {
+        return true;
     }
-    err = nvs_get_blob(nvs_handle, nvs_key, NULL, &buf_size);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS get failed with error %d", err);
-        nvs_close(nvs_handle);
-        return NULL;
+    /* The namespace could have grown between the two passes. Stop rather than
+     * write past the array. */
+    if (load->count >= load->capacity) {
+        ESP_SCHEDULE_LOGW(TAG, "More schedules in NVS than counted; ignoring the rest");
+        return false;
     }
-    esp_schedule_t *schedule = (esp_schedule_t *)malloc(buf_size);
-    if (schedule == NULL) {
-        ESP_LOGE(TAG, "Could not allocate handle");
-        nvs_close(nvs_handle);
-        return NULL;
+    ESP_SCHEDULE_LOGI(TAG, "Found schedule in NVS with key: %s", key);
+    esp_schedule_handle_t handle = esp_schedule_nvs_read_one(load->store, key);
+    if (handle != NULL) {
+        load->list[load->count++] = handle;
     }
-    err = nvs_get_blob(nvs_handle, nvs_key, schedule, &buf_size);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "NVS get failed with error %d", err);
-        nvs_close(nvs_handle);
-        free(schedule);
-        return NULL;
-    }
-    nvs_close(nvs_handle);
-    ESP_LOGI(TAG, "Schedule %s found in NVS", schedule->name);
-    return (esp_schedule_handle_t) schedule;
+    return true;
 }
 
 esp_schedule_handle_t *esp_schedule_nvs_get_all(uint8_t *schedule_count)
 {
+    *schedule_count = 0;
     if (!nvs_enabled) {
-        ESP_LOGD(TAG, "NVS not enabled. Not Initialising NVS.");
+        ESP_SCHEDULE_LOGD(TAG, "NVS not enabled. Not Initialising NVS.");
         return NULL;
     }
 
-    *schedule_count = esp_schedule_nvs_get_count();
-    if (*schedule_count == 0) {
-        ESP_LOGI(TAG, "No Entries found in NVS");
+    uint8_t stored = 0;
+    esp_err_t err = NVS_OPS()->foreach_key(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE,
+                                           esp_schedule_nvs_count_cb, &stored);
+    if (err != ESP_OK || stored == 0) {
+        ESP_SCHEDULE_LOGI(TAG, "No Entries found in NVS");
         return NULL;
     }
-    esp_schedule_handle_t *handle_list = (esp_schedule_handle_t *)malloc(sizeof(esp_schedule_handle_t) * (*schedule_count));
+
+    esp_schedule_handle_t *handle_list =
+        (esp_schedule_handle_t *)ESP_SCHEDULE_MALLOC(sizeof(esp_schedule_handle_t) * stored);
     if (handle_list == NULL) {
-        ESP_LOGE(TAG, "Could not allocate schedule list");
-        *schedule_count = 0;
+        ESP_SCHEDULE_LOGE(TAG, "Could not allocate schedule list");
         return NULL;
     }
-    int handle_count = 0;
 
-    nvs_entry_info_t nvs_entry;
-    nvs_iterator_t nvs_iterator = NULL;
-    esp_err_t err = nvs_entry_find(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, NVS_TYPE_BLOB, &nvs_iterator);
+    esp_schedule_nvs_load_ctx_t load = { .list = handle_list, .capacity = stored, .count = 0 };
+    err = NVS_OPS()->open(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE, true, &load.store);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "No entry found in NVS");
-        free(handle_list);
+        ESP_SCHEDULE_LOGE(TAG, "NVS open failed with error %d", err);
+        ESP_SCHEDULE_FREE(handle_list);
         return NULL;
     }
-    while (err == ESP_OK) {
-        nvs_entry_info(nvs_iterator, &nvs_entry);
-        ESP_LOGI(TAG, "Found schedule in NVS with key: %s", nvs_entry.key);
-        handle_list[handle_count] = esp_schedule_nvs_get(nvs_entry.key);
-        if (handle_list[handle_count] != NULL) {
-            /* Increase count only if nvs_get was successful */
-            handle_count++;
-        }
-        err = nvs_entry_next(&nvs_iterator);
+    err = NVS_OPS()->foreach_key(esp_schedule_nvs_partition, ESP_SCHEDULE_NVS_NAMESPACE,
+                                 esp_schedule_nvs_load_cb, &load);
+    NVS_OPS()->close(load.store);
+
+    if (err != ESP_OK || load.count == 0) {
+        ESP_SCHEDULE_FREE(handle_list);
+        return NULL;
     }
-    nvs_release_iterator(nvs_iterator);
-    *schedule_count = handle_count;
-    ESP_LOGI(TAG, "Found %d schedules in NVS", *schedule_count);
+    *schedule_count = load.count;
+    ESP_SCHEDULE_LOGI(TAG, "Found %d schedules in NVS", *schedule_count);
     return handle_list;
 }
 
@@ -262,18 +254,26 @@ bool esp_schedule_nvs_is_enabled(void)
 esp_err_t esp_schedule_nvs_init(char *nvs_partition)
 {
     if (nvs_enabled) {
-        ESP_LOGI(TAG, "NVS already enabled");
+        ESP_SCHEDULE_LOGI(TAG, "NVS already enabled");
         return ESP_OK;
     }
-    if (nvs_partition) {
-        esp_schedule_nvs_partition = strndup(nvs_partition, strlen(nvs_partition));
-    } else {
-        esp_schedule_nvs_partition = strndup("nvs", strlen("nvs"));
+    /* The port may legitimately supply no storage, in which case persistence is
+     * unavailable no matter what the caller asked for. esp_schedule_port_install()
+     * has already checked that the storage operations are either all present or
+     * all absent, so testing one of them is enough. */
+    if (NVS_OPS()->open == NULL) {
+        ESP_SCHEDULE_LOGW(TAG, "Port supplies no storage; schedules will not persist");
+        return ESP_ERR_NOT_SUPPORTED;
     }
+    /* Copied through the port allocator so every allocation stays on one heap. */
+    const char *partition = nvs_partition ? nvs_partition : "nvs";
+    size_t partition_len = strlen(partition);
+    esp_schedule_nvs_partition = (char *)ESP_SCHEDULE_MALLOC(partition_len + 1);
     if (esp_schedule_nvs_partition == NULL) {
-        ESP_LOGE(TAG, "Could not allocate nvs_partition");
+        ESP_SCHEDULE_LOGE(TAG, "Could not allocate nvs_partition");
         return ESP_ERR_NO_MEM;
     }
+    memcpy(esp_schedule_nvs_partition, partition, partition_len + 1);
     nvs_enabled = true;
     return ESP_OK;
 }

--- a/esp_schedule/src/esp_schedule_port.c
+++ b/esp_schedule/src/esp_schedule_port.c
@@ -1,0 +1,142 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file esp_schedule_port.c
+ * @brief Holds the installed port and validates it at install time.
+ *
+ * @note Nothing here may reference the ESP-IDF implementations in port/esp/.
+ *       They are reachable only from esp_schedule_init() in
+ *       src/esp_schedule_default.c, which is what keeps them out of the link
+ *       for anyone who only calls esp_schedule_init_with_config(). See the
+ *       comment at the top of that file.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include "esp_schedule_internal.h"
+
+static const char *TAG = "esp_schedule_port";
+
+esp_schedule_port_config_t g_esp_schedule_port;
+
+static bool s_port_installed = false;
+
+bool esp_schedule_is_inited(void)
+{
+    return s_port_installed;
+}
+
+/* Field-wise rather than memcmp: the struct has padding whose contents are
+ * unspecified even for a designated initializer, so a byte comparison of two
+ * logically identical configs can differ. */
+static bool esp_schedule_port_equal(const esp_schedule_port_config_t *a,
+                                    const esp_schedule_port_config_t *b)
+{
+    return a->timer.start == b->timer.start
+           && a->timer.stop == b->timer.stop
+           && a->timer.cancel == b->timer.cancel
+           && a->nvs.open == b->nvs.open
+           && a->nvs.close == b->nvs.close
+           && a->nvs.read == b->nvs.read
+           && a->nvs.write == b->nvs.write
+           && a->nvs.erase == b->nvs.erase
+           && a->nvs.foreach_key == b->nvs.foreach_key
+           && a->time_sync.get_time == b->time_sync.get_time
+           && a->time_sync.timesync_init == b->time_sync.timesync_init
+           && a->mem.malloc == b->mem.malloc
+           && a->mem.calloc == b->mem.calloc
+           && a->mem.free == b->mem.free
+           && a->log == b->log;
+}
+
+esp_err_t esp_schedule_port_install(const esp_schedule_port_config_t *port)
+{
+    if (port == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (s_port_installed) {
+        /* Re-initialising with the very same port is a no-op, so that calling
+         * esp_schedule_init() more than once stays harmless. Swapping in a
+         * different one is not: the table is read without locking everywhere
+         * else precisely because it never changes after init, and schedules
+         * already allocated hold timers from the old port. */
+        if (esp_schedule_port_equal(&g_esp_schedule_port, port)) {
+            return ESP_OK;
+        }
+        ESP_SCHEDULE_LOGE(TAG, "A different port is already installed; cannot replace it");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Validate once here so that no call site has to NULL-check. The log
+     * operation is deliberately not required: a NULL log is a silent build.
+     * It is also installed before the validation failures below are reported,
+     * so those reports are not lost. */
+    g_esp_schedule_port.log = port->log;
+
+    if (port->timer.start == NULL || port->timer.stop == NULL || port->timer.cancel == NULL) {
+        ESP_SCHEDULE_LOGE(TAG, "Port is missing one or more timer operations");
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (port->time_sync.get_time == NULL) {
+        ESP_SCHEDULE_LOGE(TAG, "Port is missing time_sync.get_time");
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (port->mem.malloc == NULL || port->mem.calloc == NULL || port->mem.free == NULL) {
+        ESP_SCHEDULE_LOGE(TAG, "Port is missing one or more memory operations");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Storage is optional, but it is all-or-nothing: a partially filled table
+     * would fail at some unpredictable later point instead of here. */
+    const esp_schedule_nvs_ops_t *nvs = &port->nvs;
+    int nvs_set = (nvs->open != NULL) + (nvs->close != NULL) + (nvs->read != NULL)
+                  + (nvs->write != NULL) + (nvs->erase != NULL) + (nvs->foreach_key != NULL);
+    if (nvs_set != 0 && nvs_set != 6) {
+        ESP_SCHEDULE_LOGE(TAG, "Port supplies an incomplete set of storage operations");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    g_esp_schedule_port = *port;
+    s_port_installed = true;
+    return ESP_OK;
+}
+
+/* Deliberately small: this frequently runs on the timer daemon's stack, so the
+ * buffer truncates rather than grows. Every call site in the component is
+ * written to fit, worst-case name length included - the longest expands to 152
+ * of the 159 usable bytes. A new message longer than that will be silently cut,
+ * so keep them within it rather than raising this. */
+#define ESP_SCHEDULE_LOG_BUF_LEN 160
+
+void esp_schedule_log(esp_schedule_log_level_t level, const char *tag, const char *format, ...)
+{
+    esp_schedule_log_fn_t log = g_esp_schedule_port.log;
+    if (log == NULL) {
+        return;
+    }
+    /* Format here rather than handing the va_list to the port. Ownership of a
+     * va_list is easy to get wrong across an interface boundary - an
+     * implementation that called va_end() on it would double-end this one,
+     * which is undefined - and doing it here also spares every port a varargs
+     * printf. vsnprintf always NUL-terminates within the buffer. */
+    char message[ESP_SCHEDULE_LOG_BUF_LEN];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(message, sizeof(message), format, args);
+    /* clang-analyzer-valist.Uninitialized reports this va_end() as operating on
+     * a list that was never started. It is a checker regression in clang 21
+     * (what CI runs), not a defect here: the emitted path goes straight from the
+     * `log == NULL` branch above to this line without ever modelling the
+     * va_start() two lines up, and clang 19 does not report it. The pairing is
+     * unconditional and immediate, with only vsnprintf() - which consumes but
+     * does not end the list - in between. */
+    // NOLINTNEXTLINE(clang-analyzer-valist.Uninitialized)
+    va_end(args);
+
+    log(level, tag, message);
+}

--- a/esp_schedule/test_app/main/CMakeLists.txt
+++ b/esp_schedule/test_app/main/CMakeLists.txt
@@ -1,9 +1,11 @@
-# The tests exercise the component's internal helpers (esp_schedule_internal.h),
-# so the component's private src/ directory is added to the include path. The
-# esp_schedule dependency itself is pulled in via main/idf_component.yml.
+include(${CMAKE_CURRENT_LIST_DIR}/../../esp_schedule_variables.cmake)
 set(_srcs "test_app_main.c" "test_esp_schedule.c")
+# The tests reach into esp_schedule_internal.h, so they need the component's own
+# private include dirs. The ESP-IDF port tables that test_app_main.c installs are
+# declared in esp_schedule_esp_port.h, which is public, so nothing extra is
+# needed for those.
 idf_component_register(SRCS ${_srcs}
-                    PRIV_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../src"
-                    PRIV_REQUIRES "esp_daylight" "unity" "nvs_flash" "esp_netif"
+                    PRIV_INCLUDE_DIRS ${ESP_SCHEDULE_PRIV_INCLUDE_DIRS}
+                    PRIV_REQUIRES ${ESP_SCHEDULE_PRIV_REQUIRES} "unity" "nvs_flash"
                     WHOLE_ARCHIVE
                     )

--- a/esp_schedule/test_app/main/test_app_main.c
+++ b/esp_schedule/test_app/main/test_app_main.c
@@ -5,10 +5,19 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "unity.h"
 #include "esp_err.h"
 #include "nvs_flash.h"
 #include "esp_schedule_internal.h"
+#include "esp_schedule_esp_port.h"
+
+/* See sdkconfig.defaults: the tests pin the clock, and this app installs a port
+ * with timesync_init NULL while tests call esp_schedule_init() themselves. Both
+ * tables must agree on that member or the second install is rejected. */
+#if CONFIG_ESP_SCHEDULE_ENABLE_SNTP
+#error "test_app requires CONFIG_ESP_SCHEDULE_ENABLE_SNTP=n - see sdkconfig.defaults"
+#endif
 
 // NVS initialization for tests
 static void init_nvs_for_tests(void)
@@ -22,12 +31,52 @@ static void init_nvs_for_tests(void)
     }
     ESP_ERROR_CHECK(err);
 
-    // Initialize NVS for schedules
-    esp_err_t nvs_init_result = esp_schedule_nvs_init("nvs");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(ESP_OK, nvs_init_result, "NVS initialization should succeed");
+    /* Install the ESP-IDF port. Everything in the component now reaches timers,
+     * storage, time, the heap and the log through it, so this has to happen
+     * before any other esp_schedule call - including the internal NVS helpers
+     * the tests use directly.
+     *
+     * Installed through esp_schedule_init_with_config() rather than
+     * esp_schedule_init() so that time sync can be left out. The tests pin the
+     * clock with settimeofday(); an SNTP sync completing mid-test would move it
+     * under them, which is latent flakiness on any DUT that has a network. Not
+     * starting SNTP also means no TCP/IP stack is needed here.
+     *
+     * This doubles as the in-tree exercise of the custom-port entry point: the
+     * same tables the default port installs, with one operation replaced.
+     *
+     * That replacement is only safe because SNTP is disabled for this app, which
+     * makes it a no-op. Several tests call esp_schedule_init() themselves, and
+     * esp_schedule_port_equal() compares timesync_init: if the default table
+     * carried a non-NULL one, the port installed here would differ from the one
+     * those calls build, the second install would be rejected with
+     * ESP_ERR_INVALID_STATE, and esp_schedule_init() would return NULL without
+     * restoring anything from NVS. The tests that depend on that restore would
+     * fail, and the ones that only assert NULL would pass for the wrong reason.
+     * Hence the guard above rather than a comment. */
+    esp_schedule_port_config_t port = {
+        .timer = esp_schedule_esp_timer_ops,
+        .nvs = esp_schedule_esp_nvs_ops,
+        .time_sync = esp_schedule_esp_time_sync_ops,
+        .mem = esp_schedule_esp_mem_ops,
+        .log = esp_schedule_esp_log,
+    };
+    port.time_sync.timesync_init = NULL;
+
+    uint8_t restored = 0;
+    esp_schedule_handle_t *handles = esp_schedule_init_with_config(&port, true, "nvs", &restored);
 
     // Check if NVS is enabled
     TEST_ASSERT_TRUE_MESSAGE(esp_schedule_nvs_is_enabled(), "NVS should be enabled");
+
+    /* Start every run from an empty namespace, whatever a previous run left
+     * behind, so per-test count assertions are exact. */
+    for (uint8_t i = 0; i < restored; i++) {
+        esp_schedule_delete(handles[i]);
+    }
+    /* The array came from port.mem.malloc, so it goes back the same way. */
+    ESP_SCHEDULE_FREE(handles);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(ESP_OK, esp_schedule_nvs_remove_all(), "NVS reset should succeed");
 }
 
 void app_main(void)

--- a/esp_schedule/test_app/main/test_esp_schedule.c
+++ b/esp_schedule/test_app/main/test_esp_schedule.c
@@ -10,8 +10,10 @@
 #include <stdlib.h>
 #include <sys/time.h>
 #include "esp_err.h"
-#include "esp_netif.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/timers.h"
 #include "unity.h"
 #include "esp_schedule_internal.h"
 #if CONFIG_ESP_SCHEDULE_ENABLE_DAYLIGHT
@@ -703,10 +705,6 @@ TEST_CASE("solar variants", "[esp_schedule]")
 /* --- esp_schedule_init must not dereference a NULL schedule_count --- */
 TEST_CASE("init null schedule_count", "[esp_schedule]")
 {
-    /* esp_schedule_init() runs timesync (SNTP), which needs the TCP/IP stack up.
-     * On a device this is already initialized; bring it up here for the test. */
-    esp_netif_init();
-
     /* NVS-off path used to write *schedule_count unconditionally. */
     esp_schedule_handle_t *h = esp_schedule_init(false, NULL, NULL);
     TEST_ASSERT_NULL_MESSAGE(h, "init(false, NULL, NULL) should return NULL and not crash");
@@ -1545,7 +1543,6 @@ TEST_CASE("dst rainmaker fall back fires once", "[esp_schedule]")
  * combinations that are now rejected. --- */
 TEST_CASE("nvs restore drops invalid config", "[esp_schedule]")
 {
-    esp_netif_init(); /* esp_schedule_init() runs SNTP, which needs the TCP/IP stack */
     /* app_main() already brought up NVS for this test app. Start from an empty
      * schedule namespace so the count assertions below are exact. */
     TEST_ASSERT_EQUAL(ESP_OK, esp_schedule_nvs_remove_all());
@@ -1566,13 +1563,164 @@ TEST_CASE("nvs restore drops invalid config", "[esp_schedule]")
     uint8_t count = 0xFF;
     esp_schedule_handle_t *handle_list = esp_schedule_init(true, NULL, &count);
     TEST_ASSERT_EQUAL_MESSAGE(0, count, "invalid stored config must not be armed");
-    free(handle_list);
+    ESP_SCHEDULE_FREE(handle_list);
 
     /* It was also removed from NVS, so it cannot come back on the next boot. */
     count = 0xFF;
     handle_list = esp_schedule_nvs_get_all(&count);
     TEST_ASSERT_EQUAL_MESSAGE(0, count, "invalid stored config must be deleted from NVS");
-    free(handle_list);
+    ESP_SCHEDULE_FREE(handle_list);
+}
+
+/* --- a repeating schedule must re-arm from its own callback without deadlocking
+ * the FreeRTOS timer daemon ---
+ *
+ * Regression: the timer glue serializes the timer callback against cancel() with
+ * a mutex held across the whole callback body. Re-arming a repeating schedule
+ * runs inside that callback (in the timer daemon task) via trigger_cb ->
+ * esp_schedule_start_timer -> esp_schedule_arm_timer. If arm tore the timer down
+ * and recreated it, timer_cancel() would re-take that mutex on the task that
+ * already holds it; with a non-recursive mutex the daemon deadlocks against
+ * itself on the first fire, freezing EVERY software timer in the system.
+ * esp_schedule_timer_start() instead rebinds an existing timer in place, and the
+ * mutex is recursive so the re-entrant paths cannot deadlock either way.
+ *
+ * Detection: fire the schedule once, then confirm the daemon is still alive by
+ * checking that an INDEPENDENT software timer, armed to expire AFTER the re-arm,
+ * actually runs. Under the deadlock the daemon is stuck inside the schedule's
+ * callback and the canary never fires. (Checking next_scheduled_time_utc would
+ * NOT catch the bug: start_timer updates it before the deadlocking arm call.) */
+static volatile uint32_t s_rearm_fire_count = 0;
+static void rearm_trigger_cb(esp_schedule_handle_t handle, void *priv_data)
+{
+    (void)handle;
+    (void)priv_data;
+    s_rearm_fire_count++;
+}
+
+static volatile bool s_canary_fired = false;
+static void canary_timer_cb(TimerHandle_t t)
+{
+    (void)t;
+    s_canary_fired = true;
+}
+
+TEST_CASE("repeating schedule re-arms without deadlock", "[esp_schedule]")
+{
+    /* Pin the clock ~2s before a daily 12:00 slot so the first fire is quick.
+     * The engine works in local time; the default device TZ is UTC so a
+     * make_time_local() instant matches the UTC epoch fed to settimeofday(). */
+    time_t slot = make_time_local(2025, 6, 16, 12, 0, 0);
+    struct timeval saved = {0};
+    gettimeofday(&saved, NULL);
+    struct timeval tv = { .tv_sec = slot - 2, .tv_usec = 0 };
+    settimeofday(&tv, NULL);
+
+    esp_schedule_config_t config = {0};
+    strcpy(config.name, "rearm");
+    config.trigger.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+    config.trigger.hours = 12;
+    config.trigger.minutes = 0;
+    config.trigger.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+    config.validity.end_time = 2147483647;
+    config.trigger_cb = rearm_trigger_cb;
+
+    esp_schedule_handle_t handle = esp_schedule_create(&config);
+    TEST_ASSERT_NOT_NULL(handle);
+
+    s_rearm_fire_count = 0;
+    s_canary_fired = false;
+
+    /* Canary: an independent one-shot timer that expires ~1.5s AFTER the
+     * schedule fires (and re-arms). It shares the one timer daemon task, so it
+     * can only fire if that task did not deadlock. Ticks are wall-clock
+     * independent, so the pinned time does not affect it. */
+    TimerHandle_t canary = xTimerCreate("canary", pdMS_TO_TICKS(3500), pdFALSE, NULL, canary_timer_cb);
+    TEST_ASSERT_NOT_NULL_MESSAGE(canary, "failed to create canary timer");
+    TEST_ASSERT_EQUAL_MESSAGE(pdPASS, xTimerStart(canary, portMAX_DELAY), "failed to start canary timer");
+
+    TEST_ASSERT_EQUAL_INT(ESP_OK, (int)esp_schedule_enable(handle));
+
+    esp_schedule_t *sched = (esp_schedule_t *)handle;
+    TEST_ASSERT_TRUE_MESSAGE(sched->trigger.next_scheduled_time_utc == slot, "armed for the 2s-away slot");
+
+    /* vTaskDelay is driven by the tick ISR, not the timer daemon, so it returns
+     * even if the daemon has deadlocked. */
+    vTaskDelay(pdMS_TO_TICKS(6000));
+
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, s_rearm_fire_count, "repeating trigger must have fired exactly once");
+    TEST_ASSERT_TRUE_MESSAGE(s_canary_fired,
+                             "timer daemon must survive the re-arm (canary fired) -> no deadlock");
+    /* Fixed path also re-arms for the next occurrence (next day). */
+    TEST_ASSERT_TRUE_MESSAGE(sched->trigger.next_scheduled_time_utc >= slot + 23 * 3600,
+                             "schedule must have re-armed for the next day");
+
+    xTimerDelete(canary, portMAX_DELAY);
+    esp_schedule_delete(handle);
+    /* Restore the clock this test pinned, so a later test that reads it is not
+     * silently running in June 2025. */
+    settimeofday(&saved, NULL);
+}
+
+/* --- a schedule must survive deleting itself from its own trigger callback ---
+ *
+ * Same daemon-freeze failure mode as above, reached the other way: trigger_cb ->
+ * esp_schedule_delete -> esp_schedule_delete_timer -> esp_schedule_timer_cancel,
+ * which takes the callback mutex the daemon already holds. cancel() had no
+ * daemon-task guard at all, so a non-recursive mutex blocked the daemon forever.
+ *
+ * The free is deferred to esp_schedule_common_timer_cb for the same reason: the
+ * callback still holds the schedule on its stack and would otherwise re-arm a
+ * freed allocation.
+ *
+ * Detection: the same independent-canary trick. A hang shows up as the canary
+ * never firing; a use-after-free shows up as a heap corruption abort. */
+static volatile uint32_t s_selfdel_fire_count = 0;
+static void selfdel_trigger_cb(esp_schedule_handle_t handle, void *priv_data)
+{
+    (void)priv_data;
+    s_selfdel_fire_count++;
+    TEST_ASSERT_EQUAL_INT(ESP_OK, (int)esp_schedule_delete(handle));
+}
+
+TEST_CASE("schedule deletes itself from its callback without deadlock", "[esp_schedule]")
+{
+    time_t slot = make_time_local(2025, 6, 16, 12, 0, 0);
+    struct timeval saved = {0};
+    gettimeofday(&saved, NULL);
+    struct timeval tv = { .tv_sec = slot - 2, .tv_usec = 0 };
+    settimeofday(&tv, NULL);
+
+    esp_schedule_config_t config = {0};
+    strcpy(config.name, "selfdel");
+    config.trigger.type = ESP_SCHEDULE_TYPE_DAYS_OF_WEEK;
+    config.trigger.hours = 12;
+    config.trigger.minutes = 0;
+    config.trigger.day.repeat_days = ESP_SCHEDULE_DAY_EVERYDAY;
+    config.validity.end_time = 2147483647;
+    config.trigger_cb = selfdel_trigger_cb;
+
+    esp_schedule_handle_t handle = esp_schedule_create(&config);
+    TEST_ASSERT_NOT_NULL(handle);
+
+    s_selfdel_fire_count = 0;
+    s_canary_fired = false;
+
+    TimerHandle_t canary = xTimerCreate("canary", pdMS_TO_TICKS(3500), pdFALSE, NULL, canary_timer_cb);
+    TEST_ASSERT_NOT_NULL_MESSAGE(canary, "failed to create canary timer");
+    TEST_ASSERT_EQUAL_MESSAGE(pdPASS, xTimerStart(canary, portMAX_DELAY), "failed to start canary timer");
+
+    TEST_ASSERT_EQUAL_INT(ESP_OK, (int)esp_schedule_enable(handle));
+
+    vTaskDelay(pdMS_TO_TICKS(6000));
+
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(1, s_selfdel_fire_count, "trigger must have fired exactly once");
+    TEST_ASSERT_TRUE_MESSAGE(s_canary_fired,
+                             "timer daemon must survive the self-delete (canary fired) -> no deadlock");
+
+    xTimerDelete(canary, portMAX_DELAY);
+    /* handle is already deleted; deleting again would be a double free. */
+    settimeofday(&saved, NULL);
 }
 
 /* Unity runs setUp()/tearDown() before/after every TEST_CASE. tearDown()

--- a/esp_schedule/test_app/sdkconfig.defaults
+++ b/esp_schedule/test_app/sdkconfig.defaults
@@ -1,2 +1,26 @@
 # Disable watchdog
 CONFIG_ESP_TASK_WDT_INIT=n
+
+# A schedule re-arms from inside its own timer callback, which runs on the
+# FreeRTOS timer daemon task. That path formats the next fire time (strftime,
+# localtime_r) and runs the date engine, which does not fit in the 2048-byte
+# default on every IDF version.
+CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=3072
+
+# Required, not merely preferred. Most tests pin the clock with settimeofday(),
+# so an SNTP sync completing mid-test would move time under them.
+#
+# It also has to be off for the ports to match. test_app_main.c installs the
+# port through esp_schedule_init_with_config() with timesync_init NULL, while
+# the esp_schedule_init() calls inside the tests build the default table. With
+# SNTP enabled those two tables differ in exactly that member,
+# esp_schedule_port_equal() rejects the second install, and every in-test
+# esp_schedule_init() returns NULL instead of restoring from NVS - which fails
+# "nvs restore drops invalid config" and makes "init null schedule_count" pass
+# for the wrong reason. With SNTP off the default table carries a NULL
+# timesync_init itself, so both tables are identical and the second install is
+# the intended same-port no-op.
+#
+# test_app_main.c has a #error guarding this, so the coupling cannot break
+# silently.
+CONFIG_ESP_SCHEDULE_ENABLE_SNTP=n


### PR DESCRIPTION
# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [x] _Optional:_ Component contains unit tests
- [x] CI passing

# Change description
Platform access - timer, storage, time, memory, log - now goes through function-pointer tables installed at init instead of substituted headers. esp_schedule_init() installs the ESP-IDF ones; esp_schedule_init_with_config() takes your own, and because esp_schedule_init() is the only referrer of the defaults, they never reach the link.

Replaces #790. Also closes #733 