### PR TITLE
Sysview optimizations

### DIFF
--- a/esp_sysview/CMakeLists.txt
+++ b/esp_sysview/CMakeLists.txt
@@ -46,6 +46,10 @@ if(CONFIG_ESP_TRACE_LIB_EXTERNAL)
     # This allows freertos component to find esp_trace_freertos_impl.h
     idf_component_get_property(freertos_lib freertos COMPONENT_LIB)
     target_include_directories(${freertos_lib} INTERFACE ${include_dirs})
+
+    if(CONFIG_SEGGER_SYSVIEW_OPTIMIZE_SPEED)
+        target_compile_options(${COMPONENT_LIB} PRIVATE -O2)
+    endif()
 else()
     idf_component_register(REQUIRES "${requires}" PRIV_REQUIRES "${priv_requires}")
 endif()

--- a/esp_sysview/Kconfig
+++ b/esp_sysview/Kconfig
@@ -28,6 +28,15 @@ menu "SEGGER SystemView Configuration"
 
     endchoice
 
+    config SEGGER_SYSVIEW_OPTIMIZE_SPEED
+        bool "Compile SystemView for speed (-O2)"
+        default y
+        help
+            Compile this component with -O2 regardless of the project-wide
+            optimization level. Every trace event record runs through this
+            code, so its speed directly sets the per-event tracing overhead
+            and the minimum observable spacing between events.
+
     config SEGGER_SYSVIEW_MAX_TASKS
         int "Maximum supported tasks"
         range 1 64

--- a/esp_sysview/idf_component.yml
+++ b/esp_sysview/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.1.1
+version: 1.1.2
 description: SEGGER SystemView component for ESP-IDF
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_sysview
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/esp_sysview/src/SEGGER/SEGGER_RTT.h
+++ b/esp_sysview/src/SEGGER/SEGGER_RTT.h
@@ -404,9 +404,13 @@ unsigned     SEGGER_RTT_GetBytesInBuffer        (unsigned BufferIndex);
 //
 // Function macro for performance optimization
 //
-// @AGv: This macro is used inside SEGGER SystemView code.
-// For ESP32 we use our own implementation of RTT, so this macro should not check SEGGER's RTT buffer state.
-#define      SEGGER_RTT_HASDATA(n)       (1)
+// @AGv: ESP uses its own RTT; this is not a SEGGER buffer check.
+// While tracing is not active, poll every event so START/STOP commands are
+// picked up promptly. While tracing is active, poll every 32nd event.
+#define      SEGGER_RTT_ESP_DOWN_POLL_MASK  31u
+extern unsigned SEGGER_RTT_ESP_DownPollCnt;
+#define      SEGGER_RTT_HASDATA(n)       (_SYSVIEW_Globals.EnableState != 1 || \
+                                          ((++SEGGER_RTT_ESP_DownPollCnt & SEGGER_RTT_ESP_DOWN_POLL_MASK) == 0))
 
 #if RTT_USE_ASM
 #define SEGGER_RTT_WriteSkipNoLock  SEGGER_RTT_ASM_WriteSkipNoLock

--- a/esp_sysview/src/SEGGER/SEGGER_SYSVIEW.h
+++ b/esp_sysview/src/SEGGER/SEGGER_SYSVIEW.h
@@ -425,7 +425,6 @@ void SEGGER_SYSVIEW_X_OnEventRecorded             (unsigned NumBytes);
 *       Espressif specific functions
 */
 int SEGGER_SYSVIEW_ESP_SetEncoder(void *encoder);
-void *SEGGER_SYSVIEW_ESP_GetEncoder(void);
 
 #ifdef __cplusplus
 }

