### PR TITLE
docs(spi_nand_flash_fatfs): add NAND FAT integration guide to example…

### DIFF
--- a/spi_nand_flash/README.md
+++ b/spi_nand_flash/README.md
@@ -77,13 +77,26 @@ At present, `spi_nand_flash` component is compatible with the chips produced by 
 
 **GigaDevice voltage classes:** Parts ending in **UExxG** are rated for 2.7–3.6 V and are suitable for typical ESP32 3.3 V SPI designs. Parts ending in **RExxG** are rated for 1.7–2.0 V and are not recommended for direct connection to 3.3 V ESP GPIO/SPI without level shifting and a 1.8 V supply. Some `RExx` variants remain in the driver from earlier releases for backward compatibility; new additions target the 3.3 V `UExx` parts only (for example, **GD5F4GM7UExxG**, not GD5F4GM7RExxG).
 
+## Driver configuration
+
+Before calling **`spi_nand_flash_init_device()`** (legacy) or **`spi_nand_flash_init_with_layers()`** (BDL), initialize the ESP-IDF SPI bus (`spi_bus_initialize()`, `spi_bus_add_device()`) and pass the resulting `spi_device_handle_t` in **`spi_nand_flash_config_t`** (same struct for both init APIs):
+
+| Field | Description |
+|-------|-------------|
+| `device_handle` | `spi_device_handle_t` from `spi_bus_add_device()` |
+| `io_mode` | `SPI_NAND_IO_MODE_SIO`, `DIO`, `DOUT`, `QIO`, or `QOUT` |
+| `flags` | `SPI_DEVICE_HALFDUPLEX` for half-duplex (required for DIO/DOUT/QIO/QOUT); `0` for full-duplex SIO. This value has to match the half-duplex flag in `spi_device_interface_config_t.flags` |
+| `gc_factor` | Optional wear-leveling GC tuning; `0` uses the driver default |
+
+See `spi_nand_flash_config_t` in [`include/spi_nand_flash.h`](include/spi_nand_flash.h). End-to-end SPI + config setup is shown in the FatFS example READMEs below.
+
 ## FATFS Integration
 
 Use the separate [`spi_nand_flash_fatfs`](../spi_nand_flash_fatfs) component for filesystem examples and helpers:
 
-1. **Legacy mode (ESP-IDF 5.0+, BDL off):** `spi_nand_flash_init_device()` and **`esp_vfs_fat_nand_mount()`** / **`esp_vfs_fat_nand_unmount()`** from `spi_nand_flash_fatfs` (this component’s diskio). See **`spi_nand_flash_fatfs/examples/nand_flash`**.
+1. **Legacy mode (ESP-IDF 5.0+, BDL off):** `spi_nand_flash_init_device()` and **`esp_vfs_fat_nand_mount()`** / **`esp_vfs_fat_nand_unmount()`** from `spi_nand_flash_fatfs` (this component’s diskio). Integration guide: [`spi_nand_flash_fatfs/examples/nand_flash/README.md`](../spi_nand_flash_fatfs/examples/nand_flash/README.md).
 
-2. **BDL + FatFS (ESP-IDF 6.1+, `CONFIG_NAND_FLASH_ENABLE_BDL=y`):** `spi_nand_flash_init_with_layers()` and ESP-IDF’s **`esp_vfs_fat_bdl_mount()`** / **`esp_vfs_fat_bdl_unmount()`** (generic `diskio_bdl`; does not use `esp_vfs_fat_nand_*`). See **`spi_nand_flash_fatfs/examples/nand_flash_bdl`**.
+2. **BDL + FatFS (ESP-IDF 6.1+, `CONFIG_NAND_FLASH_ENABLE_BDL=y`):** `spi_nand_flash_init_with_layers()` and ESP-IDF’s **`esp_vfs_fat_bdl_mount()`** / **`esp_vfs_fat_bdl_unmount()`** (generic `diskio_bdl`; does not use `esp_vfs_fat_nand_*`). Integration guide: [`spi_nand_flash_fatfs/examples/nand_flash_bdl/README.md`](../spi_nand_flash_fatfs/examples/nand_flash_bdl/README.md).
 
 Details and Kconfig rules: [`spi_nand_flash_fatfs/README.md`](../spi_nand_flash_fatfs/README.md).
 

