### PR TITLE
fix(catch2): detect console component via target instead of BUILD_COM… (IEC-581)

### DIFF
--- a/catch2/CMakeLists.txt
+++ b/catch2/CMakeLists.txt
@@ -19,9 +19,6 @@ if(NOT target STREQUAL "linux")
 endif()
 
 # If console component is present in the build, include the console
-# command feature. 
-idf_build_get_property(build_components BUILD_COMPONENTS)
-if("console" IN_LIST build_components)
-    target_compile_definitions(${COMPONENT_LIB} PRIVATE WITH_CONSOLE)
-    target_link_libraries(${COMPONENT_LIB} PUBLIC idf::console)
-endif()
+# command feature.
+target_compile_definitions(${COMPONENT_LIB} PRIVATE "$<$<TARGET_EXISTS:idf::console>:WITH_CONSOLE>")
+target_link_libraries(${COMPONENT_LIB} PUBLIC "$<TARGET_NAME_IF_EXISTS:idf::console>")

--- a/catch2/idf_component.yml
+++ b/catch2/idf_component.yml
@@ -1,4 +1,4 @@
-version: "3.7.0"
+version: "3.7.0~1"
 description: A modern, C++-native, test framework for unit-tests, TDD and BDD - using C++14, C++17 and later
 url: https://github.com/espressif/idf-extra-components/tree/master/catch2
 repository: https://github.com/espressif/idf-extra-components.git


### PR DESCRIPTION
Build system v2 does not support the `BUILD_COMPONENTS` variable. Instead, detect the console component through its target using generator expressions.