--- a/esp_sysview/src/Sample/FreeRTOSV10.4/Config/esp/SEGGER_SYSVIEW_Config_FreeRTOS.c
+++ b/esp_sysview/src/Sample/FreeRTOSV10.4/Config/esp/SEGGER_SYSVIEW_Config_FreeRTOS.c
@@ -62,6 +62,7 @@ Revision: $Rev: 7745 $
 #include "sdkconfig.h"
 #include "freertos/FreeRTOS.h"
 #include "SEGGER_SYSVIEW.h"
+#include "SEGGER_SYSVIEW_esp.h"
 #include "esp_app_desc.h"
 #include "esp_intr_alloc.h"
 #include "soc/soc.h"

--- a/esp_sysview/src/esp/SEGGER_RTT_esp.c
+++ b/esp_sysview/src/esp/SEGGER_RTT_esp.c
@@ -31,6 +31,8 @@
 #define SEGGER_HOST_WAIT_TMO    CONFIG_SEGGER_SYSVIEW_BUF_WAIT_TMO
 #endif
 
+unsigned SEGGER_RTT_ESP_DownPollCnt;
+
 static uint8_t s_events_buf[SYSVIEW_EVENTS_BUF_SZ];
 static uint16_t s_events_buf_filled;
 static uint8_t s_down_buf[SYSVIEW_DOWN_BUF_SIZE];

--- a/esp_sysview/src/esp/SEGGER_RTT_esp.c
+++ b/esp_sysview/src/esp/SEGGER_RTT_esp.c
@@ -9,6 +9,7 @@
 #include "SEGGER_RTT.h"
 #include "SEGGER_RTT_esp.h"
 #include "SEGGER_SYSVIEW.h"
+#include "SEGGER_SYSVIEW_esp.h"
 #include "SEGGER_SYSVIEW_Conf.h"
 
 #include "esp_cpu.h"