--- a/spi_nand_flash/layered_architecture.md
+++ b/spi_nand_flash/layered_architecture.md
@@ -628,12 +628,11 @@ FATFS support has been moved to a separate `spi_nand_flash_fatfs` component. If 
 uses FATFS with NAND flash:
 1. Add `spi_nand_flash_fatfs` as a dependency in your `idf_component.yml`.
 2. Include headers from `spi_nand_flash_fatfs` instead of the old unified headers.
-3. Use **`spi_nand_flash_init_device()`** and keep **`CONFIG_NAND_FLASH_ENABLE_BDL` disabled**.
-   When BDL is enabled, `spi_nand_flash_init_device()` returns `ESP_ERR_NOT_SUPPORTED`. **This release does not
-   provide FatFs on top of the wear-leveling BDL** (`esp_blockdev_t`); that will be added in a
-   future component update.
-4. Aside from the component split and the BDL constraint above, FatFs usage matches 0.x
-   (same mount helpers and diskio behavior).
+3. Choose **one** path:
+   - **Legacy (ESP-IDF 5.0+):** Use **`spi_nand_flash_init_device()`** with **`CONFIG_NAND_FLASH_ENABLE_BDL` disabled**, then **`esp_vfs_fat_nand_mount()`**. Example: **`spi_nand_flash_fatfs/examples/nand_flash`**.
+   - **BDL + FatFS (ESP-IDF 6.1+, added in `spi_nand_flash_fatfs` 1.1.0):** Enable **`CONFIG_NAND_FLASH_ENABLE_BDL=y`**, use **`spi_nand_flash_init_with_layers()`**, then ESP-IDF **`esp_vfs_fat_bdl_mount()`**. Optional pre-format: **`esp_vfs_fat_nand_bdl_format()`**. Example: **`spi_nand_flash_fatfs/examples/nand_flash_bdl`**.
+4. Aside from the component split and the path choice above, legacy FatFs usage matches 0.x
+   (same mount helpers and diskio behavior when BDL is off).
 
 ### For Existing Projects (Legacy API)
 
@@ -655,8 +654,9 @@ New projects are encouraged to use the Block Device Layer API, which provides:
   for most workloads prefer the **wear-leveling** BDL (Dhara FTL: wear leveling, bad-block
   management, logical sectors). Raw flash BDL is mainly for diagnostics, bring-up etc.
 - Advanced diagnostics operations (ECC stats, bad block tracking)
-- Integration with consumers of **`esp_blockdev_t`** (this release does **not** include
-  FatFs-on-BDL for SPI NAND; use **`spi_nand_flash_fatfs`** with BDL off for FatFs)
+- Integration with consumers of **`esp_blockdev_t`**, including FatFS via ESP-IDF
+  **`esp_vfs_fat_bdl_mount()`** on ESP-IDF 6.1+ (see **`spi_nand_flash_fatfs/examples/nand_flash_bdl`**).
+  Legacy FatFS (**`esp_vfs_fat_nand_*`**) still requires BDL off.
 - Fine-grained control over layers
 
 ### Enabling BDL Support

--- a/spi_nand_flash_fatfs/README.md
+++ b/spi_nand_flash_fatfs/README.md
@@ -19,37 +19,31 @@ Choose **one** integration path; they use different init APIs and Kconfig:
 
 ## Dependencies
 
-- `spi_nand_flash` component (driver)
+- `spi_nand_flash` component (driver; pulled in automatically)
 - ESP-IDF `fatfs` component
 - ESP-IDF `vfs` component
 
 ## Usage
 
