### PR TITLE
fix(spi_nand_flash): handle GigaDevice Internal Data Move parity correctly

### DIFF
--- a/spi_nand_flash/CHANGELOG.md
+++ b/spi_nand_flash/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Versioning policy: see [VERSIONING.md](VERSIONING.md). From **v1.0.0** onward this component follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2]
+- fix: use Internal Data Move same-parity handling for GigaDevice chips that require it (GD5F2GQ5, GD5F2GM7, GD5F4GQ6, GD5F4GM8, GD5F4GM7, GD5F8GM8), without treating them as hardware dual-plane
+
 ## [1.4.1]
 - fix: free SPI bus in Unity tearDown so a failed test case does not leave the bus initialized for later cases
 

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.1"
+version: "1.4.2"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/priv_include/nand.h
+++ b/spi_nand_flash/priv_include/nand.h
@@ -28,10 +28,13 @@ extern "C" {
 
 #define INVALID_PAGE 0xFFFF
 
-// For some GigaDevice parts, these encode odd/even block parity in the column
-// address (not a second physical plane). See get_column_address() in nand_impl.c.
+// True hardware dual-plane devices (e.g. Micron MT29F2G): plane index is encoded
+// in the column address. See get_column_address() in nand_impl.c.
 #define NAND_FLAG_HAS_PROG_PLANE_SELECT       BIT(0)
 #define NAND_FLAG_HAS_READ_PLANE_SELECT       BIT(1)
+// Single-plane devices whose Internal Data Move requires same odd/even block
+// parity (e.g. some GigaDevice parts). nand_copy() uses a RAM path when parity differs.
+#define NAND_FLAG_IDM_SAME_PARITY_REQUIRED    BIT(2)
 
 // Legacy typedef for compatibility - now uses nand_flash_geometry_t internally
 typedef nand_flash_geometry_t spi_nand_chip_t;

--- a/spi_nand_flash/src/devices/nand_gigadevice.c
+++ b/spi_nand_flash/src/devices/nand_gigadevice.c
@@ -36,43 +36,54 @@ esp_err_t spi_nand_gigadevice_init(spi_nand_flash_device_t *dev)
     case GIGADEVICE_DI_21:
     case GIGADEVICE_DI_81:
     case GIGADEVICE_DI_91:
+        // GD5F1GQ5 / GD5F1GM7: single-plane, Internal Data Move has no parity restriction
         dev->chip.num_blocks = 1024;
+        break;
+    case GIGADEVICE_DI_32:
+    case GIGADEVICE_DI_22:
+        dev->chip.num_blocks = 2048;
         break;
     case GIGADEVICE_DI_52:
     case GIGADEVICE_DI_42:
-    case GIGADEVICE_DI_32:
-    case GIGADEVICE_DI_22:
+        // GD5F2GQ5: single-plane; IDM requires same odd/even block parity
+        dev->chip.num_blocks = 2048;
+        dev->chip.flags = NAND_FLAG_IDM_SAME_PARITY_REQUIRED;
+        break;
     case GIGADEVICE_DI_92:
     case GIGADEVICE_DI_82:
+        // GD5F2GM7: single-plane; IDM requires same odd/even block parity
         dev->chip.num_blocks = 2048;
+        dev->chip.flags = NAND_FLAG_IDM_SAME_PARITY_REQUIRED;
         break;
-    case GIGADEVICE_DI_55:
-    case GIGADEVICE_DI_45:
     case GIGADEVICE_DI_35:
     case GIGADEVICE_DI_25:
         dev->chip.num_blocks = 4096;
         break;
+    case GIGADEVICE_DI_55:
+    case GIGADEVICE_DI_45:
+        // GD5F4GQ6: single-plane; IDM requires same odd/even block parity
+        // (2Gb partition limit for IDM is deferred)
+        dev->chip.num_blocks = 4096;
+        dev->chip.flags = NAND_FLAG_IDM_SAME_PARITY_REQUIRED;
+        break;
     case GIGADEVICE_DI_95:
     case GIGADEVICE_DI_85:
+        // GD5F4GM8: single-plane; IDM requires same odd/even block parity
+        // (2Gb partition limit for IDM is deferred)
         dev->chip.num_blocks = 4096;
-        // Not hardware dual-plane: num_planes models odd/even block parity required
-        // for Internal Data Move (GD5F4GM8 datasheet §9.5). See nand_copy().
-        dev->chip.flags = NAND_FLAG_HAS_PROG_PLANE_SELECT | NAND_FLAG_HAS_READ_PLANE_SELECT;
-        dev->chip.num_planes = 2;
+        dev->chip.flags = NAND_FLAG_IDM_SAME_PARITY_REQUIRED;
         break;
     case GIGADEVICE_DI_94:
+        // GD5F4GM7UExxG: single-plane; IDM requires same odd/even block parity
         dev->chip.log2_page_size = 12;  // 4096 bytes per page
         dev->chip.num_blocks = 2048;
-        // Same parity grouping as GD5F4GM8 (GIGADEVICE_DI_95) above.
-        dev->chip.flags = NAND_FLAG_HAS_PROG_PLANE_SELECT | NAND_FLAG_HAS_READ_PLANE_SELECT;
-        dev->chip.num_planes = 2;
+        dev->chip.flags = NAND_FLAG_IDM_SAME_PARITY_REQUIRED;
         break;
     case GIGADEVICE_DI_99:
+        // GD5F8GM8UExxG: single-plane; IDM requires same odd/even block parity
         dev->chip.log2_page_size = 12; // 4096 bytes per page
         dev->chip.num_blocks = 4096;
-        // Same parity grouping as GD5F4GM7 (GIGADEVICE_DI_94) above.
-        dev->chip.flags = NAND_FLAG_HAS_PROG_PLANE_SELECT | NAND_FLAG_HAS_READ_PLANE_SELECT;
-        dev->chip.num_planes = 2;
+        dev->chip.flags = NAND_FLAG_IDM_SAME_PARITY_REQUIRED;
         break;
     default:
         return ESP_ERR_INVALID_RESPONSE;

--- a/spi_nand_flash/src/nand_impl.c
+++ b/spi_nand_flash/src/nand_impl.c
@@ -214,8 +214,6 @@ static uint16_t get_column_address(spi_nand_flash_device_t *handle, uint32_t blo
         uint32_t plane = block % handle->chip.num_planes;
         // Plane index is encoded in the column address bit after the page MSB.
         // 2048-byte pages use bit 12; 4096-byte pages use bit 13.
-        // On some GigaDevice GD5F4GM7/8, this models odd/even block parity for Internal
-        // Data Move; nand_copy() falls back to a RAM copy when parity differs.
         column_addr += plane << (handle->chip.log2_page_size + 1);
     }
     return column_addr;
@@ -465,6 +463,19 @@ fail:
     return ret;
 }
 
