### PR TITLE
fix(flash_dispatcher): fix blocking when directly calling the flash i… (IEC-583)

### DIFF
--- a/esp_flash_dispatcher/CHANGELOG.md
+++ b/esp_flash_dispatcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- fix: Bypass the dispatcher and call the real Flash operations directly when the stack resides in internal DRAM. This prevents deadlocks that could arise from nested calls to flash operation interfaces (e.g. specifically, calling a flash operation from within a flash operation already executing under the scheduler) and avoids unnecessary task scheduling overhead.
+
 ## 1.0.2
 
 - fix: Bypass the dispatcher and call the real Flash operations directly when it is not initialized yet, so early-boot Flash access (e.g. partition loading and core dump probing during system startup).

--- a/esp_flash_dispatcher/esp_flash_dispatcher.c
+++ b/esp_flash_dispatcher/esp_flash_dispatcher.c
@@ -16,6 +16,7 @@
 #include "esp_flash_dispatcher.h"
 #include "spi_flash_mmap.h"
 #include "esp_private/spi_flash_os.h"
+#include "esp_memory_utils.h"
 
 static const char *TAG = "flash_dispatcher";
 
@@ -97,13 +98,9 @@ typedef struct {
 
 static flash_dispatcher_context_t s_flash_dispatcher_ctx;
 
-// Bypass the dispatcher (call the real flash ops directly) when it cannot serve
-// the request: either the scheduler is gone (no-OS / panic handler), or the
-// scheduler hasn't started yet (early boot flash access such as partition
-// loading / core dump probing).
 static inline bool flash_dispatcher_should_bypass(void)
 {
-    return flash_dispatcher_is_no_os() || xTaskGetSchedulerState() != taskSCHEDULER_RUNNING;
+    return flash_dispatcher_is_no_os() || esp_ptr_in_dram(esp_cpu_get_sp()) || xTaskGetSchedulerState() != taskSCHEDULER_RUNNING;
 }
 
 static void flash_dispatcher_task(void *arg)

--- a/esp_flash_dispatcher/idf_component.yml
+++ b/esp_flash_dispatcher/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.0.2"
+version: "1.0.3"
 description: This component allows flash operations to be performed by tasks with stacks in PSRAM.
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_flash_dispatcher
 repository: https://github.com/espressif/idf-extra-components.git


### PR DESCRIPTION
Fixed an issue where directly calling the flash interface without first reading and loading the partition table would cause blocking.

The internal Flash erase and write interfaces check whether the operation range is protected. If the partition table has not yet been loaded, calling the `esp_flash_write`, `esp_flash_write_encrypted`, or `esp_flash_erase_region` APIs triggers an internal execution of `spi_flash_mmap` to load the partition table. Repeated execution of the scheduler results in a deadlock.

# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [x] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [x] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
Allow tasks whose own task stack resides in internal DRAM to directly invoke actual flash operations. Avoid repeatedly executing the scheduler and unnecessary task scheduling.
