### PR TITLE
fix(esp_delta_ota): NVS init failed due to no free pages

### DIFF
--- a/esp_delta_ota/examples/https_delta_ota/main/main.c
+++ b/esp_delta_ota/examples/https_delta_ota/main/main.c
@@ -287,7 +287,13 @@ void app_main(void)
 {
     ESP_LOGI(TAG, "Initialising WiFi Connection...");
 
-    ESP_ERROR_CHECK(nvs_flash_init());
+    esp_err_t err = nvs_flash_init();
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        err = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(err);
+
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
 


### PR DESCRIPTION
### Problem
- [CI fails](https://github.com/espressif/idf-extra-components/actions/runs/32239551752/job/96050527307) for esp_delta_ota example due to `err` returned by `nvs_flash_init` - `ESP_ERROR_CHECK failed: esp_err_t 0x110d (ESP_ERR_NVS_NO_FREE_PAGES) at 0x400dcc22` ([log](https://github.com/espressif/idf-extra-components/actions/runs/32239551752/job/96050527307#step:7:6169))
- This may happen if any `previous test` has `written` something into the `NVS` and `did not erase`. And `by default, pytest do not erase the nvs`.

### Solution
- Add failure check for the `nvs_flash_init`.