### PR TITLE
feat: upgrade freetype component to 2.14.3

### DIFF
--- a/freetype/CMakeLists.txt
+++ b/freetype/CMakeLists.txt
@@ -17,4 +17,9 @@ add_subdirectory(freetype output)
 # https://gitlab.freedesktop.org/freetype/freetype/-/issues/1299
 target_compile_options(freetype PRIVATE "-Wno-dangling-pointer")
 
+# Suppress `unused-but-set-variable` warning triggered by `ft_stroke_border_get_counts`
+# in FreeType 2.14.3 (src/base/ftstroke.c). This flag is applied at the target
+# level and therefore affects all FreeType sources built in this component.
+target_compile_options(freetype PRIVATE "-Wno-unused-but-set-variable")
+
 target_link_libraries(${COMPONENT_LIB} INTERFACE freetype)

--- a/freetype/README.md
+++ b/freetype/README.md
@@ -1,7 +1,39 @@
-# freetype compression and decompression Library
+# FreeType Library
 
 [![Component Registry](https://components.espressif.com/components/espressif/freetype/badge.svg)](https://components.espressif.com/components/espressif/freetype)
 
-This is an IDF component for freetype library.
+This is an IDF component that ports the [FreeType](https://freetype.org/) library into ESP-IDF.
+
+**FreeType** is a software font engine designed to support a large variety of font formats, including TrueType, OpenType, Type1, and more. It is used widely as a rendering library for text and graphics on embedded devices.
+
+## Features
+
+- Load and render fonts from filesystems (SPIFFS, LittleFS, FAT, etc.) or from memory.
+- Support for a wide range of font formats (TrueType, OpenType, Type1, CFF, etc.).
+- Vector-to-raster conversion with hinting for quality text rendering.
+
+## Usage
+
+Add `espressif/freetype` to the `dependencies` of your project:
+
+```yaml
+dependencies:
+  espressif/freetype: "^2.14.3"
+```
+
+Include the FreeType header and use the API as usual:
+
+```c
+#include "freetype/freetype.h"
+#include "freetype/ftglyph.h"
+```
+
+This component disables optional dependencies (HarfBuzz, BZIP2, Brotli, PNG, and ZLIB) by default to keep the binary size small. Note that the **WOFF2** font format relies on Brotli decompression and is therefore **not supported** in this configuration. Please use TTF/OTF instead.
+
+## Example
+
+An example is available in [examples/freetype-example](examples/freetype-example/README.md), which loads the DejaVu Sans font from filesystem and renders the text "FreeType" into the console as ASCII art.
+
+## Documentation
 
 For usage instructions, please refer to the official documentation: https://freetype.org/freetype2/docs/documentation.html

--- a/freetype/examples/freetype-example/README.md
+++ b/freetype/examples/freetype-example/README.md
@@ -2,7 +2,7 @@
 
 This is a simple example of initializing FreeType library, loading a font from a filesystem, and rendering a line of text.
 
-The font file (DejaVu Sans) is downloaded at compile time and is added into a SPIFFS filesystem image. The filesystem is flashed to the board together with the application. The example loads the font file and renders "FreeType" text into the console as ASCII art.
+The font file (DejaVu Sans) is downloaded at compile time and is added into a LittleFS filesystem image. The filesystem is flashed to the board together with the application. The example loads the font file and renders "FreeType" text into the console as ASCII art.
 
 This example doesn't require any special hardware and can run on any development board.
 
@@ -45,7 +45,4 @@ I (2208) example: Rendering char: 'e'
                                             ##   ##
                                            +#.   ##
                                           ##+    ##
-
-
-
 ```

--- a/freetype/examples/freetype-example/main/CMakeLists.txt
+++ b/freetype/examples/freetype-example/main/CMakeLists.txt
@@ -1,13 +1,12 @@
 idf_component_register(SRCS "freetype-example.c"
-                    INCLUDE_DIRS "."
-                    PRIV_REQUIRES spiffs)
+                       INCLUDE_DIRS ".")
 
-# Download the example font into a directory "spiffs" in the build directory
+# Download the example font into a directory "littlefs" in the build directory
 set(URL "https://github.com/espressif/esp-docs/raw/f036a337d8bee5d1a93b2264ecd29255baec4260/src/esp_docs/fonts/DejaVuSans.ttf")
 set(FILE "DejaVuSans.ttf")
-set(SPIFFS_DIR "${CMAKE_BINARY_DIR}/spiffs")
-file(MAKE_DIRECTORY ${SPIFFS_DIR})
-file(DOWNLOAD ${URL} ${SPIFFS_DIR}/${FILE} SHOW_PROGRESS)
+set(LITTLEFS_DIR "${CMAKE_BINARY_DIR}/littlefs")
+file(MAKE_DIRECTORY ${LITTLEFS_DIR})
+file(DOWNLOAD ${URL} ${LITTLEFS_DIR}/${FILE} SHOW_PROGRESS)
 
 # Create a partition named "fonts" with the example font
-spiffs_create_partition_image(fonts ${SPIFFS_DIR} FLASH_IN_PROJECT)
+littlefs_create_partition_image(fonts ${LITTLEFS_DIR} FLASH_IN_PROJECT)

--- a/freetype/examples/freetype-example/main/freetype-example.c
+++ b/freetype/examples/freetype-example/main/freetype-example.c
@@ -1,14 +1,16 @@
 /*
- * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: CC0-1.0
  */
 
 
 #include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
 #include "esp_log.h"
 #include "esp_err.h"
-#include "esp_spiffs.h"
+#include "esp_littlefs.h"
 #include "ft2build.h"
 #include FT_FREETYPE_H
 
@@ -37,18 +39,18 @@ void app_main(void)
 
 static void init_filesystem(void)
 {
-    esp_vfs_spiffs_conf_t conf = {
+    esp_vfs_littlefs_conf_t conf = {
         .base_path = "/fonts",
         .partition_label = "fonts",
-        .max_files = 1,
+        .format_if_mount_failed = true,
     };
 
-    ESP_ERROR_CHECK(esp_vfs_spiffs_register(&conf));
+    ESP_ERROR_CHECK(esp_vfs_littlefs_register(&conf));
 }
 
 static void init_freetype(void)
 {
-    FT_Error error = FT_Init_FreeType( &s_library );
+    FT_Error error = FT_Init_FreeType(&s_library);
     if (error) {
         ESP_LOGE(TAG, "Error initializing FreeType library: %d", error);
         abort();
@@ -59,10 +61,10 @@ static void init_freetype(void)
 
 static void load_font(void)
 {
-    FT_Error error = FT_New_Face( s_library,
-                                  "/fonts/DejaVuSans.ttf",
-                                  0,
-                                  &s_face );
+    FT_Error error = FT_New_Face(s_library,
+                                 "/fonts/DejaVuSans.ttf",
+                                 0,
+                                 &s_face);
     if (error) {
         ESP_LOGE(TAG, "Error loading font: %d", error);
         abort();
@@ -77,7 +79,7 @@ static void render_text(void)
     /* Configure character size. */
     const int font_size = 14;
     const int freetype_scale = 64;
-    FT_Error error = FT_Set_Char_Size(s_face, 0, font_size * freetype_scale, 0, 0 );
+    FT_Error error = FT_Set_Char_Size(s_face, 0, font_size * freetype_scale, 0, 0);
     if (error) {
         ESP_LOGE(TAG, "Error setting font size: %d", error);
         abort();
@@ -94,17 +96,17 @@ static void render_text(void)
         ESP_LOGI(TAG, "Rendering char: '%c'", text[n]);
 
         /* retrieve glyph index from character code */
-        FT_UInt  glyph_index = FT_Get_Char_Index( s_face, text[n] );
+        FT_UInt  glyph_index = FT_Get_Char_Index(s_face, text[n]);
 
         /* load glyph image into the slot (erase previous one) */
-        error = FT_Load_Glyph( s_face, glyph_index, FT_LOAD_DEFAULT );
+        error = FT_Load_Glyph(s_face, glyph_index, FT_LOAD_DEFAULT);
         if (error) {
             ESP_LOGE(TAG, "Error loading glyph: %d", error);
             abort();
         }
 
         /* convert to a bitmap */
-        error = FT_Render_Glyph( s_face->glyph, FT_RENDER_MODE_NORMAL );
+        error = FT_Render_Glyph(s_face->glyph, FT_RENDER_MODE_NORMAL);
         if (error) {
             ESP_LOGE(TAG, "Error rendering glyph: %d", error);
             abort();

--- a/freetype/examples/freetype-example/main/idf_component.yml
+++ b/freetype/examples/freetype-example/main/idf_component.yml
@@ -2,3 +2,4 @@ dependencies:
   espressif/freetype:
     version: "*"
     override_path: "../../.."
+  joltwallet/littlefs: "~1.22.3"

--- a/freetype/examples/freetype-example/partitions.csv
+++ b/freetype/examples/freetype-example/partitions.csv
@@ -1,4 +1,4 @@
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
 factory,  app,  factory, 0x10000, 1M,
-fonts,    data, spiffs,  ,        0xF0000,
+fonts,    data, littlefs,  ,      0xF0000,

--- a/freetype/idf_component.yml
+++ b/freetype/idf_component.yml
@@ -1,5 +1,5 @@
-version: "2.14.2"
-description: freetype C library
+version: "2.14.3"
+description: FreeType C library
 url: https://github.com/espressif/idf-extra-components/tree/master/freetype
 repository: "https://github.com/espressif/idf-extra-components.git"
 documentation: "https://freetype.org/freetype2/docs/documentation.html"

--- a/freetype/sbom_freetype.yml
+++ b/freetype/sbom_freetype.yml
@@ -1,10 +1,10 @@
 name: freetype
-version: 2.14.2
+version: 2.14.3
 cpe: cpe:2.3:a:freetype:freetype:{}:*:*:*:*:*:*:*
 supplier: 'Organization: freetype <https://www.freetype.org>'
 description: FreeType is a software font engine
 url: https://github.com/freetype/freetype
-hash: f4205da14867c5387cd6a329b90ee10a6df6eeff
+hash: 0a0221a1347e2f1e07c395263540026e9a0aa7c7
 cve-exclude-list:
   - cve: CVE-2026-23865
     reason: Fixed in version 2.14.2 with commit https://github.com/freetype/freetype/commit/fc85a255849229c024c8e65f536fe1875d84841c


### PR DESCRIPTION
- Update freetype submodule to upstream release VER-2-14-3
- Sync component version in idf_component.yml to 2.14.3
- Suppress unused-but-set-variable warning in ftstroke.c (not fixed upstream)