+static bool nand_copy_needs_ram_path(uint32_t flags,
+                                     uint32_t src_block,
+                                     uint32_t dst_block,
+                                     uint16_t src_column_addr,
+                                     uint16_t dst_column_addr)
+{
+    if (src_column_addr != dst_column_addr) {
+        return true;
+    }
+    return (flags & NAND_FLAG_IDM_SAME_PARITY_REQUIRED) &&
+           ((src_block & 1U) != (dst_block & 1U));
+}
+
 esp_err_t nand_copy(spi_nand_flash_device_t *handle, uint32_t src, uint32_t dst)
 {
     ESP_LOGD(TAG, "copy, src=%"PRIu32", dst=%"PRIu32"", src, dst);
@@ -487,8 +498,11 @@ esp_err_t nand_copy(spi_nand_flash_device_t *handle, uint32_t src, uint32_t dst)
     uint16_t src_column_addr = get_column_address(handle, src_block, 0);
     uint16_t dst_column_addr = get_column_address(handle, dst_block, 0);
 
-    if (src_column_addr != dst_column_addr) {
-        // In a 2 plane structure of the flash, if the pages are not on the same plane, the data must be copied through RAM.
+    bool need_ram_copy = nand_copy_needs_ram_path(handle->chip.flags, src_block, dst_block,
+                         src_column_addr, dst_column_addr);
+
+    if (need_ram_copy) {
+        // Copy through RAM when HW Internal Data Move is not valid for this src/dst pair.
         uint8_t *copy_buf = heap_caps_malloc(handle->chip.page_size, MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
         ESP_GOTO_ON_FALSE(copy_buf, ESP_ERR_NO_MEM, fail, TAG, "Failed to allocate copy buffer");
 
@@ -520,7 +534,7 @@ esp_err_t nand_copy(spi_nand_flash_device_t *handle, uint32_t src, uint32_t dst)
 
 #if CONFIG_NAND_FLASH_VERIFY_WRITE
     // First read src page data from cache to temp_buf
-    if (src_column_addr != dst_column_addr) {
+    if (need_ram_copy) {
         // Then read src page data from nand memory array and load it in cache
         ESP_GOTO_ON_ERROR(read_page_and_wait(handle, src, &status), fail, TAG, "");
         if (is_ecc_error(handle, status)) {


### PR DESCRIPTION
# Change description
Some GigaDevice SPI NAND parts are single-plane but require **same odd/even block parity** for Internal Data Move (IDM). The driver previously modeled that by setting `num_planes = 2` and plane-select flags, which incorrectly looks like hardware dual-plane and did not cover all affected parts.

This change introduces `NAND_FLAG_IDM_SAME_PARITY_REQUIRED` and uses it in `nand_copy()` to fall back to a RAM copy when src/dst blocks have different parity. Hardware dual-plane handling (e.g. Micron) is unchanged.

## Test plan
- [x] Build `spi_nand_flash` test app
- [x] On GD5F2GM7 / GD5F2GQ5 / GD5F4GQ6 (if available): run copy / Dhara GC across same-parity and different-parity blocks; different-parity should succeed via RAM path
- [x] On GD5F4GM8 / GD5F4GM7 (if available): same parity checks; confirm normal read/write on odd blocks still works
- [x] Micron dual-plane : confirm cross-plane copy still uses RAM path
- [x] CI green