@@ -54,12 +55,11 @@ static uint8_t s_down_buf[SYSVIEW_DOWN_BUF_SIZE];
 esp_err_t SEGGER_RTT_ESP_FlushNoLock(void)
 {
     esp_trace_encoder_t *encoder = SEGGER_SYSVIEW_ESP_GetEncoder();
-
     if (!encoder) {
         return ESP_ERR_INVALID_STATE;
     }
-
     esp_trace_transport_t *tp = encoder->tp;
+
     esp_err_t write_res = ESP_OK;
 
     if (s_events_buf_filled > 0) {
@@ -119,8 +119,9 @@ unsigned SEGGER_RTT_ReadNoLock(unsigned BufferIndex, void *pData, unsigned Buffe
     if (!encoder) {
         return 0;
     }
+    esp_trace_transport_t *tp = encoder->tp;
     size_t size = BufferSize;
-    esp_err_t res = encoder->tp->vt->read(encoder->tp, pData, &size, 0);
+    esp_err_t res = tp->vt->read(tp, pData, &size, 0);
     return res != ESP_OK ? 0 : size;
 }
 
@@ -154,14 +155,14 @@ unsigned SEGGER_RTT_WriteSkipNoLock(unsigned BufferIndex, const void *pBuffer, u
     if (!encoder) {
         return 0;  // Encoder is not initialized
     }
-
     esp_trace_transport_t *tp = encoder->tp;
+    sysview_encoder_ctx_t *ctx = encoder->ctx;
+
     uint8_t *pbuf = (uint8_t *)pBuffer;
     uint8_t event_id = *pbuf;
 
-    esp_trace_link_types_t link_type = tp->vt->get_link_type(tp);
-    sysview_encoder_ctx_t *ctx = encoder->ctx;
-    if (ctx && ctx->filter_by_cpu) {
+    esp_trace_link_types_t link_type = SEGGER_SYSVIEW_ESP_GetLinkType();
+    if (ctx->filter_by_cpu) {
         if (
             (ctx->dest_cpu != esp_cpu_get_core_id()) &&
             (
@@ -215,7 +216,9 @@ unsigned SEGGER_RTT_WriteSkipNoLock(unsigned BufferIndex, const void *pBuffer, u
         }
         s_events_buf_filled = 0;
     }
-    memcpy(&s_events_buf[s_events_buf_filled], pBuffer, NumBytes);
+    for (unsigned k = 0; k < NumBytes; k++) {
+        s_events_buf[s_events_buf_filled + k] = pbuf[k];
+    }
     s_events_buf_filled += NumBytes;
 
     if (link_type != ESP_TRACE_LINK_DEBUG_PROBE) {
@@ -294,5 +297,6 @@ int SEGGER_RTT_ConfigDownBuffer(unsigned BufferIndex, const char *sName, void *p
     if (!encoder) {
         return -1;
     }
-    return encoder->tp->vt->down_buffer_config(encoder->tp, s_down_buf, sizeof(s_down_buf));
+    esp_trace_transport_t *tp = encoder->tp;
+    return tp->vt->down_buffer_config(tp, s_down_buf, sizeof(s_down_buf));
 }

--- a/esp_sysview/src/esp/SEGGER_SYSVIEW_esp.c
+++ b/esp_sysview/src/esp/SEGGER_SYSVIEW_esp.c
@@ -7,15 +7,12 @@
 
 #include "esp_trace_port_encoder.h"
 #include "esp_trace_port_transport.h"
-#include "adapter_encoder_sysview.h"
+#include "SEGGER_SYSVIEW_esp.h"
 
 static const char *TAG = "sysview-esp";
 
-/**
- * @brief Encoder reference used by RTT layer
- * Set by SEGGER_SYSVIEW_ESP_SetEncoder() during encoder init.
- */
-static esp_trace_encoder_t *s_encoder = NULL;
+esp_trace_encoder_t *s_sysview_encoder;
+esp_trace_link_types_t s_sysview_link_type;
 
 /*********************************************************************
 *
@@ -55,27 +52,8 @@ int SEGGER_SYSVIEW_ESP_SetEncoder(void *encoder)
         return -1;
     }
 
-    s_encoder = enc;
+    s_sysview_link_type = enc->tp->vt->get_link_type(enc->tp);
+    s_sysview_encoder = enc;
 
     return 0;
-}
-
-/*********************************************************************
-*
-*       SEGGER_SYSVIEW_ESP_GetEncoder()
-*
-*  Function description
-*    Returns the encoder handle for accessing transport functions.
-*    This is used by SEGGER_SYSVIEW_Config_FreeRTOS.c to access
-*    transport lock functions.
-*
-*  Parameters
-*    None
-*
-*  Return value
-*    Pointer to encoder instance, or NULL if not initialized.
-*/
-void *SEGGER_SYSVIEW_ESP_GetEncoder(void)
-{
-    return s_encoder;
 }

--- a/esp_sysview/src/include/SEGGER_SYSVIEW_esp.h
+++ b/esp_sysview/src/include/SEGGER_SYSVIEW_esp.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "esp_attr.h"
+#include "esp_trace_port_encoder.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern esp_trace_encoder_t *s_sysview_encoder;
+extern esp_trace_link_types_t s_sysview_link_type;
+
+FORCE_INLINE_ATTR esp_trace_encoder_t *SEGGER_SYSVIEW_ESP_GetEncoder(void)
+{
+    return s_sysview_encoder;
+}
+
+FORCE_INLINE_ATTR esp_trace_link_types_t SEGGER_SYSVIEW_ESP_GetLinkType(void)
+{
+    return s_sysview_link_type;
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
These optimizations reduce per event SystemView tracing cost from ~9 µs to ~2 µs together with the esp_trace changes

- Compile SystemView hot path at -O2 (CONFIG_SEGGER_SYSVIEW_OPTIMIZE_SPEED, default on).
- Poll the down channel every 32nd event instead of on every event.
- Cache encoder pointer and link type at SetEncoder; load transport/ctx from the encoder.
- Inline those accessors; copy packets with a byte loop instead of memcpy.

Credits to @igrr 