+Pick **one** path from [Requirements](#requirements-read-first). Both need SPI bus setup and a filled **`spi_nand_flash_config_t`** before NAND init.
+
+**Full end-to-end guides** (dependency, CMake, headers, SPI init, config fields, mount, file I/O) live in the example READMEs — those are the canonical references:
+
 ### Legacy mode (`esp_vfs_fat_nand_*`)
 
-```c
-#include "spi_nand_flash.h"
-#include "esp_vfs_fat_nand.h"
-
-// CONFIG_NAND_FLASH_ENABLE_BDL must be off
-spi_nand_flash_device_t *nand_device;
-spi_nand_flash_init_device(&config, &nand_device);
-
-esp_vfs_fat_mount_config_t mount_config = {
-    .max_files = 4,
-    .format_if_mount_failed = true,
-};
-esp_vfs_fat_nand_mount("/nand", nand_device, &mount_config);
-
-FILE *f = fopen("/nand/test.txt", "w");
-// ...
-esp_vfs_fat_nand_unmount("/nand", nand_device);
-spi_nand_flash_deinit_device(nand_device);
-```
+- Mount helpers: **`esp_vfs_fat_nand_mount()`** / **`esp_vfs_fat_nand_unmount()`** in `esp_vfs_fat_nand.h`, on a handle from **`spi_nand_flash_init_device()`**
+- **`CONFIG_NAND_FLASH_ENABLE_BDL` must be off**
+- Integration guide: [`examples/nand_flash/README.md`](examples/nand_flash/README.md)
+- Source: [`examples/nand_flash/main/spi_nand_flash_example_main.c`](examples/nand_flash/main/spi_nand_flash_example_main.c)
 
 ### BDL mode (`esp_vfs_fat_bdl_*`)
 
-Use the wear-leveling block device from **`spi_nand_flash_init_with_layers()`** with **`esp_vfs_fat_bdl_mount()`**. To format unconditionally before mount (e.g. chosen **`allocation_unit_size`**), call **`esp_vfs_fat_nand_bdl_format()`** with the same **`esp_vfs_fat_mount_config_t`**, then mount. Details: **`examples/nand_flash_bdl/README.md`**.
+- Init: **`spi_nand_flash_init_with_layers()`** → wear-leveling **`esp_blockdev_t`**
+- Mount: ESP-IDF **`esp_vfs_fat_bdl_mount()`** / **`esp_vfs_fat_bdl_unmount()`**
+- Optional pre-format: **`esp_vfs_fat_nand_bdl_format()`** (this component) with the same **`esp_vfs_fat_mount_config_t`**
+- **`CONFIG_NAND_FLASH_ENABLE_BDL=y`**, ESP-IDF **6.1+**
+- Integration guide: [`examples/nand_flash_bdl/README.md`](examples/nand_flash_bdl/README.md)
+- Source: [`examples/nand_flash_bdl/main/spi_nand_flash_bdl_example_main.c`](examples/nand_flash_bdl/main/spi_nand_flash_bdl_example_main.c)
 
 ## Examples (this component)
 
@@ -61,4 +55,4 @@ All paths are under **`spi_nand_flash_fatfs/examples/`**:
 | `nand_flash_bdl` | BDL + `esp_vfs_fat_bdl_*` | **On** | 6.1+ |
 | `nand_flash_debug_app` | Diagnostics only (no VFS) | **Off** | 5.0+ |
 
-See each example’s `README.md` for wiring and menuconfig.
+See each example’s `README.md` for wiring, menuconfig, and **Use in your own project**.

--- a/spi_nand_flash_fatfs/examples/nand_flash/README.md
+++ b/spi_nand_flash_fatfs/examples/nand_flash/README.md
@@ -1,28 +1,114 @@
 | Supported Targets | ESP32 | ESP32-C2 | ESP32-C3 | ESP32-C6 | ESP32-H2 | ESP32-P4 | ESP32-S2 | ESP32-S3 |
 | ----------------- | ----- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
 
-# SPI NAND Flash Example
+# SPI NAND Flash Example (Legacy FatFS)
 
-This example demonstrates how to use the SPI NAND Flash driver with FAT filesystem in ESP-IDF.
+This example mounts FatFS on SPI NAND using the **legacy** path: **`spi_nand_flash_init_device()`** + **`esp_vfs_fat_nand_mount()`**. Keep **`CONFIG_NAND_FLASH_ENABLE_BDL` disabled**.
+
+For the **BDL + FatFS** path (ESP-IDF 6.1+, BDL on), see [`examples/nand_flash_bdl`](../nand_flash_bdl/README.md).
+
+Canonical source: [`main/spi_nand_flash_example_main.c`](main/spi_nand_flash_example_main.c).
+
+## Use in your own project
+
+### 1. Add the component dependency
+
+```bash
+idf.py add-dependency "espressif/spi_nand_flash_fatfs"
+```
+
+Or add to your project's `idf_component.yml`:
+
+```yaml
+dependencies:
+  espressif/spi_nand_flash_fatfs:
+    version: "*"
+```
+
+This also resolves `espressif/spi_nand_flash` transitively.
+
+### 2. Declare the component in CMake
+
+In your main component's `CMakeLists.txt`:
+
+```cmake
+idf_component_register(SRCS "main.c"
+                       INCLUDE_DIRS "."
+                       PRIV_REQUIRES spi_nand_flash_fatfs)
+```
+
+### 3. Required headers
+
+Match the includes in [`main/spi_nand_flash_example_main.c`](main/spi_nand_flash_example_main.c):
+
+```c
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_system.h"
+#include "soc/spi_pins.h"
+#include "esp_vfs_fat_nand.h"
+```
+
+`esp_vfs_fat_nand.h` pulls in `spi_nand_flash.h` and the SPI driver headers transitively.
+
+### 4. Initialization flow
+
+Follow the same order as `example_init_nand_flash()` in [`main/spi_nand_flash_example_main.c`](main/spi_nand_flash_example_main.c):
+
+1. **SPI bus** — `spi_bus_initialize()` with `spi_bus_config_t` (MOSI, MISO, CLK, WP, HD GPIOs).
+2. **SPI device** — `spi_bus_add_device()` with `spi_device_interface_config_t` (clock, CS, mode, `flags`).
+3. **NAND driver** — `spi_nand_flash_init_device()` with `spi_nand_flash_config_t`.
+4. **FAT mount** — `esp_vfs_fat_nand_mount()` with `esp_vfs_fat_mount_config_t`.
+5. **File I/O** — standard `fopen()` / `fprintf()` / `fgets()` on paths under the mount point (e.g. `/nandflash/hello.txt`).
+6. **Cleanup** — `esp_vfs_fat_nand_unmount()`, then `spi_nand_flash_deinit_device()`, `spi_bus_remove_device()`, `spi_bus_free()` (see `example_deinit_nand_flash()`).
+
+Default pin macros (`HOST_ID`, `PIN_MOSI`, etc.) are defined at the top of the example source. Adjust them for your board or use the tables in [Hardware Required](#hardware-required) below.
+
+### 5. `spi_nand_flash_config_t`
+
+Populated in `example_init_nand_flash()` before `spi_nand_flash_init_device()`:
+
+| Field | Description |
+|-------|-------------|
+| `device_handle` | `spi_device_handle_t` returned by `spi_bus_add_device()` |
+| `io_mode` | `SPI_NAND_IO_MODE_SIO` in this example; also `DIO`, `DOUT`, `QIO`, or `QOUT` |
+| `flags` | `SPI_DEVICE_HALFDUPLEX` for half-duplex (required for DIO/DOUT/QIO/QOUT); `0` for full-duplex SIO. This value has to match the half-duplex flag in `spi_device_interface_config_t.flags` |
+| `gc_factor` | Optional wear-leveling GC tuning; omit or set `0` for the driver default |
+
+Full struct documentation is in [`spi_nand_flash.h`](../../../spi_nand_flash/include/spi_nand_flash.h).
+
+### 6. Mount configuration
+
+```c
+esp_vfs_fat_mount_config_t config = {
+    .max_files = 4,
+    .format_if_mount_failed = false,  // or true to format on first mount failure
+    // Cluster size used when formatting. Must be a power of 2 between the
+    // NAND sector/page size and 128 * sector size. Larger values improve
+    // sequential throughput; smaller values waste less space for small files.
+    // 16 KiB matches this example (and common ESP-IDF FatFs samples);
+    // use 0 to default to one sector per cluster.
+    .allocation_unit_size = 16 * 1024,
+};
+esp_err_t ret = esp_vfs_fat_nand_mount("/nandflash", flash, &config);
+```
+
+In this example project, `format_if_mount_failed` is controlled by `CONFIG_EXAMPLE_FORMAT_IF_MOUNT_FAILED` in menuconfig.
+
+### 7. Prerequisites
+
+- Keep **`CONFIG_NAND_FLASH_ENABLE_BDL` disabled** (Component config → SPI NAND Flash). `spi_nand_flash_init_device()` returns `ESP_ERR_NOT_SUPPORTED` when BDL is enabled, and FatFs mount helpers require the legacy handle.
+- See also [`spi_nand_flash_fatfs` component README](../../README.md#requirements-read-first).
 
 ## Hardware Required
 
 * Any ESP board from the supported targets list above
-* An external SPI NAND Flash chip connected to the following pins:
-  * For ESP32 (SPI3):
-    - MOSI - SPI3_IOMUX_PIN_NUM_MOSI (23)
-    - MISO - SPI3_IOMUX_PIN_NUM_MISO (19)
-    - CLK  - SPI3_IOMUX_PIN_NUM_CLK (18)
-    - CS   - SPI3_IOMUX_PIN_NUM_CS (5)
-    - WP   - SPI3_IOMUX_PIN_NUM_WP (22)
-    - HD   - SPI3_IOMUX_PIN_NUM_HD (21)
-  * For other ESP chips (SPI2):
-    - MOSI - SPI2_IOMUX_PIN_NUM_MOSI (13)
-    - MISO - SPI2_IOMUX_PIN_NUM_MISO (12)
-    - CLK  - SPI2_IOMUX_PIN_NUM_CLK (14)
-    - CS   - SPI2_IOMUX_PIN_NUM_CS (15)
-    - WP   - SPI2_IOMUX_PIN_NUM_WP (2)
-    - HD   - SPI2_IOMUX_PIN_NUM_HD (4)
+* An external SPI NAND Flash chip connected to the SPI pins selected in the example source
+  ([`main/spi_nand_flash_example_main.c`](main/spi_nand_flash_example_main.c)):
+  * **ESP32:** SPI3 host with `SPI3_IOMUX_PIN_NUM_*` (IOMUX defaults: MOSI 23, MISO 19, CLK 18, CS 5, WP 22, HD 21)
+  * **Other targets:** SPI2 host with `SPI2_IOMUX_PIN_NUM_*` — GPIO numbers differ by chip (for example ESP32-S3 vs ESP32-C3 vs ESP32-P4). Prefer the macros in `soc/spi_pins.h`, or override the `PIN_*` defines for your board wiring.
 
 ## Configuration
 

--- a/spi_nand_flash_fatfs/examples/nand_flash_bdl/README.md
+++ b/spi_nand_flash_fatfs/examples/nand_flash_bdl/README.md
@@ -8,6 +8,110 @@ This example is like [examples/nand_flash](../nand_flash/README.md), but it moun
 - **`spi_nand_flash_init_with_layers()`** builds **Flash BDL → WL BDL** (Dhara wear leveling).
 - **`esp_vfs_fat_bdl_mount()`** / **`esp_vfs_fat_bdl_unmount()`** connect VFS + FatFS to that WL block device.
 
+Canonical source: [`main/spi_nand_flash_bdl_example_main.c`](main/spi_nand_flash_bdl_example_main.c).
+
+## Use in your own project
+
+### 1. Add the component dependency
+
+```bash
+idf.py add-dependency "espressif/spi_nand_flash_fatfs"
+```
+
+Or add to your project's `idf_component.yml`:
+
+```yaml
+dependencies:
+  espressif/spi_nand_flash_fatfs:
+    version: "*"
+```
+
+This also resolves `espressif/spi_nand_flash` transitively.
+
+### 2. Declare the component in CMake
+
+In your main component's `CMakeLists.txt`:
+
+```cmake
+idf_component_register(SRCS "main.c"
+                       INCLUDE_DIRS "."
+                       PRIV_REQUIRES spi_nand_flash_fatfs)
+```
+
+### 3. Required headers
+
+Match the includes in [`main/spi_nand_flash_bdl_example_main.c`](main/spi_nand_flash_bdl_example_main.c):
+
+```c
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_blockdev.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "esp_vfs_fat.h"
+#include "esp_vfs_fat_nand.h"   /* esp_vfs_fat_nand_bdl_format (optional) */
+#include "driver/spi_master.h"
+#include "soc/spi_pins.h"
+#include "spi_nand_flash.h"
+```
+
+### 4. Initialization flow
+
+Follow the same order as `example_spi_nand_setup()` / `app_main()` in the example source:
+
+1. **SPI bus** — `spi_bus_initialize()` with `spi_bus_config_t` (MOSI, MISO, CLK, WP, HD GPIOs).
+2. **SPI device** — `spi_bus_add_device()` with `spi_device_interface_config_t` (clock, CS, mode, `flags`).
+3. **NAND driver** — `spi_nand_flash_init_with_layers()` with `spi_nand_flash_config_t` (returns WL `esp_blockdev_handle_t`).
+4. **Optional pre-format** — `esp_vfs_fat_nand_bdl_format()` with `esp_vfs_fat_mount_config_t` (same config you will use for mount).
+5. **FAT mount** — `esp_vfs_fat_bdl_mount()` with `esp_vfs_fat_mount_config_t`.
+6. **File I/O** — standard `fopen()` / `fprintf()` / `fgets()` on paths under the mount point (e.g. `/nandflash/hello.txt`).
+7. **Cleanup** — `esp_vfs_fat_bdl_unmount()`, then `wl_bdl->ops->release(wl_bdl)`, `spi_bus_remove_device()`, `spi_bus_free()` (see `example_spi_nand_teardown()`).
+
+Default pin macros (`HOST_ID`, `PIN_MOSI`, etc.) are defined at the top of the example source. Wiring matches [examples/nand_flash](../nand_flash/README.md).
+
+### 5. `spi_nand_flash_config_t`
+
+Populated in `example_spi_nand_setup()` before `spi_nand_flash_init_with_layers()`:
+
+| Field | Description |
+|-------|-------------|
+| `device_handle` | `spi_device_handle_t` returned by `spi_bus_add_device()` |
+| `io_mode` | `SPI_NAND_IO_MODE_SIO` in this example; also `DIO`, `DOUT`, `QIO`, or `QOUT` |
+| `flags` | `SPI_DEVICE_HALFDUPLEX` for half-duplex (required for DIO/DOUT/QIO/QOUT); `0` for full-duplex SIO. This value has to match the half-duplex flag in `spi_device_interface_config_t.flags` |
+| `gc_factor` | Optional wear-leveling GC tuning; omit or set `0` for the driver default |
+
+Full struct documentation is in [`spi_nand_flash.h`](../../../spi_nand_flash/include/spi_nand_flash.h). The same config type is used for legacy `spi_nand_flash_init_device()`.
+
+### 6. Mount configuration
+
+```c
+const esp_vfs_fat_mount_config_t mount_config = {
+    .max_files = 4,
+    .format_if_mount_failed = false,  // or true to format on first mount failure
+    // Cluster size used when formatting. Must be a power of 2 between the
+    // logical sector size and 128 * sector size. Larger values improve
+    // sequential throughput; smaller values waste less space for small files.
+    // 16 KiB matches this example (and common ESP-IDF FatFs samples);
+    // use 0 to default to one sector per cluster.
+    .allocation_unit_size = 16 * 1024,
+};
+
+#ifdef CONFIG_EXAMPLE_FORMAT_BEFORE_MOUNT
+ESP_ERROR_CHECK(esp_vfs_fat_nand_bdl_format(wl_bdl, &mount_config));
+#endif
+ESP_ERROR_CHECK(esp_vfs_fat_bdl_mount("/nandflash", wl_bdl, &mount_config));
+```
+
+In this example project, `format_if_mount_failed` and pre-mount format are controlled by `CONFIG_EXAMPLE_FORMAT_IF_MOUNT_FAILED` and `CONFIG_EXAMPLE_FORMAT_BEFORE_MOUNT` in menuconfig.
+
+### 7. Prerequisites
+
+- **ESP-IDF 6.1+** (`esp_vfs_fat_bdl_mount` / `diskio_bdl`).
+- Enable **`CONFIG_NAND_FLASH_ENABLE_BDL=y`** (Component config → SPI NAND Flash). When BDL is on, **`spi_nand_flash_init_device()` is not available**.
+- See also [`spi_nand_flash_fatfs` component README](../../README.md#requirements-read-first).
+
 ## Requirements
 
 - **ESP-IDF 6.1 or newer** (`esp_vfs_fat_bdl_mount` / `diskio_bdl`; NAND BDL itself needs IDF 6.0+).


### PR DESCRIPTION
## Summary

- Expand `spi_nand_flash_fatfs/examples/nand_flash/README.md` with an end-to-end **Use in your own project** guide: dependency, CMake, headers, init flow, `spi_nand_flash_config_t`, mount config, and BDL prerequisite
- Slim `spi_nand_flash_fatfs/README.md` to point at the example instead of duplicating full source
- Add `spi_nand_flash_config_t` driver configuration notes to `spi_nand_flash/README.md` and link to the FAT example

Addresses [IDF-15775](https://jira.espressif.com:8443/browse/IDF-15775) (DocChatbot CSAT: missing end-to-end SPI NAND + FatFS integration docs).