### PR TITLE
feat(soem): add initial ESP-IDF port (IEC-588)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 skip = build,COPYING*,LICENSE*,*/COPYING*,*/LICENSE*,*.svg
-ignore-words-list = ser,DOUT,dout,ans,nd,Dettached,IST
+ignore-words-list = ser,DOUT,dout,ans,nd,Dettached,IST,soem,SOEM,emac,EMAC
 write-changes = true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -67,6 +67,7 @@ body:
         - qrcode
         - quirc
         - sh2lib
+        - soem
         - spi_nand_flash
         - spi_nand_flash_fatfs
         - supertinycron

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -69,6 +69,7 @@ jobs:
             qrcode
             quirc
             sh2lib
+            soem
             spi_nand_flash
             spi_nand_flash_fatfs
             supertinycron

--- a/.gitmodules
+++ b/.gitmodules
@@ -93,3 +93,7 @@
 [submodule "lz4/lz4"]
 	path = lz4/lz4
 	url = https://github.com/lz4/lz4.git
+
+[submodule "soem/soem"]
+	path = soem/soem
+	url = https://github.com/OpenEtherCATsociety/SOEM.git

--- a/.idf_build_apps.toml
+++ b/.idf_build_apps.toml
@@ -38,6 +38,7 @@ manifest_file = [
     "qoi/.build-test-rules.yml",
     "qrcode/.build-test-rules.yml",
     "quirc/.build-test-rules.yml",
+    "soem/.build-test-rules.yml",
     "thorvg/.build-test-rules.yml",
     "touch_element/.build-test-rules.yml",
     "zlib/.build-test-rules.yml",

--- a/astyle-rules.yml
+++ b/astyle-rules.yml
@@ -31,6 +31,7 @@ submodules:
   - "/qoi/qoi/"
   - "/qrcode/qrcodegen*"
   - "/quirc/quirc/"
+  - "/soem/soem/"
   - "/supertinycron/supertinycron/"
   - "/thorvg/thorvg/"
   - "/zlib/zlib/"

--- a/soem/.build-test-rules.yml
+++ b/soem/.build-test-rules.yml
@@ -1,0 +1,4 @@
+soem/examples/ecat_io:
+  enable:
+    - if: IDF_TARGET == "esp32p4"
+      reason: "The example uses the ESP32-P4 internal EMAC and board-specific PHY configuration."

--- a/soem/.build-test-rules.yml
+++ b/soem/.build-test-rules.yml
@@ -1,4 +1,4 @@
 soem/examples/ecat_io:
   enable:
-    - if: IDF_TARGET == "esp32p4"
-      reason: "The example uses the ESP32-P4 internal EMAC and board-specific PHY configuration."
+    - if: (IDF_VERSION_MAJOR >= 6) and (IDF_TARGET == "esp32p4")
+      reason: "The example requires ESP-IDF 6.0 or later and uses the ESP32-P4 internal EMAC."

--- a/soem/CMakeLists.txt
+++ b/soem/CMakeLists.txt
@@ -1,7 +1,4 @@
-set(SOEM_ROOT "${CMAKE_CURRENT_LIST_DIR}/soem") #设置soem源码仓库根路径
-
-# -----------------------------------------------------------------------------------
-# SOEM的ec_options.h由模板ec_options.h.in在编译时生成
+set(SOEM_ROOT "${CMAKE_CURRENT_LIST_DIR}/soem")
 
 # SOEM build-time resource limits
 set(EC_BUFSIZE EC_MAXECATFRAME)
@@ -41,51 +38,48 @@ set(EC_PRIMARY_MAC_ARRAY "{0x0101, 0x0101, 0x0101}")
 set(EC_SECONDARY_MAC_ARRAY "{0x0404, 0x0404, 0x0404}")
 
 if(NOT CMAKE_BUILD_EARLY_EXPANSION)
-    configure_file(                                                 # 打开.in文件，把所有变量名替换成set值，写成新文件
-        "${SOEM_ROOT}/include/soem/ec_options.h.in"                 # 模板文件位置
-        "${CMAKE_CURRENT_BINARY_DIR}/include/soem/ec_options.h"     # 新文件输出位置，放在本次编译的产出build目录内
+    configure_file(
+        "${SOEM_ROOT}/include/soem/ec_options.h.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/include/soem/ec_options.h"
     )
 endif()
 
-# -----------------------------------------------------------------------------------
 set(SOEM_CORE_SOURCES
-    "${SOEM_ROOT}/src/ec_base.c"                    # ECAT报文读写
-    "${SOEM_ROOT}/src/ec_config.c"                  # 从站扫描、PDO/FMMU/SM配置等
-    "${SOEM_ROOT}/src/ec_main.c"                    # SOEM主流程、状态和过程数据
-    "${SOEM_ROOT}/src/ec_print.c"                   # 错误信息格式化
-    "${SOEM_ROOT}/src/ec_dc.c"                      # 分布时钟
-    "${SOEM_ROOT}/src/ec_coe.c"                     # CANopen over ECAT
-    "${SOEM_ROOT}/src/ec_eoe.c"                     # Ethernet over ECAT
-    "${SOEM_ROOT}/src/ec_foe.c"                     # File over ECAT
-    "${SOEM_ROOT}/src/ec_soe.c"                     # Servo over ECAT
+    "${SOEM_ROOT}/src/ec_base.c"
+    "${SOEM_ROOT}/src/ec_config.c"
+    "${SOEM_ROOT}/src/ec_main.c"
+    "${SOEM_ROOT}/src/ec_print.c"
+    "${SOEM_ROOT}/src/ec_dc.c"
+    "${SOEM_ROOT}/src/ec_coe.c"
+    "${SOEM_ROOT}/src/ec_eoe.c"
+    "${SOEM_ROOT}/src/ec_foe.c"
+    "${SOEM_ROOT}/src/ec_soe.c"
 )
 
 set(SOEM_PORT_SOURCES
-    "port/esp_soem.c"                               # (SOEM移植)本组件的特定功能
-    "port/osal/osal.c"                              # 底层软件平台(操作系统)适配
-    "port/oshw/oshw.c"                              # 底层硬件平台(字节序等)适配
-    "port/oshw/nicdrv.c"                            # 底层硬件平台(网卡收发专用)适配
+    "port/esp_soem.c"
+    "port/osal/osal.c"
+    "port/oshw/oshw.c"
+    "port/oshw/nicdrv.c"
 )
 
-# 将当前目录注册为一个ESP-IDF组件
 idf_component_register(
-    SRCS                                            # 本组件需要参与编译的C源文件
-        ${SOEM_CORE_SOURCES}                        # SOEM CORE源码，明确不编译其中的samples和平台适配代码
-        ${SOEM_PORT_SOURCES}                        # SOEM移植到ESP-IDF的平台适配代码
+    SRCS
+        ${SOEM_CORE_SOURCES}
+        ${SOEM_PORT_SOURCES}
 
-    INCLUDE_DIRS                                    # 设置头文件搜索路径，可传播给依赖本组件的其它组件继承
+    # Prefer ESP-IDF port headers over upstream platform headers.
+    INCLUDE_DIRS
         "port/include"
         "port/oshw"
-        "port/osal"                                 # 必须比下面优先，确保选择ESP-IDF版、而非Linux版的osal_defs.h和nicdrv.h
-        "${SOEM_ROOT}/osal"                         # 单纯是为了SOEM源码的共用osal.h
-        "${SOEM_ROOT}/include"                      # 为了SOEM CORE API
-        "${CMAKE_CURRENT_BINARY_DIR}/include"       # 单纯是为了编译生成的ec_options.h
+        "port/osal"
+        "${SOEM_ROOT}/osal"
+        "${SOEM_ROOT}/include"
+        "${CMAKE_CURRENT_BINARY_DIR}/include"
 
-    # PRIV_INCLUDE_DIRS
-
-    REQUIRES                                        # 本组件公开头文件里需要的依赖
+    REQUIRES
         esp_eth
 
-    PRIV_REQUIRES                                   # 本组件内部实现所需的其它ESP-IDF组件依赖
+    PRIV_REQUIRES
         esp_timer
 )

--- a/soem/CMakeLists.txt
+++ b/soem/CMakeLists.txt
@@ -1,0 +1,87 @@
+set(SOEM_ROOT "${CMAKE_CURRENT_LIST_DIR}/soem") #设置soem源码仓库根路径
+
+# -----------------------------------------------------------------------------------
+# SOEM的ec_options.h由模板ec_options.h.in在编译时生成
+set(EC_BUFSIZE EC_MAXECATFRAME)
+set(EC_MAXBUF 16)
+set(EC_MAXEEPBITMAP 128)
+set(EC_MAXEEPBUF "EC_MAXEEPBITMAP << 5")
+set(EC_LOGGROUPOFFSET 16)
+set(EC_MAXELIST 64)
+set(EC_MAXNAME 40)
+set(EC_MAXSLAVE 200)
+set(EC_MAXGROUP 2)
+set(EC_MAXIOSEGMENTS 64)
+set(EC_MAXMBX 1486)
+set(EC_MBXPOOLSIZE 32)
+set(EC_MAXEEPDO 0x200)
+set(EC_MAXSM 8)
+set(EC_MAXFMMU 4)
+set(EC_MAXLEN_ADAPTERNAME 128)
+set(EC_MAX_MAPT 1)
+set(EC_MAXODLIST 1024)
+set(EC_MAXOELIST 256)
+set(EC_SOE_MAXNAME 60)
+set(EC_SOE_MAXMAPPING 64)
+
+set(EC_TIMEOUTRET 2000)                                         # 超时单位均为微秒
+set(EC_TIMEOUTRET3 "EC_TIMEOUTRET * 3")
+set(EC_TIMEOUTSAFE 20000)
+set(EC_TIMEOUTEEP 20000)
+set(EC_TIMEOUTTXM 20000)
+set(EC_TIMEOUTRXM 700000)
+set(EC_TIMEOUTSTATE 2000000)
+set(EC_DEFAULTRETRIES 3)
+
+set(EC_PRIMARY_MAC_ARRAY "{0x0101, 0x0101, 0x0101}")            # 逻辑MAC，非网卡真实MAC
+set(EC_SECONDARY_MAC_ARRAY "{0x0404, 0x0404, 0x0404}")
+
+configure_file(                                                 # 打开.in文件，把所有变量名替换成set值，写成新文件
+    "${SOEM_ROOT}/include/soem/ec_options.h.in"                 # 模板文件位置
+    "${CMAKE_CURRENT_BINARY_DIR}/include/soem/ec_options.h"     # 新文件输出位置，放在本次编译的产出build目录内
+)
+
+# -----------------------------------------------------------------------------------
+set(SOEM_CORE_SOURCES
+    "${SOEM_ROOT}/src/ec_base.c"                    # ECAT报文读写
+    "${SOEM_ROOT}/src/ec_config.c"                  # 从站扫描、PDO/FMMU/SM配置等
+    "${SOEM_ROOT}/src/ec_main.c"                    # SOEM主流程、状态和过程数据
+    "${SOEM_ROOT}/src/ec_print.c"                   # 错误信息格式化
+    "${SOEM_ROOT}/src/ec_dc.c"                      # 分布时钟
+    "${SOEM_ROOT}/src/ec_coe.c"                     # CANopen over ECAT
+    "${SOEM_ROOT}/src/ec_eoe.c"                     # Ethernet over ECAT
+    "${SOEM_ROOT}/src/ec_foe.c"                     # File over ECAT
+    "${SOEM_ROOT}/src/ec_soe.c"                     # Servo over ECAT
+)
+
+set(SOEM_PORT_SOURCES
+    "port/esp_soem.c"                               # (SOEM移植)本组件的特定功能
+    "port/osal/osal.c"                              # 底层软件平台(操作系统)适配
+    "port/oshw/oshw.c"                              # 底层硬件平台(字节序等)适配
+    "port/oshw/nicdrv.c"                            # 底层硬件平台(网卡收发专用)适配
+)
+
+# 将当前目录注册为一个ESP-IDF组件
+idf_component_register(
+    SRCS                                            # 本组件需要参与编译的C源文件
+        ${SOEM_CORE_SOURCES}                        # SOEM CORE源码，明确不编译其中的samples和平台适配代码
+        ${SOEM_PORT_SOURCES}                        # SOEM移植到ESP-IDF的平台适配代码
+
+    INCLUDE_DIRS                                    # 设置头文件搜索路径，可传播给依赖本组件的其它组件继承
+        "port/include"
+        "port/oshw"
+        "port/osal"                                 # 必须比下面优先，确保选择ESP-IDF版、而非Linux版的osal_defs.h和nicdrv.h
+        "${SOEM_ROOT}/osal"                         # 单纯是为了SOEM源码的共用osal.h
+        "${SOEM_ROOT}/include"                      # 为了SOEM CORE API
+        "${CMAKE_CURRENT_BINARY_DIR}/include"       # 单纯是为了编译生成的ec_options.h
+
+    # PRIV_INCLUDE_DIRS
+
+    REQUIRES                                        # 本组件公开头文件里需要的依赖
+        esp_eth
+        freertos
+
+    PRIV_REQUIRES                                   # 本组件内部实现所需的其它ESP-IDF组件依赖
+        esp_rom
+        esp_timer
+)

--- a/soem/CMakeLists.txt
+++ b/soem/CMakeLists.txt
@@ -2,44 +2,50 @@ set(SOEM_ROOT "${CMAKE_CURRENT_LIST_DIR}/soem") #设置soem源码仓库根路径
 
 # -----------------------------------------------------------------------------------
 # SOEM的ec_options.h由模板ec_options.h.in在编译时生成
+
+# SOEM build-time resource limits
 set(EC_BUFSIZE EC_MAXECATFRAME)
-set(EC_MAXBUF 16)
-set(EC_MAXEEPBITMAP 128)
+set(EC_MAXBUF ${CONFIG_EC_MAXBUF})
+set(EC_MAXEEPBITMAP ${CONFIG_EC_MAXEEPBITMAP})
 set(EC_MAXEEPBUF "EC_MAXEEPBITMAP << 5")
-set(EC_LOGGROUPOFFSET 16)
-set(EC_MAXELIST 64)
-set(EC_MAXNAME 40)
-set(EC_MAXSLAVE 200)
-set(EC_MAXGROUP 2)
-set(EC_MAXIOSEGMENTS 64)
-set(EC_MAXMBX 1486)
-set(EC_MBXPOOLSIZE 32)
-set(EC_MAXEEPDO 0x200)
-set(EC_MAXSM 8)
-set(EC_MAXFMMU 4)
-set(EC_MAXLEN_ADAPTERNAME 128)
-set(EC_MAX_MAPT 1)
-set(EC_MAXODLIST 1024)
-set(EC_MAXOELIST 256)
-set(EC_SOE_MAXNAME 60)
-set(EC_SOE_MAXMAPPING 64)
+set(EC_LOGGROUPOFFSET ${CONFIG_EC_LOGGROUPOFFSET})
+set(EC_MAXELIST ${CONFIG_EC_MAXELIST})
+set(EC_MAXNAME ${CONFIG_EC_MAXNAME})
+set(EC_MAXSLAVE ${CONFIG_EC_MAXSLAVE})
+set(EC_MAXGROUP ${CONFIG_EC_MAXGROUP})
+set(EC_MAXIOSEGMENTS ${CONFIG_EC_MAXIOSEGMENTS})
+set(EC_MAXMBX ${CONFIG_EC_MAXMBX})
+set(EC_MBXPOOLSIZE ${CONFIG_EC_MBXPOOLSIZE})
+set(EC_MAXEEPDO ${CONFIG_EC_MAXEEPDO})
+set(EC_MAXSM ${CONFIG_EC_MAXSM})
+set(EC_MAXFMMU ${CONFIG_EC_MAXFMMU})
+set(EC_MAXLEN_ADAPTERNAME ${CONFIG_EC_MAXLEN_ADAPTERNAME})
+set(EC_MAX_MAPT ${CONFIG_EC_MAX_MAPT})
+set(EC_MAXODLIST ${CONFIG_EC_MAXODLIST})
+set(EC_MAXOELIST ${CONFIG_EC_MAXOELIST})
+set(EC_SOE_MAXNAME ${CONFIG_EC_SOE_MAXNAME})
+set(EC_SOE_MAXMAPPING ${CONFIG_EC_SOE_MAXMAPPING})
 
-set(EC_TIMEOUTRET 2000)                                         # 超时单位均为微秒
+# SOEM timeouts are expressed in microseconds
+set(EC_TIMEOUTRET ${CONFIG_EC_TIMEOUTRET})
 set(EC_TIMEOUTRET3 "EC_TIMEOUTRET * 3")
-set(EC_TIMEOUTSAFE 20000)
-set(EC_TIMEOUTEEP 20000)
-set(EC_TIMEOUTTXM 20000)
-set(EC_TIMEOUTRXM 700000)
-set(EC_TIMEOUTSTATE 2000000)
-set(EC_DEFAULTRETRIES 3)
+set(EC_TIMEOUTSAFE ${CONFIG_EC_TIMEOUTSAFE})
+set(EC_TIMEOUTEEP ${CONFIG_EC_TIMEOUTEEP})
+set(EC_TIMEOUTTXM ${CONFIG_EC_TIMEOUTTXM})
+set(EC_TIMEOUTRXM ${CONFIG_EC_TIMEOUTRXM})
+set(EC_TIMEOUTSTATE ${CONFIG_EC_TIMEOUTSTATE})
+set(EC_DEFAULTRETRIES ${CONFIG_EC_DEFAULTRETRIES})
 
-set(EC_PRIMARY_MAC_ARRAY "{0x0101, 0x0101, 0x0101}")            # 逻辑MAC，非网卡真实MAC
+# Logical MAC patterns used by SOEM for path identification
+set(EC_PRIMARY_MAC_ARRAY "{0x0101, 0x0101, 0x0101}")
 set(EC_SECONDARY_MAC_ARRAY "{0x0404, 0x0404, 0x0404}")
 
-configure_file(                                                 # 打开.in文件，把所有变量名替换成set值，写成新文件
-    "${SOEM_ROOT}/include/soem/ec_options.h.in"                 # 模板文件位置
-    "${CMAKE_CURRENT_BINARY_DIR}/include/soem/ec_options.h"     # 新文件输出位置，放在本次编译的产出build目录内
-)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    configure_file(                                                 # 打开.in文件，把所有变量名替换成set值，写成新文件
+        "${SOEM_ROOT}/include/soem/ec_options.h.in"                 # 模板文件位置
+        "${CMAKE_CURRENT_BINARY_DIR}/include/soem/ec_options.h"     # 新文件输出位置，放在本次编译的产出build目录内
+    )
+endif()
 
 # -----------------------------------------------------------------------------------
 set(SOEM_CORE_SOURCES
@@ -79,9 +85,7 @@ idf_component_register(
 
     REQUIRES                                        # 本组件公开头文件里需要的依赖
         esp_eth
-        freertos
 
     PRIV_REQUIRES                                   # 本组件内部实现所需的其它ESP-IDF组件依赖
-        esp_rom
         esp_timer
 )

--- a/soem/Kconfig
+++ b/soem/Kconfig
@@ -1,0 +1,115 @@
+menu "SOEM Configuration"
+
+    menu "Resource limits"
+
+        config EC_MAXBUF
+            int "Frame buffers per channel"
+            default 16
+
+        config EC_MAXEEPBITMAP
+            int "EEPROM bitmap cache size"
+            default 128
+
+        config EC_LOGGROUPOFFSET
+            int "Default group size exponent"
+            default 16
+
+        config EC_MAXELIST
+            int "Maximum error list entries"
+            default 64
+
+        config EC_MAXNAME
+            int "Maximum readable name length"
+            default 40
+
+        config EC_MAXSLAVE
+            int "Maximum number of slaves"
+            default 200
+
+        config EC_MAXGROUP
+            int "Maximum number of groups"
+            default 2
+
+        config EC_MAXIOSEGMENTS
+            int "Maximum IO segments per group"
+            default 64
+
+        config EC_MAXMBX
+            int "Maximum mailbox size"
+            default 1486
+
+        config EC_MBXPOOLSIZE
+            int "Number of mailboxes in pool"
+            default 32
+
+        config EC_MAXEEPDO
+            hex "Maximum EEPROM PDO entries"
+            default 0x200
+
+        config EC_MAXSM
+            int "Maximum Sync Managers per slave"
+            default 8
+
+        config EC_MAXFMMU
+            int "Maximum FMMUs per slave"
+            default 4
+
+        config EC_MAXLEN_ADAPTERNAME
+            int "Maximum adapter name length"
+            default 128
+
+        config EC_MAX_MAPT
+            int "Maximum concurrent mapping tasks"
+            default 1
+
+        config EC_MAXODLIST
+            int "Maximum Object Dictionary entries"
+            default 1024
+
+        config EC_MAXOELIST
+            int "Maximum Object Entry entries"
+            default 256
+
+        config EC_SOE_MAXNAME
+            int "Maximum SoE name length"
+            default 60
+
+        config EC_SOE_MAXMAPPING
+            int "Maximum SoE mappings"
+            default 64
+
+    endmenu
+
+    menu "Timeouts and retries"
+
+        config EC_TIMEOUTRET
+            int "Frame return timeout (us)"
+            default 2000
+
+        config EC_TIMEOUTSAFE
+            int "Safe return timeout (us)"
+            default 20000
+
+        config EC_TIMEOUTEEP
+            int "EEPROM access timeout (us)"
+            default 20000
+
+        config EC_TIMEOUTTXM
+            int "Mailbox transmit timeout (us)"
+            default 20000
+
+        config EC_TIMEOUTRXM
+            int "Mailbox receive timeout (us)"
+            default 700000
+
+        config EC_TIMEOUTSTATE
+            int "State transition timeout (us)"
+            default 2000000
+
+        config EC_DEFAULTRETRIES
+            int "Default number of retries"
+            default 3
+
+    endmenu
+
+endmenu

--- a/soem/LICENSE
+++ b/soem/LICENSE
@@ -1,0 +1,244 @@
+SOEM upstream license
+=====================
+
+The upstream SOEM sources under the soem/ directory and the adapted
+OSAL/OSHW files carrying the SOEM license notice are dual-licensed
+under GPLv3 and a commercial license.
+
+# Simple Open EtherCAT Master Library
+
+* Copyright (C) 2005-2025 Speciaal Machinefabriek Ketels v.o.f.
+* Copyright (C) 2005-2025 Arthur Ketels
+* Copyright (C) 2009-2025 RT-Labs AB, Sweden
+
+# License
+
+This software is dual-licensed.
+
+## GPL version 3
+
+This software is distributed under GPLv3. You are allowed to use this
+software for an open-source project with a compatible license.
+
+[GNU GPL license v3](https://www.gnu.org/licenses/gpl-3.0.html)
+
+## Commercial license
+
+This software is also available under a commercial license with
+options for support and maintenance. Please contact sales@rt-labs.com
+for further details.
+
+If you intend to use this stack in a commercial product, you likely need to
+buy a license.
+
+ESP-IDF integration code
+========================
+
+The independently developed ESP-IDF wrapper and example files that
+carry an SPDX-License-Identifier: Apache-2.0 notice are licensed under
+the Apache License 2.0.
+
+The adapted OSAL and OSHW port files retain the upstream SOEM
+dual-license notice.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/soem/README.md
+++ b/soem/README.md
@@ -1,0 +1,61 @@
+# SOEM for ESP-IDF
+
+This component ports [SOEM](https://github.com/OpenEtherCATsociety/SOEM), the Simple Open EtherCAT Master library, to ESP-IDF.
+
+The component is based on SOEM v2.0.0 and uses the ESP-IDF Ethernet driver to transmit and receive raw EtherCAT frames.
+
+## Add the component
+
+```bash
+idf.py add-dependency "espressif/soem^2.0.0"
+```
+
+Include the public header:
+
+```c
+#include "esp_soem.h"
+```
+
+## Basic usage
+
+The application is responsible for initializing and starting the Ethernet driver.
+
+Initialize SOEM with the Ethernet driver handle:
+
+```c
+ecx_contextt *context = esp_soem_init(eth_handle);
+if (context == NULL) {
+    /* Handle initialization failure. */
+}
+```
+
+The returned context can be used with standard SOEM context APIs:
+
+```c
+int slave_count = ecx_config_init(context);
+```
+
+Stop Ethernet reception before releasing the SOEM context:
+
+```c
+ESP_ERROR_CHECK(esp_eth_stop(eth_handle));
+esp_soem_deinit(context);
+```
+
+The Ethernet driver remains owned by the application.
+
+## Configuration
+
+SOEM resource limits and timeout values can be configured under **SOEM Configuration** in `idf.py menuconfig`.
+
+## Example
+
+The [ecat_io](examples/ecat_io) example demonstrates slave discovery, state transitions and cyclic process-data communication on ESP32-P4.
+
+## License
+
+The upstream SOEM library and adapted OSAL/OSHW files are dual-licensed under GPLv3 and a commercial license.
+
+The independently developed ESP-IDF wrapper and example are licensed under the Apache License 2.0.
+
+See [LICENSE](LICENSE) for details.

--- a/soem/examples/ecat_io/CMakeLists.txt
+++ b/soem/examples/ecat_io/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.22) # ask CMake for version >= 3.22
+cmake_minimum_required(VERSION 3.22)
 
-set(COMPONENTS main) # 缩小构建范围，从main组件开始构建(其依赖也要)
+set(COMPONENTS main)
 
-include($ENV{IDF_PATH}/tools/cmake/project.cmake) # add CMake build system designed for ESP-IDF
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-project(ecat_io) # define demo project name
+project(ecat_io)

--- a/soem/examples/ecat_io/CMakeLists.txt
+++ b/soem/examples/ecat_io/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.22) # ask CMake for version >= 3.22
+
+set(COMPONENTS main) # 缩小构建范围，从main组件开始构建(其依赖也要)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake) # add CMake build system designed for ESP-IDF
+
+project(ecat_io) # define demo project name

--- a/soem/examples/ecat_io/README.md
+++ b/soem/examples/ecat_io/README.md
@@ -1,0 +1,93 @@
+# EtherCAT digital IO example
+
+This example runs a SOEM EtherCAT master on ESP32-P4 and exchanges digital process data with one LAN9252 slave.
+
+Pressing SW1 turns LED3 on. Releasing SW1 turns LED3 off.
+
+## Hardware
+
+The example requires:
+
+- An ESP32-P4 using the internal EMAC
+- An external IP101 Ethernet PHY
+- One LAN9252 EtherCAT digital IO slave
+
+The example uses PHY address 1 and GPIO 51 as the PHY reset pin.
+
+Connect the ESP32-P4 Ethernet port to the EtherCAT input port of the slave.
+
+The expected slave identity is:
+
+- Vendor ID: `0x000004D8`
+- Product code: `0x0000000D`
+- Revision: `0x00000001`
+
+## Process-data mapping
+
+The example configures a fixed one-byte output and one-byte input mapping.
+
+Output:
+
+- Logical address: `0x00000000`
+- ESC physical address: `0x0F01`
+- SM0 and FMMU0
+- LED3 on bit 0, active high
+
+Input:
+
+- Logical address: `0x00000001`
+- ESC physical address: `0x1000`
+- SM1 and FMMU1
+- SW1 on bit 0, active low
+
+The mapping is configured directly because the tested slave does not support CoE PDO mapping.
+
+## Build and run
+
+Set up the ESP-IDF environment, then run:
+
+```bash
+cd soem/examples/ecat_io
+idf.py set-target esp32p4
+idf.py build
+idf.py -p PORT flash monitor
+```
+
+Replace `PORT` with the serial port connected to the ESP32-P4 board.
+
+## Expected behavior
+
+The example discovers and validates the slave, configures its process-data mapping and requests PRE-OP, SAFE-OP and OP states.
+
+In OP, LRW process-data communication runs every 10 ms. The input state of SW1 determines the output state of LED3.
+
+Communication stops if the Ethernet link is disconnected or an unexpected working counter is received.
+
+## Example output
+
+A successful startup and process-data exchange produces output similar to:
+
+```text
+I (2411) ecat_io: Ethernet Link Up
+I (2411) ecat_io: MAC XX:XX:XX:XX:XX:XX
+I (2411) ecat_io: SOEM initialized
+I (2411) ecat_io: 1 EtherCAT slave(s) found
+I (2411) ecat_io: Slave: vendor=0xXXXXXXXX, product=0xXXXXXXXX, revision=0xXXXXXXXX
+I (2421) ecat_io: Slave reached PRE-OP
+I (2421) ecat_io: Process-data mapping configured
+I (2421) ecat_io: Slave reached SAFE-OP
+I (2431) ecat_io: Slave reached OP
+I (2431) ecat_io: EtherCAT cyclic IO started
+I (2431) ecat_io: Press SW1: LED3 ON; release SW1: LED3 OFF
+I (2441) ecat_io: Cycle 0: input=0xff SW1=RELEASED, next output=0x00 LED3=OFF
+I (3891) ecat_io: Cycle 145: input=0xfe SW1=PRESSED, next output=0x01 LED3=ON
+I (4181) ecat_io: Cycle 174: input=0xff SW1=RELEASED, next output=0x00 LED3=OFF
+I (5071) ecat_io: Cycle 263: input=0xfe SW1=PRESSED, next output=0x01 LED3=ON
+I (6011) ecat_io: Cycle 357: input=0xff SW1=RELEASED, next output=0x00 LED3=OFF
+I (6731) ecat_io: Cycle 429: input=0xfe SW1=PRESSED, next output=0x01 LED3=ON
+I (8171) ecat_io: Cycle 573: input=0xff SW1=RELEASED, next output=0x00 LED3=OFF
+```
+
+## Limitations
+
+This example supports only the slave identity and fixed mapping described above. Other EtherCAT slaves require their own identity checks, process-data mapping and expected working counter.

--- a/soem/examples/ecat_io/main/CMakeLists.txt
+++ b/soem/examples/ecat_io/main/CMakeLists.txt
@@ -1,6 +1,4 @@
-# 定义main组件如何被编译，会被应用工程顶层cmakelists读取
-# -----------------------------------------------------------------------------------
-idf_component_register(             # 将当前目录注册为一个ESP-IDF组件
+idf_component_register(
     SRCS
         "ecat_io_example_main.c"
 
@@ -8,5 +6,5 @@ idf_component_register(             # 将当前目录注册为一个ESP-IDF组�
         soem
         esp_eth
         esp_event
-        freertos
+        esp_timer
 )

--- a/soem/examples/ecat_io/main/CMakeLists.txt
+++ b/soem/examples/ecat_io/main/CMakeLists.txt
@@ -1,0 +1,12 @@
+# 定义main组件如何被编译，会被应用工程顶层cmakelists读取
+# -----------------------------------------------------------------------------------
+idf_component_register(             # 将当前目录注册为一个ESP-IDF组件
+    SRCS
+        "ecat_io_example_main.c"
+
+    PRIV_REQUIRES
+        soem
+        esp_eth
+        esp_event
+        freertos
+)

--- a/soem/examples/ecat_io/main/ecat_io_example_main.c
+++ b/soem/examples/ecat_io/main/ecat_io_example_main.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "freertos/task.h"

--- a/soem/examples/ecat_io/main/ecat_io_example_main.c
+++ b/soem/examples/ecat_io/main/ecat_io_example_main.c
@@ -1,0 +1,939 @@
+/* 第一步，旨在完成以下工作，把ESP32P4的EMAC和IP101的PHY启动起来，确认物理链路LinkUp，
+把有效的eth_handle交给ecat master组件 */
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+
+#include "esp_soem.h" /* 本组件公开API */
+#include "esp_eth.h"
+#include "esp_event.h" /* eth link信号通过event loop发出*/
+#include "esp_log.h"
+
+#include <inttypes.h>
+#include <string.h>
+
+static const char *TAG = "ecat_io"; /* 给日志加一个模块名字 */
+
+/* PHY Link Up事件到达后置位 */
+#define ETH_LINK_UP_BIT BIT0 /* 人为定义，ETH PHY LINKUP事件由BIT0标识 */
+
+/* ECAT从站身份常量，取决于从站ESI/SII信息 */
+#define EXPECTED_VENDOR_ID  0x000004D8u
+#define EXPECTED_PRODUCT_ID 0x0000000Du
+#define EXPECTED_REVISION   0x00000001u
+
+/* 地址常量 */
+#define OUTPUT_PHYS_ADDR 0x0F01u /* ESC的放RxPDO的起始物理地址，会配置由SM0管理，FMMU映射 */
+#define INPUT_PHYS_ADDR  0x1000u /* ESC的放TxPDO的起始物理地址，会配置由SM1管理，FMMU映射 */
+
+#define OUTPUT_LOG_ADDR  0x00000000u /* ECAT网络放现场侧输出数据的逻辑地址 */
+#define INPUT_LOG_ADDR   0x00000001u /* ECAT网络放现场侧输入数据的逻辑地址 */
+
+/* 探针常量，测试用 */
+#define PROBE_CYCLES       500  /* 探针测试周期数 */
+#define PROBE_PERIOD_MS    10   /* 探针测试周期时长 */
+#define EXPECTED_LRW_WKC   3    /* 探针测试周期内期望收到的WKC数，LWR命令向从站写成功+2,读成功+1 */
+
+/* 正式ECAT_IO闭环运行参数*/
+#define IO_CYCLE_PERIOD_MS             10   /* IO闭环周期时长 */
+#define IO_EXPECTED_WKC                3    /* IO闭环周期内期望收到的WKC数，LWR命令向从站写成功+2,读成功+1 */
+#define IO_MAX_CONSECUTIVE_WKC_ERRORS  3    /* IO闭环连续LRW WKC错误次数允许上限 */
+
+#define SW1_INPUT_MASK                 0x01u
+#define LED3_OUTPUT_MASK               0x01u
+
+static EventGroupHandle_t s_eth_events; /* 事件组句柄，事件组暂时理解成一个由很多bit组成的事件状态板；
+                                        eth事件cb()里SET，app_main()里WAIT */
+
+/*
+ * ecx_contextt很大，不能作为app_main局部变量放在任务栈中。
+ * static全局变量存放在BSS，并自动清零。
+ */
+static ecx_contextt s_ecat_context;
+
+static void eth_event_handler(void *arg,
+                              esp_event_base_t event_base,
+                              int32_t event_id,
+                              void *event_data)
+{
+    (void)arg;
+    (void)event_base;
+
+    esp_eth_handle_t eth_handle = *(esp_eth_handle_t *)event_data;
+
+    switch (event_id) {
+    case ETHERNET_EVENT_CONNECTED: {
+        uint8_t mac_addr[6] = {0};
+
+        (void)esp_eth_ioctl(eth_handle, ETH_CMD_G_MAC_ADDR, mac_addr);
+        ESP_LOGI(TAG, "Ethernet Link Up");
+        ESP_LOGI(TAG, "MAC %02x:%02x:%02x:%02x:%02x:%02x",
+                 mac_addr[0], mac_addr[1], mac_addr[2],
+                 mac_addr[3], mac_addr[4], mac_addr[5]);
+        xEventGroupSetBits(s_eth_events, ETH_LINK_UP_BIT);
+        break;
+    }
+
+    case ETHERNET_EVENT_DISCONNECTED:
+        ESP_LOGW(TAG, "Ethernet Link Down");
+        xEventGroupClearBits(s_eth_events, ETH_LINK_UP_BIT);
+        break;
+
+    default:
+        break;
+    }
+}
+
+static esp_err_t eth_init(esp_eth_handle_t *eth_handle_out)
+{
+    if (eth_handle_out == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+    eth_esp32_emac_config_t emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+
+    /*
+     * P4默认EMAC配置已经包含：
+     * MDC=31、MDIO=52、RMII REF_CLK=50，
+     * TX_EN=49、TXD0=34、TXD1=35、
+     * CRS_DV=28、RXD0=29、RXD1=30。
+     */
+    phy_config.phy_addr = 1;
+    phy_config.reset_gpio_num = 51;
+
+    esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&emac_config, &mac_config);
+    if (mac == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    /* IDF v6使用IEEE 802.3通用PHY驱动支持IP101 */
+    esp_eth_phy_t *phy = esp_eth_phy_new_generic(&phy_config);
+    if (phy == NULL) {
+        mac->del(mac);
+        return ESP_ERR_NO_MEM;
+    }
+
+    esp_eth_config_t eth_config = ETH_DEFAULT_CONFIG(mac, phy);
+    esp_eth_handle_t eth_handle = NULL;
+    esp_err_t ret = esp_eth_driver_install(&eth_config, &eth_handle);
+    if (ret != ESP_OK) {
+        mac->del(mac);
+        phy->del(phy);
+        return ret;
+    }
+
+    *eth_handle_out = eth_handle;
+    return ESP_OK;
+}
+
+/*
+手动配置从站ESC#1的过程数据通道；
+告诉SM哪两个ESC本地RAM区域分别用于1Byte输入和1Byte输出；
+再告诉FMMU把ECAT网络逻辑地址0和1映射到这两个本地物理地址；
+最后把同样的信息同步到SOEM自己的slavelist里。
+常见CoE从站是SM0 = Mailbox 主→从，SM1 = Mailbox 从→主，SM2 = Process Output，SM3 = Process Input；
+但ECAT没有规定SM0 SM1必须用作邮箱通信，而且现在的从站没有CoE功能，所以把SM0 SM1用作过程数据通信。
+这个函数既要通过ecat报文指令改真实硬件，又要改SOEM软件记录。
+变量命名站在从站角度，IN/OUT指现场侧输入输出，Rx/Tx指ECAT通信侧接收发送。
+*/
+static int configure_runtime_mapping(uint16 slave_number)
+{
+    ec_slavet *slave = &s_ecat_context.slavelist[slave_number]; /* SOEM扫描完以后维护的从站描述表 */
+    uint16 config_address = slave->configadr; /* 前面扫描、初始化时SOEM给这个从站分配过配置地址，可用FRxx指令*/
+
+    ec_smt sm_output; /* 一整组SyncManager配置寄存器的数据结构 */
+    ec_smt sm_input;
+    ec_fmmut fmmu_output; /* 一系列逻辑地址与物理地址映射规则所需的参数 */
+    ec_fmmut fmmu_input;
+
+    memset(&sm_output, 0, sizeof(sm_output)); /* 主动初始化，避免栈上随机垃圾值 */
+    memset(&sm_input, 0, sizeof(sm_input));
+    memset(&fmmu_output, 0, sizeof(fmmu_output));
+    memset(&fmmu_input, 0, sizeof(fmmu_input));
+
+    /* P4小端存储，ECAT小端解读；
+    SM0用作管理主站到从站的1字节输出过程数据的内存；SM1用作管理从站到主站的1字节输入过程数据的内存。*/
+    sm_output.StartAddr = htoes(OUTPUT_PHYS_ADDR); /* 起始物理地址 */
+    sm_output.SMlength = htoes(1); /* 管理字节数 */
+    sm_output.SMflags = htoel(0x00010044u); /* Control，Status，Activate，PDI Ctrl；Control里配置SM模式、SM方向等 */
+
+    sm_input.StartAddr = htoes(INPUT_PHYS_ADDR);
+    sm_input.SMlength = htoes(1);
+    sm_input.SMflags = htoel(0x00010000u);
+
+    /* 对config_address这个从站，用FPWR报文指令从ESC的SM0寄存器起始地址开始，
+    写入整个sm_output结构体，最多允许6000us完成整套FPWR的发送和等待对应返回帧；
+    ecx_FPWR()返回的软件wkc，<0代表没收到返回帧，=0代表收到返回帧但没从站处理过，皆需报错*/
+    int wkc = ecx_FPWR(
+        &s_ecat_context.port,
+        config_address,
+        ECT_REG_SM0,
+        sizeof(sm_output),
+        &sm_output,
+        EC_TIMEOUTRET3);
+    ESP_LOGI(TAG, "Program SM0 WKC=%d", wkc);
+    if (wkc <= 0) {
+        return 0;
+    }
+
+    wkc = ecx_FPWR(
+        &s_ecat_context.port,
+        config_address,
+        ECT_REG_SM1,
+        sizeof(sm_input),
+        &sm_input,
+        EC_TIMEOUTRET3);
+    ESP_LOGI(TAG, "Program SM1 WKC=%d", wkc);
+    if (wkc <= 0) {
+        return 0;
+    }
+
+    /* FMMU0：逻辑字节0映射到物理输出0x0F01 */
+    fmmu_output.LogStart = htoel(OUTPUT_LOG_ADDR); /* 映射的逻辑地址起始地址*/
+    fmmu_output.LogLength = htoes(1); /* 映射的字节数 */
+    fmmu_output.LogStartbit = 0; /* 除了整Byte映射外，还支持截断Byte映射，也就是位级映射*/
+    fmmu_output.LogEndbit = 7; /* Length决定跨多少各Byte，Startbit决定第一个Byte从哪一位开始，Endbit决定最后一个Byte从哪一位结束 */
+    fmmu_output.PhysStart = htoes(OUTPUT_PHYS_ADDR); /* 映射的物理地址起始地址*/
+    fmmu_output.PhysStartBit = 0; /* 映射的物理地址起始位 */
+    fmmu_output.FMMUtype = 2; /* 映射的方向，1=逻辑读，2=逻辑写 */
+    fmmu_output.FMMUactive = 1; /* 1=激活映射 */
+
+    /* FMMU1：物理输入0x1000映射到逻辑字节1 */
+    fmmu_input.LogStart = htoel(INPUT_LOG_ADDR);
+    fmmu_input.LogLength = htoes(1);
+    fmmu_input.LogStartbit = 0;
+    fmmu_input.LogEndbit = 7;
+    fmmu_input.PhysStart = htoes(INPUT_PHYS_ADDR);
+    fmmu_input.PhysStartBit = 0;
+    fmmu_input.FMMUtype = 1;
+    fmmu_input.FMMUactive = 1;
+
+    wkc = ecx_FPWR(
+        &s_ecat_context.port,
+        config_address,
+        ECT_REG_FMMU0,
+        sizeof(fmmu_output),
+        &fmmu_output,
+        EC_TIMEOUTRET3);
+    ESP_LOGI(TAG, "Program FMMU0 WKC=%d", wkc);
+    if (wkc <= 0) {
+        return 0;
+    }
+
+    wkc = ecx_FPWR(
+        &s_ecat_context.port,
+        config_address,
+        ECT_REG_FMMU1,
+        sizeof(fmmu_input),
+        &fmmu_input,
+        EC_TIMEOUTRET3);
+    ESP_LOGI(TAG, "Program FMMU1 WKC=%d", wkc);
+    if (wkc <= 0) {
+        return 0;
+    }
+
+    /* 同步SOEM内存中的从站描述 */
+    slave->SM[0] = sm_output;
+    slave->SM[1] = sm_input;
+    slave->SMtype[0] = 3; /* 1=MailboxWrite, 2=MailboxRead */
+    slave->SMtype[1] = 4; /* 3=ProcessDataOutput, 4=ProcessDataInput */
+    slave->Obits = 8;
+    slave->Ibits = 8;
+    slave->Obytes = 1;
+    slave->Ibytes = 1;
+
+    slave->FMMU[0] = fmmu_output;
+    slave->FMMU[1] = fmmu_input;
+    slave->FMMUunused = 2; /* 下一个空闲的FMMU编号，0和1我们用了，下个从2开始 */
+
+    ESP_LOGI(TAG, "Runtime SM/FMMU mapping programmed");
+    return 1;
+}
+
+/*
+请求某个从站切换到指定ECAT状态，然后严格确认它最终“干净地”进入该状态，不能带ERROR位，AL状态码也必须为0；
+OP状态必须用专门的函数，因为OP转换必须要有持续周期通信要求；
+*/
+static int request_clean_state(uint16 slave_number,
+                               uint16 requested_state)
+{
+    ec_slavet *slave = &s_ecat_context.slavelist[slave_number];
+
+    slave->state = requested_state; /* 设目标状态，先在SOEM内存里写“我想要什么状态” */
+
+    int wkc = ecx_writestate(&s_ecat_context, slave_number); /* 向ESC发状态切换命令 */
+    ESP_LOGI(TAG,
+             "State request 0x%02x WKC=%d",
+             requested_state,
+             wkc);
+
+    if (wkc <= 0) {
+        return 0;
+    }
+
+    /* 函数内部不断读取从站AL Status，发现是目标状态了就返回，发现还不是就继续检查，直到超时返回 */
+    (void)ecx_statecheck(
+        &s_ecat_context,
+        slave_number,
+        requested_state,
+        EC_TIMEOUTSTATE);
+
+    vTaskDelay(pdMS_TO_TICKS(20)); /* 阻塞延迟，给ESC时间让状态切换命令产生作用、状态稳定下来，感觉没必要 */
+    /* 函数内部会读取全部从站状态并更新 ec_slave/slavelist；
+    不拿ecx_statecheck()的返回值作为最终成功标准，因为它只检查AL基础状态，会忽略0x10 ERROR位 */
+    (void)ecx_readstate(&s_ecat_context);
+
+    ESP_LOGI(TAG,
+             "State result: state=0x%04x, "
+             "AL status=0x%04x (%s)",
+             slave->state,
+             slave->ALstatuscode,
+             ec_ALstatuscode2string(slave->ALstatuscode));
+
+    /* 最终真正严格判断 */
+    return (slave->state == requested_state) &&
+           (slave->ALstatuscode == 0);
+}
+
+/* 请求某个从站进入OP状态，需要一边维持有效的过程数据通信，一边请求并确认进入OP；*/
+static int request_operational(uint16 slave_number,
+                               uint8 process_image[2])
+{
+    ec_slavet *slave = &s_ecat_context.slavelist[slave_number];
+
+    /* 请求OP前，先在SAFE-OP下发送10帧有效过程数据，先证明过程数据已经连续、稳定、有效 */
+    for (int cycle = 0; cycle < 10; cycle++) {
+        process_image[0] = 0x00;
+
+        int wkc = ecx_LRW(
+            &s_ecat_context.port,
+            OUTPUT_LOG_ADDR,
+            2,
+            process_image,
+            EC_TIMEOUTRET3);
+
+        if (wkc != IO_EXPECTED_WKC) {
+            ESP_LOGE(TAG,
+                     "SAFE-OP LRW before OP failed: cycle=%d WKC=%d",
+                     cycle,
+                     wkc);
+            return 0;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS));
+    }
+
+    slave->state = EC_STATE_OPERATIONAL;
+
+    int state_wkc = ecx_writestate(&s_ecat_context, slave_number); /*向ESC发送OP切换命令 */
+    ESP_LOGI(TAG, "OP state request WKC=%d", state_wkc);
+
+    if (state_wkc <= 0) {
+        return 0;
+    }
+
+    /* 请求OP后不能停止过程数据，一边持续LRW，一边检查状态是否到达OP，持续200个周期 */
+    for (int cycle = 0; cycle < 200; cycle++) {
+        process_image[0] = 0x00; //输出全零，保证安全
+
+        /* 向ESC发送LRW命令，读写过程数据 */
+        int wkc = ecx_LRW(
+            &s_ecat_context.port,
+            OUTPUT_LOG_ADDR,
+            2,
+            process_image,
+            EC_TIMEOUTRET3);
+
+        if (wkc != IO_EXPECTED_WKC) {
+            ESP_LOGE(TAG,
+                     "OP transition LRW failed: cycle=%d WKC=%d",
+                     cycle,
+                     wkc);
+            return 0;
+        }
+
+        /* 函数内部不断读取从站AL Status，发现是目标状态了就返回，发现还不是就继续检查，直到超时返回；
+        很可能每次都耗满3ms； */
+        uint16 reached_state = ecx_statecheck(
+            &s_ecat_context,
+            slave_number,
+            EC_STATE_OPERATIONAL,
+            EC_TIMEOUTRET);
+
+        if (reached_state == EC_STATE_OPERATIONAL) {
+            break;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS));
+    }
+
+    (void)ecx_readstate(&s_ecat_context);
+
+    ESP_LOGI(TAG,
+             "OP state result: state=0x%04x, "
+             "AL status=0x%04x (%s)",
+             slave->state,
+             slave->ALstatuscode,
+             ec_ALstatuscode2string(slave->ALstatuscode));
+
+    return (slave->state == EC_STATE_OPERATIONAL) &&
+           (slave->ALstatuscode == 0);
+}
+
+void app_main(void)
+{
+    esp_eth_handle_t eth_handle = NULL;
+
+    s_eth_events = xEventGroupCreate();
+    ESP_ERROR_CHECK(s_eth_events != NULL ? ESP_OK : ESP_ERR_NO_MEM);
+
+    /* esp_eth_start()会发布Ethernet事件，因此必须先创建默认事件循环 */
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    ESP_ERROR_CHECK(esp_event_handler_register(
+        ETH_EVENT, ESP_EVENT_ANY_ID, eth_event_handler, NULL));
+
+    ESP_ERROR_CHECK(eth_init(&eth_handle));
+    ESP_ERROR_CHECK(esp_eth_start(eth_handle));
+
+    EventBits_t bits = xEventGroupWaitBits(
+        s_eth_events,
+        ETH_LINK_UP_BIT,
+        pdFALSE,
+        pdTRUE,
+        pdMS_TO_TICKS(10000));
+
+    if ((bits & ETH_LINK_UP_BIT) == 0) {
+        ESP_LOGE(TAG, "Ethernet Link Up timeout");
+        return;
+    }
+
+    /* 只把应用拥有的句柄交给组件借用；尚未启动SOEM */
+    ESP_ERROR_CHECK(esp_soem_bind_eth(eth_handle));
+    ESP_LOGI(TAG, "esp_eth handle bound to SOEM nicdrv");
+
+    /*
+    * "esp_eth"是我们约定的适配器名字。
+    * ecx_init最终调用自己移植的ecx_setupnic()，挂接RX回调并初始化端口。
+    */
+    if (!ecx_init(&s_ecat_context, "esp_eth")) {
+        ESP_LOGE(TAG, "SOEM port initialization failed");
+        return;
+    }
+    ESP_LOGI(TAG, "SOEM port initialized");
+
+    /*
+    * 扫描EtherCAT总线、分配从站配置地址、读取基本SII信息，
+    * 并尝试让从站进入PRE-OP。
+    */
+    int slave_count = ecx_config_init(&s_ecat_context);
+    if (slave_count <= 0) {
+        ESP_LOGE(TAG, "No EtherCAT slaves found");
+        ecx_close(&s_ecat_context);
+        return;
+    }
+
+    ESP_LOGI(TAG, "%d EtherCAT slave(s) found", slave_count);
+
+    /* 扫描后限制只能连接这一块板 */
+    if (slave_count != 1) {
+        ESP_LOGE(TAG, "Expected exactly one EtherCAT slave");
+        ecx_close(&s_ecat_context);
+        return;
+    }
+
+    /* PRE-OP检查循环 */
+    for (int i = 1; i <= slave_count; i++) {
+        /*
+         * 先等待从站进入PRE-OP。
+         * ecx_statecheck只用状态低四位判断，因此它可能在ERROR位清除前返回。
+         */
+        (void)ecx_statecheck(
+            &s_ecat_context,
+            (uint16)i,
+            EC_STATE_PRE_OP,
+            EC_TIMEOUTSTATE);
+
+        /*
+         * 给从站一点时间处理状态变化，然后重新读取完整状态和AL Status Code。
+         */
+        vTaskDelay(pdMS_TO_TICKS(20));
+
+        int lowest_state = ecx_readstate(&s_ecat_context);
+        ec_slavet *slave = &s_ecat_context.slavelist[i];
+        /* 从站身份检查 */
+        if ((slave->eep_man != EXPECTED_VENDOR_ID) ||
+            (slave->eep_id != EXPECTED_PRODUCT_ID) ||
+            (slave->eep_rev != EXPECTED_REVISION)) {
+            ESP_LOGE(TAG,
+                     "Unexpected slave identity; refusing register configuration");
+            ecx_close(&s_ecat_context);
+            return;
+        }
+
+        ESP_LOGI(TAG, "State refresh result=0x%02x", lowest_state);
+
+        ESP_LOGI(TAG,
+                 "Slave %d: name='%s', state=0x%04x, config=0x%04x, "
+                 "vendor=0x%08" PRIx32 ", product=0x%08" PRIx32
+                 ", revision=0x%08" PRIx32,
+                 i,
+                 slave->name,
+                 slave->state,
+                 slave->configadr,
+                 slave->eep_man,
+                 slave->eep_id,
+                 slave->eep_rev);
+
+        ESP_LOGI(TAG,
+                 "Slave %d AL status: 0x%04x (%s)",
+                 i,
+                 slave->ALstatuscode,
+                 ec_ALstatuscode2string(slave->ALstatuscode));
+
+        if (((slave->state & 0x000f) != EC_STATE_PRE_OP) ||
+            ((slave->state & EC_STATE_ERROR) != 0)) {
+            ESP_LOGW(TAG,
+                    "Slave %d needs AL error acknowledge: "
+                    "state=0x%04x, AL status=0x%04x (%s)",
+                    i,
+                    slave->state,
+                    slave->ALstatuscode,
+                    ec_ALstatuscode2string(slave->ALstatuscode));
+
+            /*
+            * 按当前基础状态PRE-OP，加上ACK位写入AL Control。
+            * 这里只确认状态错误，不涉及EEPROM、SM或FMMU。
+            */
+            slave->state =
+            (slave->state & 0x000f) | EC_STATE_ACK;
+
+            int ack_wkc = ecx_writestate(&s_ecat_context, (uint16)i);
+            ESP_LOGI(TAG, "AL error acknowledge WKC=%d", ack_wkc);
+
+            if (ack_wkc <= 0) {
+                ESP_LOGE(TAG, "Failed to send AL error acknowledge");
+                ecx_close(&s_ecat_context);
+                return;
+            }
+
+            vTaskDelay(pdMS_TO_TICKS(20));
+            (void)ecx_readstate(&s_ecat_context);
+
+            ESP_LOGI(TAG,
+                    "After ACK: state=0x%04x, AL status=0x%04x (%s)",
+                    slave->state,
+                    slave->ALstatuscode,
+                    ec_ALstatuscode2string(slave->ALstatuscode));
+
+            /*
+            * ACK已成功写入，但ERROR位仍保留。
+            * 再写一次不带ACK位的纯PRE-OP请求，观察状态位是否清除。
+            */
+            slave->state = EC_STATE_PRE_OP;
+
+            int preop_wkc =
+                ecx_writestate(&s_ecat_context, (uint16)i);
+            ESP_LOGI(TAG, "Clean PRE-OP request WKC=%d", preop_wkc);
+
+            if (preop_wkc <= 0) {
+                ESP_LOGE(TAG, "Failed to send clean PRE-OP request");
+                ecx_close(&s_ecat_context);
+                return;
+            }
+
+            vTaskDelay(pdMS_TO_TICKS(20));
+            (void)ecx_readstate(&s_ecat_context);
+
+            ESP_LOGI(TAG,
+                    "After clean PRE-OP request: "
+                    "state=0x%04x, AL status=0x%04x (%s)",
+                    slave->state,
+                    slave->ALstatuscode,
+                    ec_ALstatuscode2string(slave->ALstatuscode));
+        }
+
+        if ((slave->state != EC_STATE_PRE_OP) ||
+        (slave->ALstatuscode != 0)) {
+            ESP_LOGE(TAG,
+                    "Slave %d failed to reach clean PRE-OP: "
+                    "state=0x%04x, AL status=0x%04x (%s)",
+                    i,
+                    slave->state,
+                    slave->ALstatuscode,
+                    ec_ALstatuscode2string(slave->ALstatuscode));
+            ecx_close(&s_ecat_context);
+            return;
+        }
+
+        ESP_LOGI(TAG, "Slave %d reached clean PRE-OP", i);
+    }
+
+    /* 在从站已经处于PRE-OP后，手工写入SM/FMMU配置，然后重新读取从站状态，
+    确认这次配置没有把从站“配坏”。如果出现AL错误或掉出PRE-OP，就立即停止 */
+    if (!configure_runtime_mapping(1)) {
+        ESP_LOGE(TAG, "Runtime SM/FMMU mapping failed");
+        ecx_close(&s_ecat_context);
+        return;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(20)); /* blocking delay，给从站ESC一点时间，让刚写进去的配置产生作用、状态稳定下来 */
+    (void)ecx_readstate(&s_ecat_context); /*重新读取各从站AL Status及其Code，更新soem内存中的描述 */
+
+    ec_slavet *slave = &s_ecat_context.slavelist[1];
+    ESP_LOGI(TAG,
+             "After mapping: state=0x%04x, AL status=0x%04x (%s)",
+             slave->state,
+             slave->ALstatuscode,
+             ec_ALstatuscode2string(slave->ALstatuscode));
+
+    if ((slave->state != EC_STATE_PRE_OP) || /* 配置完后仍然处于pre-op阶段 */
+        (slave->ALstatuscode != 0)) { /* AL Status Code全零，表示没有错误*/
+        ESP_LOGE(TAG, "Slave left clean PRE-OP after mapping");
+        ecx_close(&s_ecat_context);
+        return;
+    }
+
+    /* 请求从站进入SAFE-OP状态 */
+    ESP_LOGI(TAG, "Requesting SAFE-OP");
+
+    if (!request_clean_state(1, EC_STATE_SAFE_OP)) {
+        ESP_LOGE(TAG, "Slave did not reach clean SAFE-OP");
+        ecx_close(&s_ecat_context);
+        return;
+    }
+
+    ESP_LOGI(TAG, "Slave reached clean SAFE-OP");
+
+    /* SAFE_OP LRW探针测试，验证整条Process Data数据链路能真的跑通 */
+    #if 0
+    /* 临时创建过程数据映射数组，就是ECAT网络逻辑地址虚拟内存数组 */
+    uint8 process_image[2] = {0x00, 0x00};
+    /* 控制日志输出，每个周期都打印会很吵，只在1st或者Input数据变化的时候打印log */
+    uint8 previous_input = 0; /* 上次输入数据 */
+    int first_input = 1; /* 是否是第一次输入 */
+
+    /* 统计各种wkc，不只是想知道有没有失败，更想知道每次失败的具体表现；一切为了probe诊断 */
+    int wkc_0 = 0;
+    int wkc_1 = 0;
+    int wkc_2 = 0;
+    int wkc_3 = 0;
+    int wkc_other = 0;
+
+    ESP_LOGI(TAG, "Starting five-second SAFE-OP LRW probe");
+    ESP_LOGI(TAG, "Output is fixed at 0x00; press and release SW1");
+
+    for (int cycle = 0; cycle < PROBE_CYCLES; cycle++) {
+        /* 逻辑字节0是输出，每次强制为0。LRW返回后，逻辑字节1包含从站输入。*/
+        process_image[0] = 0x00;
+
+        int wkc = ecx_LRW(
+            &s_ecat_context.port,
+            OUTPUT_LOG_ADDR,
+            sizeof(process_image),
+            process_image,
+            EC_TIMEOUTRET3);
+
+        switch (wkc) {
+        case 0:
+            wkc_0++;
+            break;
+        case 1:
+            wkc_1++;
+            break;
+        case 2:
+            wkc_2++;
+            break;
+        case EXPECTED_LRW_WKC:
+            wkc_3++;
+            break;
+        default:
+            wkc_other++;
+            break;
+        }
+
+        if ((wkc == EXPECTED_LRW_WKC) &&
+            (first_input || process_image[1] != previous_input)) {
+            ESP_LOGI(TAG,
+                    "Cycle %d: WKC=%d input=0x%02x",
+                    cycle,
+                    wkc,
+                    process_image[1]);
+
+            previous_input = process_image[1];
+            first_input = 0;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(PROBE_PERIOD_MS)); /* 阻塞延迟，让探针周期性运行；当前并非精准ECAT周期控制 */
+    }
+
+    ESP_LOGI(TAG,
+            "WKC summary: 0=%d 1=%d 2=%d 3=%d other=%d",
+            wkc_0,
+            wkc_1,
+            wkc_2,
+            wkc_3,
+            wkc_other);
+
+    /* 全部探针周期跑完后，再次读取ESC AL状态，确认5s持续LRW不会让从站状态机出错 */
+    (void)ecx_readstate(&s_ecat_context);
+    slave = &s_ecat_context.slavelist[1];
+
+    ESP_LOGI(TAG,
+            "After SAFE-OP probe: state=0x%04x, "
+            "AL status=0x%04x (%s)",
+            slave->state,
+            slave->ALstatuscode,
+            ec_ALstatuscode2string(slave->ALstatuscode));
+
+    if ((wkc_3 != PROBE_CYCLES) ||
+        (slave->state != EC_STATE_SAFE_OP) ||
+        (slave->ALstatuscode != 0)) {
+        ESP_LOGE(TAG, "SAFE-OP LRW probe failed");
+    } else {
+        ESP_LOGI(TAG, "SAFE-OP LRW probe passed");
+    }
+    #endif
+
+    ESP_LOGI(TAG, "Requesting OPERATIONAL with continuous LRW");
+    uint8 process_image[2] = {0x00, 0x00};
+    if (!request_operational(1, process_image)) {
+        ESP_LOGE(TAG, "Slave did not reach clean OPERATIONAL");
+
+        (void)request_clean_state(1, EC_STATE_INIT);
+        ecx_close(&s_ecat_context);
+        return;
+    }
+
+    ESP_LOGI(TAG, "Slave reached clean OPERATIONAL");
+
+    /* OP LRW探针测试 */
+    #if 0
+    ESP_LOGI(TAG, "Starting five-second OP probe; output fixed at 0x00");
+
+    int op_wkc_good = 0;
+    int op_wkc_bad = 0;
+    uint8 previous_op_input = process_image[1];
+    int first_op_input = 1;
+
+    for (int cycle = 0; cycle < PROBE_CYCLES; cycle++) {
+        /* OP期间仍然始终强制输出为0。 */
+        process_image[0] = 0x00;
+
+        int wkc = ecx_LRW(
+            &s_ecat_context.port,
+            OUTPUT_LOG_ADDR,
+            sizeof(process_image),
+            process_image,
+            EC_TIMEOUTRET3);
+
+        if (wkc == EXPECTED_LRW_WKC) {
+            op_wkc_good++;
+        } else {
+            op_wkc_bad++;
+        }
+
+        if ((wkc == EXPECTED_LRW_WKC) &&
+            (first_op_input ||
+            process_image[1] != previous_op_input)) {
+            ESP_LOGI(TAG,
+                    "OP cycle %d: WKC=%d input=0x%02x",
+                    cycle,
+                    wkc,
+                    process_image[1]);
+
+            previous_op_input = process_image[1];
+            first_op_input = 0;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(PROBE_PERIOD_MS));
+    }
+
+    (void)ecx_readstate(&s_ecat_context);
+    slave = &s_ecat_context.slavelist[1];
+
+    ESP_LOGI(TAG,
+            "OP WKC summary: good=%d bad=%d",
+            op_wkc_good,
+            op_wkc_bad);
+
+    ESP_LOGI(TAG,
+            "After OP probe: state=0x%04x, "
+            "AL status=0x%04x (%s)",
+            slave->state,
+            slave->ALstatuscode,
+            ec_ALstatuscode2string(slave->ALstatuscode));
+
+    if ((op_wkc_good != PROBE_CYCLES) ||
+        (slave->state != EC_STATE_OPERATIONAL) ||
+        (slave->ALstatuscode != 0)) {
+        ESP_LOGE(TAG, "OP LRW probe failed");
+    } else {
+        ESP_LOGI(TAG, "OP LRW probe passed");
+    }
+    #endif
+
+    // /* example结束前返回 INIT */
+    // ESP_LOGI(TAG, "Returning slave to INIT");
+
+    // if (!request_clean_state(1, EC_STATE_INIT)) {
+    //     ESP_LOGE(TAG, "Slave did not return to clean INIT");
+    //     ecx_close(&s_ecat_context);
+    //     return;
+    // }
+
+    // ecx_close(&s_ecat_context);
+    // ESP_LOGI(TAG, "SOEM port closed");
+
+    /*
+    * 正式闭环：
+    * SW1输入bit 0低有效；
+    * LED3输出bit 0高有效。
+    *
+    * 首个周期输出固定为0。每次成功LRW读取当前输入后，
+    * 计算下一周期的输出，因此存在一个周期的正常闭环延迟。
+    */
+    uint8 next_output = 0x00;
+    uint8 previous_input = 0;
+    int first_input = 1;
+    int consecutive_wkc_errors = 0;
+    uint32_t cycle = 0;
+    int communication_healthy = 1;
+
+    TickType_t last_wake_time = xTaskGetTickCount();
+
+    ESP_LOGI(TAG, "EtherCAT closed-loop IO started");
+    ESP_LOGI(TAG, "Press SW1: LED3 ON; release SW1: LED3 OFF");
+
+    while ((xEventGroupGetBits(s_eth_events) &
+            ETH_LINK_UP_BIT) != 0) {
+        /*
+        * 使用上个周期根据输入计算出的输出值。
+        * 启动时next_output为0，保证LED默认关闭。
+        */
+        process_image[0] = next_output;
+
+        int wkc = ecx_LRW(
+            &s_ecat_context.port,
+            OUTPUT_LOG_ADDR,
+            sizeof(process_image),
+            process_image,
+            EC_TIMEOUTRET3);
+
+        if (wkc != IO_EXPECTED_WKC) {
+            consecutive_wkc_errors++;
+
+            ESP_LOGW(TAG,
+                    "Cycle %" PRIu32 ": unexpected WKC=%d "
+                    "(consecutive=%d)",
+                    cycle,
+                    wkc,
+                    consecutive_wkc_errors);
+
+            if (consecutive_wkc_errors >=
+                IO_MAX_CONSECUTIVE_WKC_ERRORS) {
+                ESP_LOGE(TAG,
+                        "Too many consecutive WKC errors; "
+                        "stopping closed-loop IO");
+
+                communication_healthy = 0;
+                break;
+            }
+        } else {
+            consecutive_wkc_errors = 0;
+
+            uint8 current_input = process_image[1];
+            int sw1_pressed =
+                (current_input & SW1_INPUT_MASK) == 0;
+
+            next_output = sw1_pressed
+                ? LED3_OUTPUT_MASK
+                : 0x00;
+
+            if (first_input ||
+                current_input != previous_input) {
+                ESP_LOGI(TAG,
+                        "Cycle %" PRIu32 ": "
+                        "input=0x%02x SW1=%s, "
+                        "next output=0x%02x LED3=%s",
+                        cycle,
+                        current_input,
+                        sw1_pressed ? "PRESSED" : "RELEASED",
+                        next_output,
+                        sw1_pressed ? "ON" : "OFF");
+
+                previous_input = current_input;
+                first_input = 0;
+            }
+        }
+
+        cycle++;
+
+        /*
+        * 相比vTaskDelay，以固定唤醒基准运行，
+        * 避免每个周期额外累积LRW执行时间。
+        */
+        vTaskDelayUntil(
+            &last_wake_time,
+            pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS));
+    }
+
+    ESP_LOGW(TAG, "EtherCAT closed-loop IO stopped");
+
+    /*
+    * 链路仍在时，尽力发送10帧零输出，
+    * 确保LED3在退出OP前关闭。
+    */
+    if (communication_healthy &&
+        ((xEventGroupGetBits(s_eth_events) &
+          ETH_LINK_UP_BIT) != 0)) {
+        ESP_LOGI(TAG, "Forcing output to 0x00");
+
+        for (int i = 0; i < 10; i++) {
+            process_image[0] = 0x00;
+
+            int wkc = ecx_LRW(
+                &s_ecat_context.port,
+                OUTPUT_LOG_ADDR,
+                sizeof(process_image),
+                process_image,
+                EC_TIMEOUTRET3);
+
+            if (wkc != IO_EXPECTED_WKC) {
+                ESP_LOGW(TAG,
+                        "Zero-output cleanup WKC=%d",
+                        wkc);
+                break;
+            }
+
+            vTaskDelay(pdMS_TO_TICKS(
+                IO_CYCLE_PERIOD_MS));
+        }
+
+        /*
+        * 正常退出顺序：OP → SAFE-OP → INIT。
+        */
+        ESP_LOGI(TAG, "Returning slave to SAFE-OP");
+        if (!request_clean_state(
+                1, EC_STATE_SAFE_OP)) {
+            ESP_LOGE(TAG,
+                    "Failed to return slave to SAFE-OP");
+        }
+
+        ESP_LOGI(TAG, "Returning slave to INIT");
+        if (!request_clean_state(
+                1, EC_STATE_INIT)) {
+            ESP_LOGE(TAG,
+                    "Failed to return slave to INIT");
+        }
+    } else {
+        ESP_LOGW(TAG,
+                 "EtherCAT communication unavailable; "
+                 "skipping output and state cleanup");
+    }
+
+    ecx_close(&s_ecat_context);
+    ESP_LOGI(TAG, "SOEM port closed");
+}

--- a/soem/examples/ecat_io/main/ecat_io_example_main.c
+++ b/soem/examples/ecat_io/main/ecat_io_example_main.c
@@ -46,11 +46,8 @@ static const char *TAG = "ecat_io"; /* 给日志加一个模块名字 */
 static EventGroupHandle_t s_eth_events; /* 事件组句柄，事件组暂时理解成一个由很多bit组成的事件状态板；
                                         eth事件cb()里SET，app_main()里WAIT */
 
-/*
- * ecx_contextt很大，不能作为app_main局部变量放在任务栈中。
- * static全局变量存放在BSS，并自动清零。
- */
-static ecx_contextt s_ecat_context;
+/* SOEM allocates the context from the heap during initialization. */
+static ecx_contextt *s_ecat_context;
 
 static void eth_event_handler(void *arg,
                               esp_event_base_t event_base,
@@ -141,7 +138,7 @@ static esp_err_t eth_init(esp_eth_handle_t *eth_handle_out)
 */
 static int configure_runtime_mapping(uint16 slave_number)
 {
-    ec_slavet *slave = &s_ecat_context.slavelist[slave_number]; /* SOEM扫描完以后维护的从站描述表 */
+    ec_slavet *slave = &s_ecat_context->slavelist[slave_number]; /* SOEM扫描完以后维护的从站描述表 */
     uint16 config_address = slave->configadr; /* 前面扫描、初始化时SOEM给这个从站分配过配置地址，可用FRxx指令*/
 
     ec_smt sm_output; /* 一整组SyncManager配置寄存器的数据结构 */
@@ -168,7 +165,7 @@ static int configure_runtime_mapping(uint16 slave_number)
     写入整个sm_output结构体，最多允许6000us完成整套FPWR的发送和等待对应返回帧；
     ecx_FPWR()返回的软件wkc，<0代表没收到返回帧，=0代表收到返回帧但没从站处理过，皆需报错*/
     int wkc = ecx_FPWR(
-        &s_ecat_context.port,
+        &s_ecat_context->port,
         config_address,
         ECT_REG_SM0,
         sizeof(sm_output),
@@ -180,7 +177,7 @@ static int configure_runtime_mapping(uint16 slave_number)
     }
 
     wkc = ecx_FPWR(
-        &s_ecat_context.port,
+        &s_ecat_context->port,
         config_address,
         ECT_REG_SM1,
         sizeof(sm_input),
@@ -212,7 +209,7 @@ static int configure_runtime_mapping(uint16 slave_number)
     fmmu_input.FMMUactive = 1;
 
     wkc = ecx_FPWR(
-        &s_ecat_context.port,
+        &s_ecat_context->port,
         config_address,
         ECT_REG_FMMU0,
         sizeof(fmmu_output),
@@ -224,7 +221,7 @@ static int configure_runtime_mapping(uint16 slave_number)
     }
 
     wkc = ecx_FPWR(
-        &s_ecat_context.port,
+        &s_ecat_context->port,
         config_address,
         ECT_REG_FMMU1,
         sizeof(fmmu_input),
@@ -260,11 +257,11 @@ OP状态必须用专门的函数，因为OP转换必须要有持续周期通信�
 static int request_clean_state(uint16 slave_number,
                                uint16 requested_state)
 {
-    ec_slavet *slave = &s_ecat_context.slavelist[slave_number];
+    ec_slavet *slave = &s_ecat_context->slavelist[slave_number];
 
     slave->state = requested_state; /* 设目标状态，先在SOEM内存里写“我想要什么状态” */
 
-    int wkc = ecx_writestate(&s_ecat_context, slave_number); /* 向ESC发状态切换命令 */
+    int wkc = ecx_writestate(s_ecat_context, slave_number); /* 向ESC发状态切换命令 */
     ESP_LOGI(TAG,
              "State request 0x%02x WKC=%d",
              requested_state,
@@ -276,7 +273,7 @@ static int request_clean_state(uint16 slave_number,
 
     /* 函数内部不断读取从站AL Status，发现是目标状态了就返回，发现还不是就继续检查，直到超时返回 */
     (void)ecx_statecheck(
-        &s_ecat_context,
+        s_ecat_context,
         slave_number,
         requested_state,
         EC_TIMEOUTSTATE);
@@ -284,7 +281,7 @@ static int request_clean_state(uint16 slave_number,
     vTaskDelay(pdMS_TO_TICKS(20)); /* 阻塞延迟，给ESC时间让状态切换命令产生作用、状态稳定下来，感觉没必要 */
     /* 函数内部会读取全部从站状态并更新 ec_slave/slavelist；
     不拿ecx_statecheck()的返回值作为最终成功标准，因为它只检查AL基础状态，会忽略0x10 ERROR位 */
-    (void)ecx_readstate(&s_ecat_context);
+    (void)ecx_readstate(s_ecat_context);
 
     ESP_LOGI(TAG,
              "State result: state=0x%04x, "
@@ -302,14 +299,14 @@ static int request_clean_state(uint16 slave_number,
 static int request_operational(uint16 slave_number,
                                uint8 process_image[2])
 {
-    ec_slavet *slave = &s_ecat_context.slavelist[slave_number];
+    ec_slavet *slave = &s_ecat_context->slavelist[slave_number];
 
     /* 请求OP前，先在SAFE-OP下发送10帧有效过程数据，先证明过程数据已经连续、稳定、有效 */
     for (int cycle = 0; cycle < 10; cycle++) {
         process_image[0] = 0x00;
 
         int wkc = ecx_LRW(
-            &s_ecat_context.port,
+            &s_ecat_context->port,
             OUTPUT_LOG_ADDR,
             2,
             process_image,
@@ -328,7 +325,7 @@ static int request_operational(uint16 slave_number,
 
     slave->state = EC_STATE_OPERATIONAL;
 
-    int state_wkc = ecx_writestate(&s_ecat_context, slave_number); /*向ESC发送OP切换命令 */
+    int state_wkc = ecx_writestate(s_ecat_context, slave_number); /*向ESC发送OP切换命令 */
     ESP_LOGI(TAG, "OP state request WKC=%d", state_wkc);
 
     if (state_wkc <= 0) {
@@ -341,7 +338,7 @@ static int request_operational(uint16 slave_number,
 
         /* 向ESC发送LRW命令，读写过程数据 */
         int wkc = ecx_LRW(
-            &s_ecat_context.port,
+            &s_ecat_context->port,
             OUTPUT_LOG_ADDR,
             2,
             process_image,
@@ -358,7 +355,7 @@ static int request_operational(uint16 slave_number,
         /* 函数内部不断读取从站AL Status，发现是目标状态了就返回，发现还不是就继续检查，直到超时返回；
         很可能每次都耗满3ms； */
         uint16 reached_state = ecx_statecheck(
-            &s_ecat_context,
+            s_ecat_context,
             slave_number,
             EC_STATE_OPERATIONAL,
             EC_TIMEOUTRET);
@@ -370,7 +367,7 @@ static int request_operational(uint16 slave_number,
         vTaskDelay(pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS));
     }
 
-    (void)ecx_readstate(&s_ecat_context);
+    (void)ecx_readstate(s_ecat_context);
 
     ESP_LOGI(TAG,
              "OP state result: state=0x%04x, "
@@ -410,28 +407,21 @@ void app_main(void)
         return;
     }
 
-    /* 只把应用拥有的句柄交给组件借用；尚未启动SOEM */
-    ESP_ERROR_CHECK(esp_soem_bind_eth(eth_handle));
-    ESP_LOGI(TAG, "esp_eth handle bound to SOEM nicdrv");
-
-    /*
-    * "esp_eth"是我们约定的适配器名字。
-    * ecx_init最终调用自己移植的ecx_setupnic()，挂接RX回调并初始化端口。
-    */
-    if (!ecx_init(&s_ecat_context, "esp_eth")) {
-        ESP_LOGE(TAG, "SOEM port initialization failed");
+    s_ecat_context = esp_soem_init(eth_handle);
+    if (s_ecat_context == NULL) {
+        ESP_LOGE(TAG, "SOEM initialization failed");
         return;
     }
-    ESP_LOGI(TAG, "SOEM port initialized");
+    ESP_LOGI(TAG, "SOEM initialized");
 
     /*
     * 扫描EtherCAT总线、分配从站配置地址、读取基本SII信息，
     * 并尝试让从站进入PRE-OP。
     */
-    int slave_count = ecx_config_init(&s_ecat_context);
+    int slave_count = ecx_config_init(s_ecat_context);
     if (slave_count <= 0) {
         ESP_LOGE(TAG, "No EtherCAT slaves found");
-        ecx_close(&s_ecat_context);
+        esp_soem_deinit(s_ecat_context);
         return;
     }
 
@@ -440,7 +430,7 @@ void app_main(void)
     /* 扫描后限制只能连接这一块板 */
     if (slave_count != 1) {
         ESP_LOGE(TAG, "Expected exactly one EtherCAT slave");
-        ecx_close(&s_ecat_context);
+        esp_soem_deinit(s_ecat_context);
         return;
     }
 
@@ -451,7 +441,7 @@ void app_main(void)
          * ecx_statecheck只用状态低四位判断，因此它可能在ERROR位清除前返回。
          */
         (void)ecx_statecheck(
-            &s_ecat_context,
+            s_ecat_context,
             (uint16)i,
             EC_STATE_PRE_OP,
             EC_TIMEOUTSTATE);
@@ -461,15 +451,15 @@ void app_main(void)
          */
         vTaskDelay(pdMS_TO_TICKS(20));
 
-        int lowest_state = ecx_readstate(&s_ecat_context);
-        ec_slavet *slave = &s_ecat_context.slavelist[i];
+        int lowest_state = ecx_readstate(s_ecat_context);
+        ec_slavet *slave = &s_ecat_context->slavelist[i];
         /* 从站身份检查 */
         if ((slave->eep_man != EXPECTED_VENDOR_ID) ||
             (slave->eep_id != EXPECTED_PRODUCT_ID) ||
             (slave->eep_rev != EXPECTED_REVISION)) {
             ESP_LOGE(TAG,
                      "Unexpected slave identity; refusing register configuration");
-            ecx_close(&s_ecat_context);
+            esp_soem_deinit(s_ecat_context);
             return;
         }
 
@@ -510,17 +500,17 @@ void app_main(void)
             slave->state =
             (slave->state & 0x000f) | EC_STATE_ACK;
 
-            int ack_wkc = ecx_writestate(&s_ecat_context, (uint16)i);
+            int ack_wkc = ecx_writestate(s_ecat_context, (uint16)i);
             ESP_LOGI(TAG, "AL error acknowledge WKC=%d", ack_wkc);
 
             if (ack_wkc <= 0) {
                 ESP_LOGE(TAG, "Failed to send AL error acknowledge");
-                ecx_close(&s_ecat_context);
+                esp_soem_deinit(s_ecat_context);
                 return;
             }
 
             vTaskDelay(pdMS_TO_TICKS(20));
-            (void)ecx_readstate(&s_ecat_context);
+            (void)ecx_readstate(s_ecat_context);
 
             ESP_LOGI(TAG,
                     "After ACK: state=0x%04x, AL status=0x%04x (%s)",
@@ -535,17 +525,17 @@ void app_main(void)
             slave->state = EC_STATE_PRE_OP;
 
             int preop_wkc =
-                ecx_writestate(&s_ecat_context, (uint16)i);
+                ecx_writestate(s_ecat_context, (uint16)i);
             ESP_LOGI(TAG, "Clean PRE-OP request WKC=%d", preop_wkc);
 
             if (preop_wkc <= 0) {
                 ESP_LOGE(TAG, "Failed to send clean PRE-OP request");
-                ecx_close(&s_ecat_context);
+                esp_soem_deinit(s_ecat_context);
                 return;
             }
 
             vTaskDelay(pdMS_TO_TICKS(20));
-            (void)ecx_readstate(&s_ecat_context);
+            (void)ecx_readstate(s_ecat_context);
 
             ESP_LOGI(TAG,
                     "After clean PRE-OP request: "
@@ -564,7 +554,7 @@ void app_main(void)
                     slave->state,
                     slave->ALstatuscode,
                     ec_ALstatuscode2string(slave->ALstatuscode));
-            ecx_close(&s_ecat_context);
+            esp_soem_deinit(s_ecat_context);
             return;
         }
 
@@ -575,14 +565,14 @@ void app_main(void)
     确认这次配置没有把从站“配坏”。如果出现AL错误或掉出PRE-OP，就立即停止 */
     if (!configure_runtime_mapping(1)) {
         ESP_LOGE(TAG, "Runtime SM/FMMU mapping failed");
-        ecx_close(&s_ecat_context);
+        esp_soem_deinit(s_ecat_context);
         return;
     }
 
     vTaskDelay(pdMS_TO_TICKS(20)); /* blocking delay，给从站ESC一点时间，让刚写进去的配置产生作用、状态稳定下来 */
-    (void)ecx_readstate(&s_ecat_context); /*重新读取各从站AL Status及其Code，更新soem内存中的描述 */
+    (void)ecx_readstate(s_ecat_context); /*重新读取各从站AL Status及其Code，更新soem内存中的描述 */
 
-    ec_slavet *slave = &s_ecat_context.slavelist[1];
+    ec_slavet *slave = &s_ecat_context->slavelist[1];
     ESP_LOGI(TAG,
              "After mapping: state=0x%04x, AL status=0x%04x (%s)",
              slave->state,
@@ -592,7 +582,7 @@ void app_main(void)
     if ((slave->state != EC_STATE_PRE_OP) || /* 配置完后仍然处于pre-op阶段 */
         (slave->ALstatuscode != 0)) { /* AL Status Code全零，表示没有错误*/
         ESP_LOGE(TAG, "Slave left clean PRE-OP after mapping");
-        ecx_close(&s_ecat_context);
+        esp_soem_deinit(s_ecat_context);
         return;
     }
 
@@ -601,7 +591,7 @@ void app_main(void)
 
     if (!request_clean_state(1, EC_STATE_SAFE_OP)) {
         ESP_LOGE(TAG, "Slave did not reach clean SAFE-OP");
-        ecx_close(&s_ecat_context);
+        esp_soem_deinit(s_ecat_context);
         return;
     }
 
@@ -630,7 +620,7 @@ void app_main(void)
         process_image[0] = 0x00;
 
         int wkc = ecx_LRW(
-            &s_ecat_context.port,
+            &s_ecat_context->port,
             OUTPUT_LOG_ADDR,
             sizeof(process_image),
             process_image,
@@ -678,8 +668,8 @@ void app_main(void)
             wkc_other);
 
     /* 全部探针周期跑完后，再次读取ESC AL状态，确认5s持续LRW不会让从站状态机出错 */
-    (void)ecx_readstate(&s_ecat_context);
-    slave = &s_ecat_context.slavelist[1];
+    (void)ecx_readstate(s_ecat_context);
+    slave = &s_ecat_context->slavelist[1];
 
     ESP_LOGI(TAG,
             "After SAFE-OP probe: state=0x%04x, "
@@ -703,7 +693,7 @@ void app_main(void)
         ESP_LOGE(TAG, "Slave did not reach clean OPERATIONAL");
 
         (void)request_clean_state(1, EC_STATE_INIT);
-        ecx_close(&s_ecat_context);
+        esp_soem_deinit(s_ecat_context);
         return;
     }
 
@@ -723,7 +713,7 @@ void app_main(void)
         process_image[0] = 0x00;
 
         int wkc = ecx_LRW(
-            &s_ecat_context.port,
+            &s_ecat_context->port,
             OUTPUT_LOG_ADDR,
             sizeof(process_image),
             process_image,
@@ -751,8 +741,8 @@ void app_main(void)
         vTaskDelay(pdMS_TO_TICKS(PROBE_PERIOD_MS));
     }
 
-    (void)ecx_readstate(&s_ecat_context);
-    slave = &s_ecat_context.slavelist[1];
+    (void)ecx_readstate(s_ecat_context);
+    slave = &s_ecat_context->slavelist[1];
 
     ESP_LOGI(TAG,
             "OP WKC summary: good=%d bad=%d",
@@ -780,11 +770,11 @@ void app_main(void)
 
     // if (!request_clean_state(1, EC_STATE_INIT)) {
     //     ESP_LOGE(TAG, "Slave did not return to clean INIT");
-    //     ecx_close(&s_ecat_context);
+    //     esp_soem_deinit(s_ecat_context);
     //     return;
     // }
 
-    // ecx_close(&s_ecat_context);
+    // esp_soem_deinit(s_ecat_context);
     // ESP_LOGI(TAG, "SOEM port closed");
 
     /*
@@ -816,7 +806,7 @@ void app_main(void)
         process_image[0] = next_output;
 
         int wkc = ecx_LRW(
-            &s_ecat_context.port,
+            &s_ecat_context->port,
             OUTPUT_LOG_ADDR,
             sizeof(process_image),
             process_image,
@@ -895,7 +885,7 @@ void app_main(void)
             process_image[0] = 0x00;
 
             int wkc = ecx_LRW(
-                &s_ecat_context.port,
+                &s_ecat_context->port,
                 OUTPUT_LOG_ADDR,
                 sizeof(process_image),
                 process_image,
@@ -934,6 +924,6 @@ void app_main(void)
                  "skipping output and state cleanup");
     }
 
-    ecx_close(&s_ecat_context);
+    esp_soem_deinit(s_ecat_context);
     ESP_LOGI(TAG, "SOEM port closed");
 }

--- a/soem/examples/ecat_io/main/ecat_io_example_main.c
+++ b/soem/examples/ecat_io/main/ecat_io_example_main.c
@@ -188,13 +188,13 @@ static int example_configure_process_data_mapping(uint16_t slave_number)
 
     /* Use SM0 for process-data output, SM1 for process-data input. */
     int wkc = ecx_FPWR(&s_ecat_context->port, config_address, ECT_REG_SM0,
-                    sizeof(sm_output), &sm_output, EC_TIMEOUTRET3);
+                       sizeof(sm_output), &sm_output, EC_TIMEOUTRET3);
     if (wkc <= 0) {
         ESP_LOGE(TAG, "Failed to configure SM0: WKC=%d", wkc);
         return 0;
     }
     wkc = ecx_FPWR(&s_ecat_context->port, config_address, ECT_REG_SM1,
-                sizeof(sm_input), &sm_input, EC_TIMEOUTRET3);
+                   sizeof(sm_input), &sm_input, EC_TIMEOUTRET3);
     if (wkc <= 0) {
         ESP_LOGE(TAG, "Failed to configure SM1: WKC=%d", wkc);
         return 0;
@@ -202,13 +202,13 @@ static int example_configure_process_data_mapping(uint16_t slave_number)
 
     /* Use FMMU0 for process-data output, FMMU1 for process-data input. */
     wkc = ecx_FPWR(&s_ecat_context->port, config_address, ECT_REG_FMMU0,
-                sizeof(fmmu_output), &fmmu_output, EC_TIMEOUTRET3);
+                   sizeof(fmmu_output), &fmmu_output, EC_TIMEOUTRET3);
     if (wkc <= 0) {
         ESP_LOGE(TAG, "Failed to configure FMMU0: WKC=%d", wkc);
         return 0;
     }
     wkc = ecx_FPWR(&s_ecat_context->port, config_address, ECT_REG_FMMU1,
-                sizeof(fmmu_input), &fmmu_input, EC_TIMEOUTRET3);
+                   sizeof(fmmu_input), &fmmu_input, EC_TIMEOUTRET3);
     if (wkc <= 0) {
         ESP_LOGE(TAG, "Failed to configure FMMU1: WKC=%d", wkc);
         return 0;
@@ -391,7 +391,7 @@ void app_main(void)
 
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     ESP_ERROR_CHECK(esp_event_handler_register(
-        ETH_EVENT, ESP_EVENT_ANY_ID, eth_event_handler, NULL));
+                        ETH_EVENT, ESP_EVENT_ANY_ID, eth_event_handler, NULL));
 
     ESP_ERROR_CHECK(example_eth_init(&eth_handle));
     ESP_ERROR_CHECK(esp_eth_start(eth_handle));
@@ -420,15 +420,15 @@ void app_main(void)
     ESP_ERROR_CHECK(slave_count == 1 ? ESP_OK : ESP_ERR_INVALID_SIZE);
     ESP_ERROR_CHECK(
         ((slave->eep_man == EXPECTED_VENDOR_ID) &&
-        (slave->eep_id == EXPECTED_PRODUCT_ID) &&
-        (slave->eep_rev == EXPECTED_REVISION)) ? ESP_OK : ESP_ERR_INVALID_RESPONSE);
+         (slave->eep_id == EXPECTED_PRODUCT_ID) &&
+         (slave->eep_rev == EXPECTED_REVISION)) ? ESP_OK : ESP_ERR_INVALID_RESPONSE);
     ESP_LOGI(
         TAG, "Slave: vendor=0x%08" PRIx32 ", product=0x%08" PRIx32 ", revision=0x%08" PRIx32,
         slave->eep_man, slave->eep_id, slave->eep_rev);
 
     /* stage4: Ensure the slave is in PRE-OP before configuring the ESC. */
     ESP_ERROR_CHECK(example_request_state(
-        slave_index, EC_STATE_PRE_OP) ? ESP_OK : ESP_ERR_INVALID_STATE);
+                        slave_index, EC_STATE_PRE_OP) ? ESP_OK : ESP_ERR_INVALID_STATE);
     ESP_LOGI(TAG, "Slave reached PRE-OP");
 
     /* stage5: Configure process-data mapping. */
@@ -437,13 +437,13 @@ void app_main(void)
 
     /* stage6: Ask for entering SAFE-OP and confirm it. */
     ESP_ERROR_CHECK(example_request_state(
-        slave_index, EC_STATE_SAFE_OP) ? ESP_OK : ESP_ERR_INVALID_STATE);
+                        slave_index, EC_STATE_SAFE_OP) ? ESP_OK : ESP_ERR_INVALID_STATE);
     ESP_LOGI(TAG, "Slave reached SAFE-OP");
 
     /* stage7: Ask for entering OP state and confirm it.
        Process-data communication must remain active during such transition. */
     ESP_ERROR_CHECK(example_request_state_op(
-        slave_index) ? ESP_OK : ESP_ERR_INVALID_STATE);
+                        slave_index) ? ESP_OK : ESP_ERR_INVALID_STATE);
     ESP_LOGI(TAG, "Slave reached OP");
 
     /* stage8: Run cyclic IO closed-loop. */

--- a/soem/examples/ecat_io/main/ecat_io_example_main.c
+++ b/soem/examples/ecat_io/main/ecat_io_example_main.c
@@ -146,7 +146,8 @@ static esp_err_t example_eth_deinit(esp_eth_handle_t eth_handle)
     return phy->del(phy);
 }
 
-/* Configure the fixed process-data mapping used by this example(No CoE support).
+/* Configure the fixed process-data mapping used by this example.
+   Slave in example does not support CoE.
    Names follow the slave's perspective: IN/OUT focus on field-side, Rx/Tx focus on network-side. */
 static int example_configure_process_data_mapping(uint16_t slave_number)
 {
@@ -238,14 +239,14 @@ static int example_request_state(uint16_t slave_number, uint16_t requested_state
     slave->state = requested_state; /* Set target state wanted. */
     int wkc = ecx_writestate(s_ecat_context, slave_number);
     if (wkc <= 0) {
-        ESP_LOGE(TAG, "Failed to request state 0x%02x (wkc unexpected): WKC=%d", requested_state, wkc);
+        ESP_LOGE(TAG, "Failed to request state 0x%02x (unexpected WKC): WKC=%d", requested_state, wkc);
         return 0;
     }
 
     int64_t deadline = esp_timer_get_time() + EC_TIMEOUTSTATE; /* Set deadline timepoint in us. */
     do {
-        /* ecx_statecheck() return only the base state without the error flag,
-           but stores the complete AL Status and its Code in slave descriptor. */
+        /* ecx_statecheck() returns only the base state without the error flag,
+           but stores the complete AL Status and AL Status Code in slave descriptor. */
         (void)ecx_statecheck(s_ecat_context, slave_number, requested_state, EC_TIMEOUTRET);
         if (slave->state == requested_state) {
             return 1;
@@ -257,7 +258,7 @@ static int example_request_state(uint16_t slave_number, uint16_t requested_state
     return 0;
 }
 
-/* Request a OP state transition. Must Keep process-data exchange active. */
+/* Request an OP transition while keeping process-data exchange active. */
 static int example_request_state_op(uint16_t slave_number)
 {
     ec_slavet *slave = &s_ecat_context->slavelist[slave_number];
@@ -275,7 +276,7 @@ static int example_request_state_op(uint16_t slave_number)
     slave->state = EC_STATE_OPERATIONAL;
     wkc = ecx_writestate(s_ecat_context, slave_number);
     if (wkc <= 0) {
-        ESP_LOGE(TAG, "Failed to request state OP (wkc unexpected): WKC=%d", wkc);
+        ESP_LOGE(TAG, "Failed to request state OP (unexpected WKC): WKC=%d", wkc);
         return 0;
     }
 
@@ -308,10 +309,10 @@ static void example_cycle_timer_callback(void *arg)
 }
 
 /* Run cyclic LRW process-data exchange.
-   process_image[0] stands for output, while process_image[1] stands for input.
-   Hardware rule: When SW1 pressed, low level on pin. When high level on pin, LED3 ON.
-   Wanna achieve press SW1 make LED3 ON next cycle.
-   Use esp_timer to cyclly wake this task to achieve better timing resolution compared with tick-based delays. */
+   process_image[0] contains the output calculated from the previous input.
+   process_image[1] contains the current input.
+   SW1 is active low and LED3 is active high.
+   An esp_timer callback periodically notifies this task to start each cycle. */
 static void example_run_cyclic_io(ecx_contextt *context, EventGroupHandle_t eth_events)
 {
     uint8_t process_image[2] = {0};

--- a/soem/examples/ecat_io/main/ecat_io_example_main.c
+++ b/soem/examples/ecat_io/main/ecat_io_example_main.c
@@ -1,58 +1,43 @@
-/* 第一步，旨在完成以下工作，把ESP32P4的EMAC和IP101的PHY启动起来，确认物理链路LinkUp，
-把有效的eth_handle交给ecat master组件 */
-
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "freertos/task.h"
-
-#include "esp_soem.h" /* 本组件公开API */
+#include "esp_soem.h"
 #include "esp_eth.h"
-#include "esp_event.h" /* eth link信号通过event loop发出*/
+#include "esp_event.h"
 #include "esp_log.h"
-
+#include "esp_timer.h"
 #include <inttypes.h>
-#include <string.h>
+#include <stdbool.h>
 
-static const char *TAG = "ecat_io"; /* 给日志加一个模块名字 */
+/* Slave identification defined by ESI/SII info. */
+#define EXPECTED_VENDOR_ID      0x000004D8u
+#define EXPECTED_PRODUCT_ID     0x0000000Du
+#define EXPECTED_REVISION       0x00000001u
+#define OUTPUT_PHYS_ADDR        0x0F01u /* Store RxPDO data. */
+#define INPUT_PHYS_ADDR         0x1000u /* Store TxPDO data. */
 
-/* PHY Link Up事件到达后置位 */
-#define ETH_LINK_UP_BIT BIT0 /* 人为定义，ETH PHY LINKUP事件由BIT0标识 */
+/* Slave hardware design mapping to process-data. */
+#define SW1_INPUT_MASK          0x01u
+#define LED3_OUTPUT_MASK        0x01u
 
-/* ECAT从站身份常量，取决于从站ESI/SII信息 */
-#define EXPECTED_VENDOR_ID  0x000004D8u
-#define EXPECTED_PRODUCT_ID 0x0000000Du
-#define EXPECTED_REVISION   0x00000001u
+/* EtherCAT network logical address. */
+#define OUTPUT_LOG_ADDR         0x00000000u
+#define INPUT_LOG_ADDR          0x00000001u
 
-/* 地址常量 */
-#define OUTPUT_PHYS_ADDR 0x0F01u /* ESC的放RxPDO的起始物理地址，会配置由SM0管理，FMMU映射 */
-#define INPUT_PHYS_ADDR  0x1000u /* ESC的放TxPDO的起始物理地址，会配置由SM1管理，FMMU映射 */
+/* EtherCAT cyclic IO runtime parameters.*/
+#define IO_CYCLE_PERIOD_MS      10 /* Cycle period in milliseconds. */
+#define IO_CYCLE_PERIOD_US      (IO_CYCLE_PERIOD_MS * 1000)
+#define IO_EXPECTED_WKC         3 /* Expected WKC count in one cycle. LRW write success +2, read +1. */
 
-#define OUTPUT_LOG_ADDR  0x00000000u /* ECAT网络放现场侧输出数据的逻辑地址 */
-#define INPUT_LOG_ADDR   0x00000001u /* ECAT网络放现场侧输入数据的逻辑地址 */
+/* PHY Link-Up event bit. */
+#define ETH_LINK_UP_BIT BIT0
 
-/* 探针常量，测试用 */
-#define PROBE_CYCLES       500  /* 探针测试周期数 */
-#define PROBE_PERIOD_MS    10   /* 探针测试周期时长 */
-#define EXPECTED_LRW_WKC   3    /* 探针测试周期内期望收到的WKC数，LWR命令向从站写成功+2,读成功+1 */
+static EventGroupHandle_t s_eth_events;
+static ecx_contextt *s_ecat_context; /* SOEM allocates the context from the heap during initialization. */
+static const char *TAG = "ecat_io";
 
-/* 正式ECAT_IO闭环运行参数*/
-#define IO_CYCLE_PERIOD_MS             10   /* IO闭环周期时长 */
-#define IO_EXPECTED_WKC                3    /* IO闭环周期内期望收到的WKC数，LWR命令向从站写成功+2,读成功+1 */
-#define IO_MAX_CONSECUTIVE_WKC_ERRORS  3    /* IO闭环连续LRW WKC错误次数允许上限 */
-
-#define SW1_INPUT_MASK                 0x01u
-#define LED3_OUTPUT_MASK               0x01u
-
-static EventGroupHandle_t s_eth_events; /* 事件组句柄，事件组暂时理解成一个由很多bit组成的事件状态板；
-                                        eth事件cb()里SET，app_main()里WAIT */
-
-/* SOEM allocates the context from the heap during initialization. */
-static ecx_contextt *s_ecat_context;
-
-static void eth_event_handler(void *arg,
-                              esp_event_base_t event_base,
-                              int32_t event_id,
-                              void *event_data)
+static void eth_event_handler(void *arg, esp_event_base_t event_base,
+                              int32_t event_id, void *event_data)
 {
     (void)arg;
     (void)event_base;
@@ -82,7 +67,8 @@ static void eth_event_handler(void *arg,
     }
 }
 
-static esp_err_t eth_init(esp_eth_handle_t *eth_handle_out)
+/* Initialize the internal EMAC with an external IP101 PHY. */
+static esp_err_t example_eth_init(esp_eth_handle_t *eth_handle_out)
 {
     if (eth_handle_out == NULL) {
         return ESP_ERR_INVALID_ARG;
@@ -91,13 +77,7 @@ static esp_err_t eth_init(esp_eth_handle_t *eth_handle_out)
     eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
     eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
     eth_esp32_emac_config_t emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
-
-    /*
-     * P4默认EMAC配置已经包含：
-     * MDC=31、MDIO=52、RMII REF_CLK=50，
-     * TX_EN=49、TXD0=34、TXD1=35、
-     * CRS_DV=28、RXD0=29、RXD1=30。
-     */
+    /* Use the ESP32-P4 default RMII pins and the PHY settings required by example hardware. */
     phy_config.phy_addr = 1;
     phy_config.reset_gpio_num = 51;
 
@@ -106,7 +86,7 @@ static esp_err_t eth_init(esp_eth_handle_t *eth_handle_out)
         return ESP_ERR_NO_MEM;
     }
 
-    /* IDF v6使用IEEE 802.3通用PHY驱动支持IP101 */
+    /* IP101 is supported by the generic IEEE 802.3 PHY driver. */
     esp_eth_phy_t *phy = esp_eth_phy_new_generic(&phy_config);
     if (phy == NULL) {
         mac->del(mac);
@@ -126,804 +106,351 @@ static esp_err_t eth_init(esp_eth_handle_t *eth_handle_out)
     return ESP_OK;
 }
 
-/*
-手动配置从站ESC#1的过程数据通道；
-告诉SM哪两个ESC本地RAM区域分别用于1Byte输入和1Byte输出；
-再告诉FMMU把ECAT网络逻辑地址0和1映射到这两个本地物理地址；
-最后把同样的信息同步到SOEM自己的slavelist里。
-常见CoE从站是SM0 = Mailbox 主→从，SM1 = Mailbox 从→主，SM2 = Process Output，SM3 = Process Input；
-但ECAT没有规定SM0 SM1必须用作邮箱通信，而且现在的从站没有CoE功能，所以把SM0 SM1用作过程数据通信。
-这个函数既要通过ecat报文指令改真实硬件，又要改SOEM软件记录。
-变量命名站在从站角度，IN/OUT指现场侧输入输出，Rx/Tx指ECAT通信侧接收发送。
-*/
-static int configure_runtime_mapping(uint16 slave_number)
+/* Uninstall Ethernet and release the MAC and PHY instances. */
+static esp_err_t example_eth_deinit(esp_eth_handle_t eth_handle)
 {
-    ec_slavet *slave = &s_ecat_context->slavelist[slave_number]; /* SOEM扫描完以后维护的从站描述表 */
-    uint16 config_address = slave->configadr; /* 前面扫描、初始化时SOEM给这个从站分配过配置地址，可用FRxx指令*/
+    if (eth_handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
 
-    ec_smt sm_output; /* 一整组SyncManager配置寄存器的数据结构 */
-    ec_smt sm_input;
-    ec_fmmut fmmu_output; /* 一系列逻辑地址与物理地址映射规则所需的参数 */
-    ec_fmmut fmmu_input;
+    esp_eth_mac_t *mac = NULL;
+    esp_eth_phy_t *phy = NULL;
 
-    memset(&sm_output, 0, sizeof(sm_output)); /* 主动初始化，避免栈上随机垃圾值 */
-    memset(&sm_input, 0, sizeof(sm_input));
-    memset(&fmmu_output, 0, sizeof(fmmu_output));
-    memset(&fmmu_input, 0, sizeof(fmmu_input));
+    esp_err_t ret = esp_eth_get_mac_instance(eth_handle, &mac);
+    if (ret != ESP_OK) {
+        return ret;
+    }
 
-    /* P4小端存储，ECAT小端解读；
-    SM0用作管理主站到从站的1字节输出过程数据的内存；SM1用作管理从站到主站的1字节输入过程数据的内存。*/
-    sm_output.StartAddr = htoes(OUTPUT_PHYS_ADDR); /* 起始物理地址 */
-    sm_output.SMlength = htoes(1); /* 管理字节数 */
-    sm_output.SMflags = htoel(0x00010044u); /* Control，Status，Activate，PDI Ctrl；Control里配置SM模式、SM方向等 */
+    ret = esp_eth_get_phy_instance(eth_handle, &phy);
+    if (ret != ESP_OK) {
+        return ret;
+    }
 
-    sm_input.StartAddr = htoes(INPUT_PHYS_ADDR);
-    sm_input.SMlength = htoes(1);
-    sm_input.SMflags = htoel(0x00010000u);
+    ret = esp_eth_driver_uninstall(eth_handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
 
-    /* 对config_address这个从站，用FPWR报文指令从ESC的SM0寄存器起始地址开始，
-    写入整个sm_output结构体，最多允许6000us完成整套FPWR的发送和等待对应返回帧；
-    ecx_FPWR()返回的软件wkc，<0代表没收到返回帧，=0代表收到返回帧但没从站处理过，皆需报错*/
-    int wkc = ecx_FPWR(
-        &s_ecat_context->port,
-        config_address,
-        ECT_REG_SM0,
-        sizeof(sm_output),
-        &sm_output,
-        EC_TIMEOUTRET3);
-    ESP_LOGI(TAG, "Program SM0 WKC=%d", wkc);
+    ret = mac->del(mac);
+    if (ret != ESP_OK) {
+        phy->del(phy);
+        return ret;
+    }
+
+    return phy->del(phy);
+}
+
+/* Configure the fixed process-data mapping used by this example(No CoE support).
+   Names follow the slave's perspective: IN/OUT focus on field-side, Rx/Tx focus on network-side. */
+static int example_configure_process_data_mapping(uint16_t slave_number)
+{
+    ec_slavet *slave = &s_ecat_context->slavelist[slave_number];
+    uint16_t config_address = slave->configadr; /* Fetch slave's configured address. Use FPWR cmd. */
+
+    /* Initialize SM and FMMU parameters. */
+    ec_smt sm_output = {
+        .StartAddr = htoes(OUTPUT_PHYS_ADDR),
+        .SMlength = htoes(1),
+        .SMflags = htoel(0x00010044u),
+    };
+    ec_smt sm_input = {
+        .StartAddr = htoes(INPUT_PHYS_ADDR),
+        .SMlength = htoes(1),
+        .SMflags = htoel(0x00010000u),
+    };
+    ec_fmmut fmmu_output = {
+        .LogStart = htoel(OUTPUT_LOG_ADDR),
+        .LogLength = htoes(1),
+        .LogStartbit = 0, /* Start bit in first byte.*/
+        .LogEndbit = 7, /* End bit in last byte.*/
+        .PhysStart = htoes(OUTPUT_PHYS_ADDR),
+        .PhysStartBit = 0,
+        .FMMUtype = 2, /* Mapping direction, 2 stands for logical write. */
+        .FMMUactive = 1,
+    };
+    ec_fmmut fmmu_input = {
+        .LogStart = htoel(INPUT_LOG_ADDR),
+        .LogLength = htoes(1),
+        .LogStartbit = 0,
+        .LogEndbit = 7,
+        .PhysStart = htoes(INPUT_PHYS_ADDR),
+        .PhysStartBit = 0,
+        .FMMUtype = 1,
+        .FMMUactive = 1,
+    };
+
+    /* Use SM0 for process-data output, SM1 for process-data input. */
+    int wkc = ecx_FPWR(&s_ecat_context->port, config_address, ECT_REG_SM0,
+                    sizeof(sm_output), &sm_output, EC_TIMEOUTRET3);
     if (wkc <= 0) {
+        ESP_LOGE(TAG, "Failed to configure SM0: WKC=%d", wkc);
+        return 0;
+    }
+    wkc = ecx_FPWR(&s_ecat_context->port, config_address, ECT_REG_SM1,
+                sizeof(sm_input), &sm_input, EC_TIMEOUTRET3);
+    if (wkc <= 0) {
+        ESP_LOGE(TAG, "Failed to configure SM1: WKC=%d", wkc);
         return 0;
     }
 
-    wkc = ecx_FPWR(
-        &s_ecat_context->port,
-        config_address,
-        ECT_REG_SM1,
-        sizeof(sm_input),
-        &sm_input,
-        EC_TIMEOUTRET3);
-    ESP_LOGI(TAG, "Program SM1 WKC=%d", wkc);
+    /* Use FMMU0 for process-data output, FMMU1 for process-data input. */
+    wkc = ecx_FPWR(&s_ecat_context->port, config_address, ECT_REG_FMMU0,
+                sizeof(fmmu_output), &fmmu_output, EC_TIMEOUTRET3);
     if (wkc <= 0) {
+        ESP_LOGE(TAG, "Failed to configure FMMU0: WKC=%d", wkc);
+        return 0;
+    }
+    wkc = ecx_FPWR(&s_ecat_context->port, config_address, ECT_REG_FMMU1,
+                sizeof(fmmu_input), &fmmu_input, EC_TIMEOUTRET3);
+    if (wkc <= 0) {
+        ESP_LOGE(TAG, "Failed to configure FMMU1: WKC=%d", wkc);
         return 0;
     }
 
-    /* FMMU0：逻辑字节0映射到物理输出0x0F01 */
-    fmmu_output.LogStart = htoel(OUTPUT_LOG_ADDR); /* 映射的逻辑地址起始地址*/
-    fmmu_output.LogLength = htoes(1); /* 映射的字节数 */
-    fmmu_output.LogStartbit = 0; /* 除了整Byte映射外，还支持截断Byte映射，也就是位级映射*/
-    fmmu_output.LogEndbit = 7; /* Length决定跨多少各Byte，Startbit决定第一个Byte从哪一位开始，Endbit决定最后一个Byte从哪一位结束 */
-    fmmu_output.PhysStart = htoes(OUTPUT_PHYS_ADDR); /* 映射的物理地址起始地址*/
-    fmmu_output.PhysStartBit = 0; /* 映射的物理地址起始位 */
-    fmmu_output.FMMUtype = 2; /* 映射的方向，1=逻辑读，2=逻辑写 */
-    fmmu_output.FMMUactive = 1; /* 1=激活映射 */
-
-    /* FMMU1：物理输入0x1000映射到逻辑字节1 */
-    fmmu_input.LogStart = htoel(INPUT_LOG_ADDR);
-    fmmu_input.LogLength = htoes(1);
-    fmmu_input.LogStartbit = 0;
-    fmmu_input.LogEndbit = 7;
-    fmmu_input.PhysStart = htoes(INPUT_PHYS_ADDR);
-    fmmu_input.PhysStartBit = 0;
-    fmmu_input.FMMUtype = 1;
-    fmmu_input.FMMUactive = 1;
-
-    wkc = ecx_FPWR(
-        &s_ecat_context->port,
-        config_address,
-        ECT_REG_FMMU0,
-        sizeof(fmmu_output),
-        &fmmu_output,
-        EC_TIMEOUTRET3);
-    ESP_LOGI(TAG, "Program FMMU0 WKC=%d", wkc);
-    if (wkc <= 0) {
-        return 0;
-    }
-
-    wkc = ecx_FPWR(
-        &s_ecat_context->port,
-        config_address,
-        ECT_REG_FMMU1,
-        sizeof(fmmu_input),
-        &fmmu_input,
-        EC_TIMEOUTRET3);
-    ESP_LOGI(TAG, "Program FMMU1 WKC=%d", wkc);
-    if (wkc <= 0) {
-        return 0;
-    }
-
-    /* 同步SOEM内存中的从站描述 */
+    /* Keep the SOEM slave descriptor consistent with the ESC configuration. */
     slave->SM[0] = sm_output;
     slave->SM[1] = sm_input;
-    slave->SMtype[0] = 3; /* 1=MailboxWrite, 2=MailboxRead */
-    slave->SMtype[1] = 4; /* 3=ProcessDataOutput, 4=ProcessDataInput */
+    slave->SMtype[0] = 3; /* 3 stands for Process-data output. */
+    slave->SMtype[1] = 4; /* 4 stands for Process-data input. */
     slave->Obits = 8;
     slave->Ibits = 8;
     slave->Obytes = 1;
     slave->Ibytes = 1;
-
     slave->FMMU[0] = fmmu_output;
     slave->FMMU[1] = fmmu_input;
-    slave->FMMUunused = 2; /* 下一个空闲的FMMU编号，0和1我们用了，下个从2开始 */
+    slave->FMMUunused = 2; /* Next free FMMU index. */
 
-    ESP_LOGI(TAG, "Runtime SM/FMMU mapping programmed");
     return 1;
 }
 
-/*
-请求某个从站切换到指定ECAT状态，然后严格确认它最终“干净地”进入该状态，不能带ERROR位，AL状态码也必须为0；
-OP状态必须用专门的函数，因为OP转换必须要有持续周期通信要求；
-*/
-static int request_clean_state(uint16 slave_number,
-                               uint16 requested_state)
+/* Request a PRE-OP or SAFE-OP state transition. Repeatedly check state reached or not until timeout.
+   @return 1 if slave reach the exact requested state without AL ERROR, otherwise 0. */
+static int example_request_state(uint16_t slave_number, uint16_t requested_state)
 {
     ec_slavet *slave = &s_ecat_context->slavelist[slave_number];
 
-    slave->state = requested_state; /* 设目标状态，先在SOEM内存里写“我想要什么状态” */
-
-    int wkc = ecx_writestate(s_ecat_context, slave_number); /* 向ESC发状态切换命令 */
-    ESP_LOGI(TAG,
-             "State request 0x%02x WKC=%d",
-             requested_state,
-             wkc);
-
+    slave->state = requested_state; /* Set target state wanted. */
+    int wkc = ecx_writestate(s_ecat_context, slave_number);
     if (wkc <= 0) {
+        ESP_LOGE(TAG, "Failed to request state 0x%02x (wkc unexpected): WKC=%d", requested_state, wkc);
         return 0;
     }
 
-    /* 函数内部不断读取从站AL Status，发现是目标状态了就返回，发现还不是就继续检查，直到超时返回 */
-    (void)ecx_statecheck(
-        s_ecat_context,
-        slave_number,
-        requested_state,
-        EC_TIMEOUTSTATE);
-
-    vTaskDelay(pdMS_TO_TICKS(20)); /* 阻塞延迟，给ESC时间让状态切换命令产生作用、状态稳定下来，感觉没必要 */
-    /* 函数内部会读取全部从站状态并更新 ec_slave/slavelist；
-    不拿ecx_statecheck()的返回值作为最终成功标准，因为它只检查AL基础状态，会忽略0x10 ERROR位 */
-    (void)ecx_readstate(s_ecat_context);
-
-    ESP_LOGI(TAG,
-             "State result: state=0x%04x, "
-             "AL status=0x%04x (%s)",
-             slave->state,
-             slave->ALstatuscode,
-             ec_ALstatuscode2string(slave->ALstatuscode));
-
-    /* 最终真正严格判断 */
-    return (slave->state == requested_state) &&
-           (slave->ALstatuscode == 0);
+    int64_t deadline = esp_timer_get_time() + EC_TIMEOUTSTATE; /* Set deadline timepoint in us. */
+    do {
+        /* ecx_statecheck() return only the base state without the error flag,
+           but stores the complete AL Status and its Code in slave descriptor. */
+        (void)ecx_statecheck(s_ecat_context, slave_number, requested_state, EC_TIMEOUTRET);
+        if (slave->state == requested_state) {
+            return 1;
+        }
+        vTaskDelay(pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS)); /* No real-time requirement. */
+    } while (esp_timer_get_time() < deadline);
+    ESP_LOGE(TAG, "Failed to request state 0x%02x (timeout): state=0x%04x, AL status=0x%04x",
+             requested_state, slave->state, slave->ALstatuscode);
+    return 0;
 }
 
-/* 请求某个从站进入OP状态，需要一边维持有效的过程数据通信，一边请求并确认进入OP；*/
-static int request_operational(uint16 slave_number,
-                               uint8 process_image[2])
+/* Request a OP state transition. Must Keep process-data exchange active. */
+static int example_request_state_op(uint16_t slave_number)
 {
     ec_slavet *slave = &s_ecat_context->slavelist[slave_number];
+    uint8_t process_image[2] = {0}; /* Output fixed at zero, input not processed. */
 
-    /* 请求OP前，先在SAFE-OP下发送10帧有效过程数据，先证明过程数据已经连续、稳定、有效 */
-    for (int cycle = 0; cycle < 10; cycle++) {
-        process_image[0] = 0x00;
-
-        int wkc = ecx_LRW(
-            &s_ecat_context->port,
-            OUTPUT_LOG_ADDR,
-            2,
-            process_image,
-            EC_TIMEOUTRET3);
-
-        if (wkc != IO_EXPECTED_WKC) {
-            ESP_LOGE(TAG,
-                     "SAFE-OP LRW before OP failed: cycle=%d WKC=%d",
-                     cycle,
-                     wkc);
-            return 0;
-        }
-
-        vTaskDelay(pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS));
-    }
-
-    slave->state = EC_STATE_OPERATIONAL;
-
-    int state_wkc = ecx_writestate(s_ecat_context, slave_number); /*向ESC发送OP切换命令 */
-    ESP_LOGI(TAG, "OP state request WKC=%d", state_wkc);
-
-    if (state_wkc <= 0) {
+    /* One LRW communication before state change request. */
+    int wkc = ecx_LRW(&s_ecat_context->port, OUTPUT_LOG_ADDR,
+                      sizeof(process_image), process_image, EC_TIMEOUTRET3);
+    if (wkc != IO_EXPECTED_WKC) {
+        ESP_LOGE(TAG, "Failed to request state OP (first LRW failed): WKC=%d", wkc);
         return 0;
     }
 
-    /* 请求OP后不能停止过程数据，一边持续LRW，一边检查状态是否到达OP，持续200个周期 */
-    for (int cycle = 0; cycle < 200; cycle++) {
-        process_image[0] = 0x00; //输出全零，保证安全
+    /* Formally request OP state. */
+    slave->state = EC_STATE_OPERATIONAL;
+    wkc = ecx_writestate(s_ecat_context, slave_number);
+    if (wkc <= 0) {
+        ESP_LOGE(TAG, "Failed to request state OP (wkc unexpected): WKC=%d", wkc);
+        return 0;
+    }
 
-        /* 向ESC发送LRW命令，读写过程数据 */
-        int wkc = ecx_LRW(
-            &s_ecat_context->port,
-            OUTPUT_LOG_ADDR,
-            2,
-            process_image,
-            EC_TIMEOUTRET3);
-
+    /* Try to check OP state reached while maintaining process-data communication. */
+    int64_t deadline = esp_timer_get_time() + EC_TIMEOUTSTATE;
+    do {
+        wkc = ecx_LRW(&s_ecat_context->port, OUTPUT_LOG_ADDR,
+                      sizeof(process_image), process_image, EC_TIMEOUTRET3);
         if (wkc != IO_EXPECTED_WKC) {
-            ESP_LOGE(TAG,
-                     "OP transition LRW failed: cycle=%d WKC=%d",
-                     cycle,
-                     wkc);
+            ESP_LOGE(TAG, "Failed to request state OP (later LRW failed): WKC=%d", wkc);
             return 0;
         }
 
-        /* 函数内部不断读取从站AL Status，发现是目标状态了就返回，发现还不是就继续检查，直到超时返回；
-        很可能每次都耗满3ms； */
-        uint16 reached_state = ecx_statecheck(
-            s_ecat_context,
-            slave_number,
-            EC_STATE_OPERATIONAL,
-            EC_TIMEOUTRET);
+        (void)ecx_statecheck(s_ecat_context, slave_number, EC_STATE_OPERATIONAL, EC_TIMEOUTRET);
+        if (slave->state == EC_STATE_OPERATIONAL) {
+            return 1;
+        }
+        vTaskDelay(pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS));
+    } while (esp_timer_get_time() < deadline);
+    ESP_LOGE(TAG, "Failed to request state OP (timeout): state=0x%04x, AL status=0x%04x",
+             slave->state, slave->ALstatuscode);
+    return 0;
+}
 
-        if (reached_state == EC_STATE_OPERATIONAL) {
+/* Callback function for esp_timer. */
+static void example_cycle_timer_callback(void *arg)
+{
+    TaskHandle_t cyclic_task = (TaskHandle_t)arg;
+    xTaskNotifyGive(cyclic_task);
+}
+
+/* Run cyclic LRW process-data exchange.
+   process_image[0] stands for output, while process_image[1] stands for input.
+   Hardware rule: When SW1 pressed, low level on pin. When high level on pin, LED3 ON.
+   Wanna achieve press SW1 make LED3 ON next cycle.
+   Use esp_timer to cyclly wake this task to achieve better timing resolution compared with tick-based delays. */
+static void example_run_cyclic_io(ecx_contextt *context, EventGroupHandle_t eth_events)
+{
+    uint8_t process_image[2] = {0};
+    uint8_t next_output = 0;
+    uint8_t previous_input = 0;
+    bool first_input = true;
+    uint32_t cycle = 0;
+
+    /* Create a software timer. */
+    TaskHandle_t cyclic_task = xTaskGetCurrentTaskHandle(); /* main_task handle. */
+    esp_timer_handle_t cycle_timer = NULL;
+    const esp_timer_create_args_t cycle_timer_args = {
+        .callback = example_cycle_timer_callback,
+        .arg = cyclic_task,
+        .dispatch_method = ESP_TIMER_TASK,
+        .name = "ecat_cycle",
+    };
+    ESP_ERROR_CHECK(esp_timer_create(&cycle_timer_args, &cycle_timer));
+    ESP_ERROR_CHECK(esp_timer_start_periodic(cycle_timer, IO_CYCLE_PERIOD_US));
+
+    /* Start cyclic IO. */
+    ESP_LOGI(TAG, "EtherCAT cyclic IO started");
+    ESP_LOGI(TAG, "Press SW1: LED3 ON; release SW1: LED3 OFF");
+
+    while (true) {
+        /* Blocked wait until periodic timer notifies this task. */
+        (void)ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+
+        if ((xEventGroupGetBits(eth_events) & ETH_LINK_UP_BIT) == 0) {
             break;
         }
 
-        vTaskDelay(pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS));
+        process_image[0] = next_output;
+
+        int wkc = ecx_LRW(&context->port, OUTPUT_LOG_ADDR,
+                          sizeof(process_image), process_image, EC_TIMEOUTRET3);
+        if (wkc != IO_EXPECTED_WKC) {
+            ESP_LOGE(TAG, "Cycle %" PRIu32 ": unexpected WKC=%d", cycle, wkc);
+            break;
+        }
+
+        uint8_t current_input = process_image[1];
+        bool sw1_pressed = (current_input & SW1_INPUT_MASK) == 0;
+
+        next_output = sw1_pressed ? LED3_OUTPUT_MASK : 0;
+
+        if (first_input || current_input != previous_input) {
+            ESP_LOGI(TAG,
+                     "Cycle %" PRIu32 ": "
+                     "input=0x%02x SW1=%s, "
+                     "next output=0x%02x LED3=%s",
+                     cycle,
+                     current_input,
+                     sw1_pressed ? "PRESSED" : "RELEASED",
+                     next_output,
+                     sw1_pressed ? "ON" : "OFF");
+
+            previous_input = current_input;
+            first_input = false;
+        }
+
+        cycle++;
     }
 
-    (void)ecx_readstate(s_ecat_context);
-
-    ESP_LOGI(TAG,
-             "OP state result: state=0x%04x, "
-             "AL status=0x%04x (%s)",
-             slave->state,
-             slave->ALstatuscode,
-             ec_ALstatuscode2string(slave->ALstatuscode));
-
-    return (slave->state == EC_STATE_OPERATIONAL) &&
-           (slave->ALstatuscode == 0);
+    ESP_ERROR_CHECK(esp_timer_stop(cycle_timer));
+    ESP_ERROR_CHECK(esp_timer_delete(cycle_timer));
+    ESP_LOGW(TAG, "EtherCAT cyclic IO stopped");
 }
 
 void app_main(void)
 {
+    /* stage1: Initialize Ethernet and wait for Link-Up. */
     esp_eth_handle_t eth_handle = NULL;
-
     s_eth_events = xEventGroupCreate();
     ESP_ERROR_CHECK(s_eth_events != NULL ? ESP_OK : ESP_ERR_NO_MEM);
 
-    /* esp_eth_start()会发布Ethernet事件，因此必须先创建默认事件循环 */
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     ESP_ERROR_CHECK(esp_event_handler_register(
         ETH_EVENT, ESP_EVENT_ANY_ID, eth_event_handler, NULL));
 
-    ESP_ERROR_CHECK(eth_init(&eth_handle));
+    ESP_ERROR_CHECK(example_eth_init(&eth_handle));
     ESP_ERROR_CHECK(esp_eth_start(eth_handle));
 
-    EventBits_t bits = xEventGroupWaitBits(
-        s_eth_events,
-        ETH_LINK_UP_BIT,
-        pdFALSE,
-        pdTRUE,
-        pdMS_TO_TICKS(10000));
+    /* Wait up to 10 seconds for the physical Ethernet link. */
+    EventBits_t bits = xEventGroupWaitBits(s_eth_events, ETH_LINK_UP_BIT,
+                                           pdFALSE, pdTRUE, pdMS_TO_TICKS(10000));
+    ESP_ERROR_CHECK((bits & ETH_LINK_UP_BIT) != 0 ? ESP_OK : ESP_ERR_TIMEOUT);
 
-    if ((bits & ETH_LINK_UP_BIT) == 0) {
-        ESP_LOGE(TAG, "Ethernet Link Up timeout");
-        return;
-    }
-
+    /* stage2: Initialize SOEM over the Ethernet driver. */
     s_ecat_context = esp_soem_init(eth_handle);
-    if (s_ecat_context == NULL) {
-        ESP_LOGE(TAG, "SOEM initialization failed");
-        return;
-    }
+    ESP_ERROR_CHECK(s_ecat_context != NULL ? ESP_OK : ESP_FAIL);
     ESP_LOGI(TAG, "SOEM initialized");
 
-    /*
-    * 扫描EtherCAT总线、分配从站配置地址、读取基本SII信息，
-    * 并尝试让从站进入PRE-OP。
-    */
+    /* stage3: Discover and initialize ECAT slaves.
+       Config fixed address, read SII, and ask for entering PRE-OP(within err-acknowledge set, without check). */
     int slave_count = ecx_config_init(s_ecat_context);
-    if (slave_count <= 0) {
-        ESP_LOGE(TAG, "No EtherCAT slaves found");
-        esp_soem_deinit(s_ecat_context);
-        return;
-    }
-
+    ESP_ERROR_CHECK(slave_count > 0 ? ESP_OK : ESP_FAIL);
     ESP_LOGI(TAG, "%d EtherCAT slave(s) found", slave_count);
 
-    /* 扫描后限制只能连接这一块板 */
-    if (slave_count != 1) {
-        ESP_LOGE(TAG, "Expected exactly one EtherCAT slave");
-        esp_soem_deinit(s_ecat_context);
-        return;
-    }
-
-    /* PRE-OP检查循环 */
-    for (int i = 1; i <= slave_count; i++) {
-        /*
-         * 先等待从站进入PRE-OP。
-         * ecx_statecheck只用状态低四位判断，因此它可能在ERROR位清除前返回。
-         */
-        (void)ecx_statecheck(
-            s_ecat_context,
-            (uint16)i,
-            EC_STATE_PRE_OP,
-            EC_TIMEOUTSTATE);
-
-        /*
-         * 给从站一点时间处理状态变化，然后重新读取完整状态和AL Status Code。
-         */
-        vTaskDelay(pdMS_TO_TICKS(20));
-
-        int lowest_state = ecx_readstate(s_ecat_context);
-        ec_slavet *slave = &s_ecat_context->slavelist[i];
-        /* 从站身份检查 */
-        if ((slave->eep_man != EXPECTED_VENDOR_ID) ||
-            (slave->eep_id != EXPECTED_PRODUCT_ID) ||
-            (slave->eep_rev != EXPECTED_REVISION)) {
-            ESP_LOGE(TAG,
-                     "Unexpected slave identity; refusing register configuration");
-            esp_soem_deinit(s_ecat_context);
-            return;
-        }
-
-        ESP_LOGI(TAG, "State refresh result=0x%02x", lowest_state);
-
-        ESP_LOGI(TAG,
-                 "Slave %d: name='%s', state=0x%04x, config=0x%04x, "
-                 "vendor=0x%08" PRIx32 ", product=0x%08" PRIx32
-                 ", revision=0x%08" PRIx32,
-                 i,
-                 slave->name,
-                 slave->state,
-                 slave->configadr,
-                 slave->eep_man,
-                 slave->eep_id,
-                 slave->eep_rev);
-
-        ESP_LOGI(TAG,
-                 "Slave %d AL status: 0x%04x (%s)",
-                 i,
-                 slave->ALstatuscode,
-                 ec_ALstatuscode2string(slave->ALstatuscode));
-
-        if (((slave->state & 0x000f) != EC_STATE_PRE_OP) ||
-            ((slave->state & EC_STATE_ERROR) != 0)) {
-            ESP_LOGW(TAG,
-                    "Slave %d needs AL error acknowledge: "
-                    "state=0x%04x, AL status=0x%04x (%s)",
-                    i,
-                    slave->state,
-                    slave->ALstatuscode,
-                    ec_ALstatuscode2string(slave->ALstatuscode));
-
-            /*
-            * 按当前基础状态PRE-OP，加上ACK位写入AL Control。
-            * 这里只确认状态错误，不涉及EEPROM、SM或FMMU。
-            */
-            slave->state =
-            (slave->state & 0x000f) | EC_STATE_ACK;
-
-            int ack_wkc = ecx_writestate(s_ecat_context, (uint16)i);
-            ESP_LOGI(TAG, "AL error acknowledge WKC=%d", ack_wkc);
-
-            if (ack_wkc <= 0) {
-                ESP_LOGE(TAG, "Failed to send AL error acknowledge");
-                esp_soem_deinit(s_ecat_context);
-                return;
-            }
-
-            vTaskDelay(pdMS_TO_TICKS(20));
-            (void)ecx_readstate(s_ecat_context);
-
-            ESP_LOGI(TAG,
-                    "After ACK: state=0x%04x, AL status=0x%04x (%s)",
-                    slave->state,
-                    slave->ALstatuscode,
-                    ec_ALstatuscode2string(slave->ALstatuscode));
-
-            /*
-            * ACK已成功写入，但ERROR位仍保留。
-            * 再写一次不带ACK位的纯PRE-OP请求，观察状态位是否清除。
-            */
-            slave->state = EC_STATE_PRE_OP;
-
-            int preop_wkc =
-                ecx_writestate(s_ecat_context, (uint16)i);
-            ESP_LOGI(TAG, "Clean PRE-OP request WKC=%d", preop_wkc);
-
-            if (preop_wkc <= 0) {
-                ESP_LOGE(TAG, "Failed to send clean PRE-OP request");
-                esp_soem_deinit(s_ecat_context);
-                return;
-            }
-
-            vTaskDelay(pdMS_TO_TICKS(20));
-            (void)ecx_readstate(s_ecat_context);
-
-            ESP_LOGI(TAG,
-                    "After clean PRE-OP request: "
-                    "state=0x%04x, AL status=0x%04x (%s)",
-                    slave->state,
-                    slave->ALstatuscode,
-                    ec_ALstatuscode2string(slave->ALstatuscode));
-        }
-
-        if ((slave->state != EC_STATE_PRE_OP) ||
-        (slave->ALstatuscode != 0)) {
-            ESP_LOGE(TAG,
-                    "Slave %d failed to reach clean PRE-OP: "
-                    "state=0x%04x, AL status=0x%04x (%s)",
-                    i,
-                    slave->state,
-                    slave->ALstatuscode,
-                    ec_ALstatuscode2string(slave->ALstatuscode));
-            esp_soem_deinit(s_ecat_context);
-            return;
-        }
-
-        ESP_LOGI(TAG, "Slave %d reached clean PRE-OP", i);
-    }
-
-    /* 在从站已经处于PRE-OP后，手工写入SM/FMMU配置，然后重新读取从站状态，
-    确认这次配置没有把从站“配坏”。如果出现AL错误或掉出PRE-OP，就立即停止 */
-    if (!configure_runtime_mapping(1)) {
-        ESP_LOGE(TAG, "Runtime SM/FMMU mapping failed");
-        esp_soem_deinit(s_ecat_context);
-        return;
-    }
-
-    vTaskDelay(pdMS_TO_TICKS(20)); /* blocking delay，给从站ESC一点时间，让刚写进去的配置产生作用、状态稳定下来 */
-    (void)ecx_readstate(s_ecat_context); /*重新读取各从站AL Status及其Code，更新soem内存中的描述 */
-
-    ec_slavet *slave = &s_ecat_context->slavelist[1];
-    ESP_LOGI(TAG,
-             "After mapping: state=0x%04x, AL status=0x%04x (%s)",
-             slave->state,
-             slave->ALstatuscode,
-             ec_ALstatuscode2string(slave->ALstatuscode));
-
-    if ((slave->state != EC_STATE_PRE_OP) || /* 配置完后仍然处于pre-op阶段 */
-        (slave->ALstatuscode != 0)) { /* AL Status Code全零，表示没有错误*/
-        ESP_LOGE(TAG, "Slave left clean PRE-OP after mapping");
-        esp_soem_deinit(s_ecat_context);
-        return;
-    }
-
-    /* 请求从站进入SAFE-OP状态 */
-    ESP_LOGI(TAG, "Requesting SAFE-OP");
-
-    if (!request_clean_state(1, EC_STATE_SAFE_OP)) {
-        ESP_LOGE(TAG, "Slave did not reach clean SAFE-OP");
-        esp_soem_deinit(s_ecat_context);
-        return;
-    }
-
-    ESP_LOGI(TAG, "Slave reached clean SAFE-OP");
-
-    /* SAFE_OP LRW探针测试，验证整条Process Data数据链路能真的跑通 */
-    #if 0
-    /* 临时创建过程数据映射数组，就是ECAT网络逻辑地址虚拟内存数组 */
-    uint8 process_image[2] = {0x00, 0x00};
-    /* 控制日志输出，每个周期都打印会很吵，只在1st或者Input数据变化的时候打印log */
-    uint8 previous_input = 0; /* 上次输入数据 */
-    int first_input = 1; /* 是否是第一次输入 */
-
-    /* 统计各种wkc，不只是想知道有没有失败，更想知道每次失败的具体表现；一切为了probe诊断 */
-    int wkc_0 = 0;
-    int wkc_1 = 0;
-    int wkc_2 = 0;
-    int wkc_3 = 0;
-    int wkc_other = 0;
-
-    ESP_LOGI(TAG, "Starting five-second SAFE-OP LRW probe");
-    ESP_LOGI(TAG, "Output is fixed at 0x00; press and release SW1");
-
-    for (int cycle = 0; cycle < PROBE_CYCLES; cycle++) {
-        /* 逻辑字节0是输出，每次强制为0。LRW返回后，逻辑字节1包含从站输入。*/
-        process_image[0] = 0x00;
-
-        int wkc = ecx_LRW(
-            &s_ecat_context->port,
-            OUTPUT_LOG_ADDR,
-            sizeof(process_image),
-            process_image,
-            EC_TIMEOUTRET3);
-
-        switch (wkc) {
-        case 0:
-            wkc_0++;
-            break;
-        case 1:
-            wkc_1++;
-            break;
-        case 2:
-            wkc_2++;
-            break;
-        case EXPECTED_LRW_WKC:
-            wkc_3++;
-            break;
-        default:
-            wkc_other++;
-            break;
-        }
-
-        if ((wkc == EXPECTED_LRW_WKC) &&
-            (first_input || process_image[1] != previous_input)) {
-            ESP_LOGI(TAG,
-                    "Cycle %d: WKC=%d input=0x%02x",
-                    cycle,
-                    wkc,
-                    process_image[1]);
-
-            previous_input = process_image[1];
-            first_input = 0;
-        }
-
-        vTaskDelay(pdMS_TO_TICKS(PROBE_PERIOD_MS)); /* 阻塞延迟，让探针周期性运行；当前并非精准ECAT周期控制 */
-    }
-
-    ESP_LOGI(TAG,
-            "WKC summary: 0=%d 1=%d 2=%d 3=%d other=%d",
-            wkc_0,
-            wkc_1,
-            wkc_2,
-            wkc_3,
-            wkc_other);
-
-    /* 全部探针周期跑完后，再次读取ESC AL状态，确认5s持续LRW不会让从站状态机出错 */
-    (void)ecx_readstate(s_ecat_context);
-    slave = &s_ecat_context->slavelist[1];
-
-    ESP_LOGI(TAG,
-            "After SAFE-OP probe: state=0x%04x, "
-            "AL status=0x%04x (%s)",
-            slave->state,
-            slave->ALstatuscode,
-            ec_ALstatuscode2string(slave->ALstatuscode));
-
-    if ((wkc_3 != PROBE_CYCLES) ||
-        (slave->state != EC_STATE_SAFE_OP) ||
-        (slave->ALstatuscode != 0)) {
-        ESP_LOGE(TAG, "SAFE-OP LRW probe failed");
-    } else {
-        ESP_LOGI(TAG, "SAFE-OP LRW probe passed");
-    }
-    #endif
-
-    ESP_LOGI(TAG, "Requesting OPERATIONAL with continuous LRW");
-    uint8 process_image[2] = {0x00, 0x00};
-    if (!request_operational(1, process_image)) {
-        ESP_LOGE(TAG, "Slave did not reach clean OPERATIONAL");
-
-        (void)request_clean_state(1, EC_STATE_INIT);
-        esp_soem_deinit(s_ecat_context);
-        return;
-    }
-
-    ESP_LOGI(TAG, "Slave reached clean OPERATIONAL");
-
-    /* OP LRW探针测试 */
-    #if 0
-    ESP_LOGI(TAG, "Starting five-second OP probe; output fixed at 0x00");
-
-    int op_wkc_good = 0;
-    int op_wkc_bad = 0;
-    uint8 previous_op_input = process_image[1];
-    int first_op_input = 1;
-
-    for (int cycle = 0; cycle < PROBE_CYCLES; cycle++) {
-        /* OP期间仍然始终强制输出为0。 */
-        process_image[0] = 0x00;
-
-        int wkc = ecx_LRW(
-            &s_ecat_context->port,
-            OUTPUT_LOG_ADDR,
-            sizeof(process_image),
-            process_image,
-            EC_TIMEOUTRET3);
-
-        if (wkc == EXPECTED_LRW_WKC) {
-            op_wkc_good++;
-        } else {
-            op_wkc_bad++;
-        }
-
-        if ((wkc == EXPECTED_LRW_WKC) &&
-            (first_op_input ||
-            process_image[1] != previous_op_input)) {
-            ESP_LOGI(TAG,
-                    "OP cycle %d: WKC=%d input=0x%02x",
-                    cycle,
-                    wkc,
-                    process_image[1]);
-
-            previous_op_input = process_image[1];
-            first_op_input = 0;
-        }
-
-        vTaskDelay(pdMS_TO_TICKS(PROBE_PERIOD_MS));
-    }
-
-    (void)ecx_readstate(s_ecat_context);
-    slave = &s_ecat_context->slavelist[1];
-
-    ESP_LOGI(TAG,
-            "OP WKC summary: good=%d bad=%d",
-            op_wkc_good,
-            op_wkc_bad);
-
-    ESP_LOGI(TAG,
-            "After OP probe: state=0x%04x, "
-            "AL status=0x%04x (%s)",
-            slave->state,
-            slave->ALstatuscode,
-            ec_ALstatuscode2string(slave->ALstatuscode));
-
-    if ((op_wkc_good != PROBE_CYCLES) ||
-        (slave->state != EC_STATE_OPERATIONAL) ||
-        (slave->ALstatuscode != 0)) {
-        ESP_LOGE(TAG, "OP LRW probe failed");
-    } else {
-        ESP_LOGI(TAG, "OP LRW probe passed");
-    }
-    #endif
-
-    // /* example结束前返回 INIT */
-    // ESP_LOGI(TAG, "Returning slave to INIT");
-
-    // if (!request_clean_state(1, EC_STATE_INIT)) {
-    //     ESP_LOGE(TAG, "Slave did not return to clean INIT");
-    //     esp_soem_deinit(s_ecat_context);
-    //     return;
-    // }
-
-    // esp_soem_deinit(s_ecat_context);
-    // ESP_LOGI(TAG, "SOEM port closed");
-
-    /*
-    * 正式闭环：
-    * SW1输入bit 0低有效；
-    * LED3输出bit 0高有效。
-    *
-    * 首个周期输出固定为0。每次成功LRW读取当前输入后，
-    * 计算下一周期的输出，因此存在一个周期的正常闭环延迟。
-    */
-    uint8 next_output = 0x00;
-    uint8 previous_input = 0;
-    int first_input = 1;
-    int consecutive_wkc_errors = 0;
-    uint32_t cycle = 0;
-    int communication_healthy = 1;
-
-    TickType_t last_wake_time = xTaskGetTickCount();
-
-    ESP_LOGI(TAG, "EtherCAT closed-loop IO started");
-    ESP_LOGI(TAG, "Press SW1: LED3 ON; release SW1: LED3 OFF");
-
-    while ((xEventGroupGetBits(s_eth_events) &
-            ETH_LINK_UP_BIT) != 0) {
-        /*
-        * 使用上个周期根据输入计算出的输出值。
-        * 启动时next_output为0，保证LED默认关闭。
-        */
-        process_image[0] = next_output;
-
-        int wkc = ecx_LRW(
-            &s_ecat_context->port,
-            OUTPUT_LOG_ADDR,
-            sizeof(process_image),
-            process_image,
-            EC_TIMEOUTRET3);
-
-        if (wkc != IO_EXPECTED_WKC) {
-            consecutive_wkc_errors++;
-
-            ESP_LOGW(TAG,
-                    "Cycle %" PRIu32 ": unexpected WKC=%d "
-                    "(consecutive=%d)",
-                    cycle,
-                    wkc,
-                    consecutive_wkc_errors);
-
-            if (consecutive_wkc_errors >=
-                IO_MAX_CONSECUTIVE_WKC_ERRORS) {
-                ESP_LOGE(TAG,
-                        "Too many consecutive WKC errors; "
-                        "stopping closed-loop IO");
-
-                communication_healthy = 0;
-                break;
-            }
-        } else {
-            consecutive_wkc_errors = 0;
-
-            uint8 current_input = process_image[1];
-            int sw1_pressed =
-                (current_input & SW1_INPUT_MASK) == 0;
-
-            next_output = sw1_pressed
-                ? LED3_OUTPUT_MASK
-                : 0x00;
-
-            if (first_input ||
-                current_input != previous_input) {
-                ESP_LOGI(TAG,
-                        "Cycle %" PRIu32 ": "
-                        "input=0x%02x SW1=%s, "
-                        "next output=0x%02x LED3=%s",
-                        cycle,
-                        current_input,
-                        sw1_pressed ? "PRESSED" : "RELEASED",
-                        next_output,
-                        sw1_pressed ? "ON" : "OFF");
-
-                previous_input = current_input;
-                first_input = 0;
-            }
-        }
-
-        cycle++;
-
-        /*
-        * 相比vTaskDelay，以固定唤醒基准运行，
-        * 避免每个周期额外累积LRW执行时间。
-        */
-        vTaskDelayUntil(
-            &last_wake_time,
-            pdMS_TO_TICKS(IO_CYCLE_PERIOD_MS));
-    }
-
-    ESP_LOGW(TAG, "EtherCAT closed-loop IO stopped");
-
-    /*
-    * 链路仍在时，尽力发送10帧零输出，
-    * 确保LED3在退出OP前关闭。
-    */
-    if (communication_healthy &&
-        ((xEventGroupGetBits(s_eth_events) &
-          ETH_LINK_UP_BIT) != 0)) {
-        ESP_LOGI(TAG, "Forcing output to 0x00");
-
-        for (int i = 0; i < 10; i++) {
-            process_image[0] = 0x00;
-
-            int wkc = ecx_LRW(
-                &s_ecat_context->port,
-                OUTPUT_LOG_ADDR,
-                sizeof(process_image),
-                process_image,
-                EC_TIMEOUTRET3);
-
-            if (wkc != IO_EXPECTED_WKC) {
-                ESP_LOGW(TAG,
-                        "Zero-output cleanup WKC=%d",
-                        wkc);
-                break;
-            }
-
-            vTaskDelay(pdMS_TO_TICKS(
-                IO_CYCLE_PERIOD_MS));
-        }
-
-        /*
-        * 正常退出顺序：OP → SAFE-OP → INIT。
-        */
-        ESP_LOGI(TAG, "Returning slave to SAFE-OP");
-        if (!request_clean_state(
-                1, EC_STATE_SAFE_OP)) {
-            ESP_LOGE(TAG,
-                    "Failed to return slave to SAFE-OP");
-        }
-
-        ESP_LOGI(TAG, "Returning slave to INIT");
-        if (!request_clean_state(
-                1, EC_STATE_INIT)) {
-            ESP_LOGE(TAG,
-                    "Failed to return slave to INIT");
-        }
-    } else {
-        ESP_LOGW(TAG,
-                 "EtherCAT communication unavailable; "
-                 "skipping output and state cleanup");
-    }
-
+    /* Example uses a fixed process-data mapping for one LAN9252 slave. */
+    const uint16_t slave_index = 1;
+    ec_slavet *slave = &s_ecat_context->slavelist[slave_index];
+
+    /* Check slave's identity.*/
+    ESP_ERROR_CHECK(slave_count == 1 ? ESP_OK : ESP_ERR_INVALID_SIZE);
+    ESP_ERROR_CHECK(
+        ((slave->eep_man == EXPECTED_VENDOR_ID) &&
+        (slave->eep_id == EXPECTED_PRODUCT_ID) &&
+        (slave->eep_rev == EXPECTED_REVISION)) ? ESP_OK : ESP_ERR_INVALID_RESPONSE);
+    ESP_LOGI(
+        TAG, "Slave: vendor=0x%08" PRIx32 ", product=0x%08" PRIx32 ", revision=0x%08" PRIx32,
+        slave->eep_man, slave->eep_id, slave->eep_rev);
+
+    /* stage4: Ensure the slave is in PRE-OP before configuring the ESC. */
+    ESP_ERROR_CHECK(example_request_state(
+        slave_index, EC_STATE_PRE_OP) ? ESP_OK : ESP_ERR_INVALID_STATE);
+    ESP_LOGI(TAG, "Slave reached PRE-OP");
+
+    /* stage5: Configure process-data mapping. */
+    ESP_ERROR_CHECK(example_configure_process_data_mapping(slave_index) ? ESP_OK : ESP_FAIL);
+    ESP_LOGI(TAG, "Process-data mapping configured");
+
+    /* stage6: Ask for entering SAFE-OP and confirm it. */
+    ESP_ERROR_CHECK(example_request_state(
+        slave_index, EC_STATE_SAFE_OP) ? ESP_OK : ESP_ERR_INVALID_STATE);
+    ESP_LOGI(TAG, "Slave reached SAFE-OP");
+
+    /* stage7: Ask for entering OP state and confirm it.
+       Process-data communication must remain active during such transition. */
+    ESP_ERROR_CHECK(example_request_state_op(
+        slave_index) ? ESP_OK : ESP_ERR_INVALID_STATE);
+    ESP_LOGI(TAG, "Slave reached OP");
+
+    /* stage8: Run cyclic IO closed-loop. */
+    example_run_cyclic_io(s_ecat_context, s_eth_events);
+
+    /* stage9: Resource release when cyclic IO error occurs. */
+    ESP_ERROR_CHECK(esp_event_handler_unregister(ETH_EVENT, ESP_EVENT_ANY_ID, eth_event_handler));
+    ESP_ERROR_CHECK(esp_eth_stop(eth_handle));
     esp_soem_deinit(s_ecat_context);
-    ESP_LOGI(TAG, "SOEM port closed");
+    s_ecat_context = NULL;
+    ESP_ERROR_CHECK(example_eth_deinit(eth_handle));
+    eth_handle = NULL;
+    ESP_ERROR_CHECK(esp_event_loop_delete_default());
+    vEventGroupDelete(s_eth_events);
+    s_eth_events = NULL;
+    ESP_LOGI(TAG, "EtherCAT example stopped");
 }

--- a/soem/examples/ecat_io/main/idf_component.yml
+++ b/soem/examples/ecat_io/main/idf_component.yml
@@ -2,4 +2,4 @@ description: EtherCAT digital IO example
 dependencies:
   espressif/soem:
     version: "*"
-    override_path: "../../../" #本地相对路径，避免从registry下载
+    override_path: "../../../"

--- a/soem/examples/ecat_io/main/idf_component.yml
+++ b/soem/examples/ecat_io/main/idf_component.yml
@@ -1,0 +1,5 @@
+description: EtherCAT digital IO example
+dependencies:
+  espressif/soem:
+    version: "*"
+    override_path: "../../../" #本地相对路径，避免从registry下载

--- a/soem/examples/ecat_io/sdkconfig.defaults
+++ b/soem/examples/ecat_io/sdkconfig.defaults
@@ -1,4 +1,2 @@
-# 编译时生成的sdkconfig基于以下默认配置
-# -----------------------------------------------------------------------------------
-CONFIG_ETH_ENABLED=y            # 启用Ethernet相关功能
-CONFIG_ETH_USE_ESP32_EMAC=y     # 使用ESP32内部的Ethernet MAC外设
+CONFIG_ETH_ENABLED=y
+CONFIG_ETH_USE_ESP32_EMAC=y

--- a/soem/examples/ecat_io/sdkconfig.defaults
+++ b/soem/examples/ecat_io/sdkconfig.defaults
@@ -1,0 +1,4 @@
+# 编译时生成的sdkconfig基于以下默认配置
+# -----------------------------------------------------------------------------------
+CONFIG_ETH_ENABLED=y            # 启用Ethernet相关功能
+CONFIG_ETH_USE_ESP32_EMAC=y     # 使用ESP32内部的Ethernet MAC外设

--- a/soem/idf_component.yml
+++ b/soem/idf_component.yml
@@ -1,0 +1,8 @@
+version: "0.0.1"
+description: Simple Open EtherCAT Master (SOEM) port for ESP-IDF
+# url: https://github.com/espressif/idf-extra-components/tree/master/soem
+# issues: https://github.com/espressif/idf-extra-components/issues
+# repository: https://github.com/espressif/idf-extra-components.git
+# documentation: https://docs.rt-labs.com/soem
+dependencies:
+  idf: ">=6.0"

--- a/soem/idf_component.yml
+++ b/soem/idf_component.yml
@@ -1,8 +1,8 @@
-version: "0.0.1"
+version: "2.0.0"
 description: Simple Open EtherCAT Master (SOEM) port for ESP-IDF
-# url: https://github.com/espressif/idf-extra-components/tree/master/soem
-# issues: https://github.com/espressif/idf-extra-components/issues
-# repository: https://github.com/espressif/idf-extra-components.git
-# documentation: https://docs.rt-labs.com/soem
+url: https://github.com/espressif/idf-extra-components/tree/master/soem
+repository: https://github.com/espressif/idf-extra-components.git
+documentation: https://docs.rt-labs.com/soem
+issues: https://github.com/espressif/idf-extra-components/issues
 dependencies:
   idf: ">=6.0"

--- a/soem/port/esp_soem.c
+++ b/soem/port/esp_soem.c
@@ -1,6 +1,32 @@
 #include "esp_soem.h"
 
-const char *esp_soem_get_version(void)
+#include <stdlib.h>
+
+/* Initialize SOEM with an ESP-IDF Ethernet driver.
+   The returned context is allocated internally and must be released by esp_soem_deinit(). */
+ecx_contextt *esp_soem_init(esp_eth_handle_t eth_handle)
 {
-    return ESP_SOEM_VERSION_STRING;
+    if (eth_handle == NULL) {
+        return NULL;
+    }
+    ecx_contextt *context = calloc(1, sizeof(*context));
+    if (context == NULL) {
+        return NULL;
+    }
+    context->port.eth_handle = eth_handle;
+    if (!ecx_init(context, "esp_eth")) {
+        ecx_close(context);
+        free(context);
+        return NULL;
+    }
+    return context;
+}
+
+void esp_soem_deinit(ecx_contextt *context)
+{
+    if (context == NULL) {
+        return;
+    }
+    ecx_close(context);
+    free(context);
 }

--- a/soem/port/esp_soem.c
+++ b/soem/port/esp_soem.c
@@ -1,0 +1,6 @@
+#include "esp_soem.h"
+
+const char *esp_soem_get_version(void)
+{
+    return ESP_SOEM_VERSION_STRING;
+}

--- a/soem/port/esp_soem.c
+++ b/soem/port/esp_soem.c
@@ -1,5 +1,10 @@
-#include "esp_soem.h"
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
+#include "esp_soem.h"
 #include <stdlib.h>
 
 /* Initialize SOEM with an ESP-IDF Ethernet driver.

--- a/soem/port/include/esp_soem.h
+++ b/soem/port/include/esp_soem.h
@@ -2,7 +2,7 @@
 
 #include "esp_err.h"
 #include "esp_eth_driver.h"
-#include "soem/soem.h" /* 把SOEM CORE API囊括进本组件公开接口，CMakeLists里要设置好头文件搜索路径 */
+#include "soem/soem.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -10,25 +10,11 @@ extern "C" {
 
 #define ESP_SOEM_VERSION_STRING "0.0.1"
 
-/**
- * @brief Return the ESP-IDF SOEM port version.
- */
 const char *esp_soem_get_version(void);
 
-/**
- * @brief Bind an initialized ESP-IDF Ethernet driver to SOEM.
- *
- * The Ethernet driver remains owned by the application. SOEM just borrows it.
- *
- * @param eth Initialized ESP-IDF Ethernet driver handle.
- *
- * @return
- *      - ESP_OK on success
- *      - ESP_ERR_INVALID_ARG when eth is NULL
- */
-esp_err_t esp_soem_bind_eth(esp_eth_handle_t eth);  /* 开放给用户在应用层调用 */
+esp_err_t esp_soem_bind_eth(esp_eth_handle_t eth);
 
-/* maybe add soem other component's api here, if necessary */
+
 #ifdef __cplusplus
 }
 #endif

--- a/soem/port/include/esp_soem.h
+++ b/soem/port/include/esp_soem.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "esp_err.h"
+#include "esp_eth_driver.h"
+#include "soem/soem.h" /* 把SOEM CORE API囊括进本组件公开接口，CMakeLists里要设置好头文件搜索路径 */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESP_SOEM_VERSION_STRING "0.0.1"
+
+/**
+ * @brief Return the ESP-IDF SOEM port version.
+ */
+const char *esp_soem_get_version(void);
+
+/**
+ * @brief Bind an initialized ESP-IDF Ethernet driver to SOEM.
+ *
+ * The Ethernet driver remains owned by the application. SOEM just borrows it.
+ *
+ * @param eth Initialized ESP-IDF Ethernet driver handle.
+ *
+ * @return
+ *      - ESP_OK on success
+ *      - ESP_ERR_INVALID_ARG when eth is NULL
+ */
+esp_err_t esp_soem_bind_eth(esp_eth_handle_t eth);  /* 开放给用户在应用层调用 */
+
+/* maybe add soem other component's api here, if necessary */
+#ifdef __cplusplus
+}
+#endif

--- a/soem/port/include/esp_soem.h
+++ b/soem/port/include/esp_soem.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "esp_eth_driver.h"

--- a/soem/port/include/esp_soem.h
+++ b/soem/port/include/esp_soem.h
@@ -13,8 +13,14 @@
 extern "C" {
 #endif
 
+/* Allocate a SOEM context and install the SOEM raw-frame Rx callback
+   on the supplied Ethernet driver. The Ethernet driver remains owned by the application.
+   @param eth_handle, Handle of an installed ESP-IDF Ethernet driver.
+   @return Pointer to the allocated SOEM context, or NULL on failure. */
 ecx_contextt *esp_soem_init(esp_eth_handle_t eth_handle);
 
+/* Release a SOEM context.
+   @param context, SOEM context returned by esp_soem_init(). May be NULL. */
 void esp_soem_deinit(ecx_contextt *context);
 
 #ifdef __cplusplus

--- a/soem/port/include/esp_soem.h
+++ b/soem/port/include/esp_soem.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "esp_err.h"
 #include "esp_eth_driver.h"
 #include "soem/soem.h"
 
@@ -8,12 +7,9 @@
 extern "C" {
 #endif
 
-#define ESP_SOEM_VERSION_STRING "0.0.1"
+ecx_contextt *esp_soem_init(esp_eth_handle_t eth_handle);
 
-const char *esp_soem_get_version(void);
-
-esp_err_t esp_soem_bind_eth(esp_eth_handle_t eth);
-
+void esp_soem_deinit(ecx_contextt *context);
 
 #ifdef __cplusplus
 }

--- a/soem/port/osal/osal.c
+++ b/soem/port/osal/osal.c
@@ -1,0 +1,265 @@
+//soem core的实现，需要平台底层软件操作系统的支持
+//所以编撰本osal.c源文件，提供ESP-IDF/FreeRTOS接口适配，包括时间、休眠、任务、内存和互斥锁等
+
+#include "osal.h"
+
+#include <stdlib.h>
+#include <sys/time.h>
+
+#include "esp_rom_sys.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+
+/*
+两个用于时间格式转换的内部辅助函数；
+ESP-IDF的esp_timer_get_time()使用微妙整数结构，比如1234567us；
+而SOEM里的时间采用struct timespec结构，包含秒和纳秒，比如1s+234567000ns；
+所以需要一个时间格式的翻译器；
+*/
+static void usec_to_timespec(int64_t usec, ec_timet *ts)//将idf的us转成soem的(s+ns)
+{
+    ts->tv_sec = (time_t)(usec / 1000000);
+    ts->tv_nsec = (long)((usec % 1000000) * 1000);
+}
+
+static int64_t timespec_to_usec(const ec_timet *ts)//将soem的(s+ns)转成idf的us，供idf的单调时钟比较
+{
+    return (int64_t)ts->tv_sec * 1000000 +
+           (int64_t)ts->tv_nsec / 1000;
+}
+
+/*
+esp_timer_get_time()返回自系统启动以来的单调递增微秒数；
+转成soem时间格式后，适合拿来做超时、耗时测试等；
+*/
+void osal_get_monotonic_time(ec_timet *ts)
+{
+    usec_to_timespec(esp_timer_get_time(), ts);
+}
+
+/*
+gettimeofday()返回自1970年1月1日以来的秒和微秒，反映的是系统所认为的现实时间；
+转成soem时间格式后，适合拿来做日志时间戳、DC初始化等；最小移植用不到；P4上电后的系统现实时间不一定准；
+*/
+ec_timet osal_current_time(void)
+{
+    struct timeval tv;
+    ec_timet ts = {0};
+
+    if (gettimeofday(&tv, NULL) == 0) {
+        ts.tv_sec = tv.tv_sec;
+        ts.tv_nsec = (long)tv.tv_usec * 1000;
+    }
+
+    return ts;
+}
+
+/*
+计算soem时间格式下两个时间点的差值；再用指针把结果传出去；
+*/
+void osal_time_diff(ec_timet *start, ec_timet *end, ec_timet *diff)
+{
+    osal_timespecsub(end, start, diff);//运算宏
+}
+
+/*
+基于现在的soem格式的单增时间，往后延一些微秒数(会转成soem时间格式)；
+做加法后就设置了一个截止时间点(超时判定时间点)，soem时间格式；
+并用指针传出去；
+*/
+void osal_timer_start(osal_timert *self, uint32 timeout_usec)
+{
+    ec_timet now;
+    ec_timet timeout;
+
+    osal_get_monotonic_time(&now);
+    osal_timespec_from_usec(timeout_usec, &timeout);
+    osal_timespecadd(&now, &timeout, &self->stop_time);//运算宏
+}
+
+/*
+当前单调递增时间与所设定的截止时间点(超时判定时间点)比大小；
+返回1表示超时了；
+soem core收ecat报文的时候，经常会用这个机制，等从站响应->没收到->检查是否超时->没超时就继续等，超时了就返回失败；
+*/
+boolean osal_timer_is_expired(osal_timert *self)
+{
+    ec_timet now;
+
+    osal_get_monotonic_time(&now);
+    return osal_timespeccmp(&now, &self->stop_time, >=) ? TRUE : FALSE;//运算宏
+}
+
+/*
+休眠到某个绝对时间点；函数内部会先把目标时间转换成us数；
+*/
+int osal_monotonic_sleep(ec_timet *ts)
+{
+    const int64_t target_usec = timespec_to_usec(ts);
+    const int64_t tick_usec = 1000000LL / configTICK_RATE_HZ;
+
+    for (;;) {
+        int64_t remaining_usec = target_usec - esp_timer_get_time();
+
+        if (remaining_usec <= 0) {
+            return 0;
+        }
+
+        /*
+         * 较长等待先让出CPU；最后不足一个FreeRTOS tick的部分使用
+         * 微秒忙等，避免所有短延时都被向上取整为一个完整tick。
+         */
+        if (remaining_usec >= tick_usec) {
+            TickType_t ticks = (TickType_t)(remaining_usec / tick_usec);
+
+            if (ticks > 0) {
+                vTaskDelay(ticks);
+                continue;
+            }
+        }
+
+        /*
+         * 每次忙等最多1 ms，循环后重新读取单调时钟，
+         * 避免大延时长期占用CPU。
+         */
+        uint32_t busy_usec = (remaining_usec > 1000)
+                                 ? 1000
+                                 : (uint32_t)remaining_usec;
+        esp_rom_delay_us(busy_usec);
+    }
+}
+
+/*
+休眠一段时间，形参单位us；
+内部使用绝对截止时间，FreeRTOS提前或延迟唤醒后会重新计算剩余时间，避免简单vTaskDelay产生持续累计漂移；
+仍不是严格实时定时，freertos调度、其他任务和中断都会产生抖动；
+*/
+int osal_usleep(uint32 usec)
+{
+    ec_timet deadline;
+
+    usec_to_timespec(esp_timer_get_time() + (int64_t)usec, &deadline);
+    return osal_monotonic_sleep(&deadline);
+}
+
+/*
+下面两个函数是soem申请/释放一块动态内存；
+当前最小移植就是直接调用ESP-IDF的普通heap，以后若DMA或cache对齐有特殊要求再调整；
+*/
+void *osal_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+void osal_free(void *ptr)
+{
+    free(ptr);
+}
+
+static int osal_task_create(void *thandle,
+                            int stacksize,
+                            void *func,
+                            void *param,
+                            UBaseType_t priority,
+                            const char *name)
+{
+    TaskHandle_t *handle = (TaskHandle_t *)thandle;
+    TaskFunction_t entry = (TaskFunction_t)func;
+    uint32_t stack_bytes = (stacksize > 0) ? (uint32_t)stacksize : 4096U;
+
+    if (handle == NULL || entry == NULL) {
+        return 0;
+    }
+
+    /*
+     * ESP-IDF版本的xTaskCreate栈参数单位是字节。
+     * SOEM通过void *传入线程入口，这里转换为FreeRTOS任务入口类型。
+     */
+    BaseType_t result = xTaskCreate(entry,
+                                    name,
+                                    stack_bytes,
+                                    param,
+                                    priority,
+                                    handle);
+
+    return result == pdPASS ? 1 : 0;
+}
+
+/*
+上面、这个、下面 三个函数是一体的；
+SOEM里的thread，在ESP-IDF里要变成freertos task；
+SOEM主要可能在这些场景使用线程：并行PDO Mapping、示例中的周期任务、状态监控任务；
+这是创建普通soem后台任务，默认任务优先级是5；
+而下面_rt后缀版本的是创建实时性要求更高的soem后台任务，默认任务优先级更高(数更小)；
+设计上面static内部辅助函数的目的是抽出公共部分，只留不同的priority和name作为传参，避免重复coding；
+目前不一定用到，仅为移植完备性考虑；
+*/
+int osal_thread_create(void *thandle, int stacksize, void *func, void *param)
+{
+    UBaseType_t priority = 5;
+
+    if (priority >= configMAX_PRIORITIES) {
+        priority = configMAX_PRIORITIES - 1;
+    }
+
+    return osal_task_create(thandle,
+                            stacksize,
+                            func,
+                            param,
+                            priority,
+                            "soem_worker");
+}
+
+int osal_thread_create_rt(void *thandle,
+                          int stacksize,
+                          void *func,
+                          void *param)
+{
+    UBaseType_t priority = (configMAX_PRIORITIES > 2)
+                               ? configMAX_PRIORITIES - 2
+                               : configMAX_PRIORITIES - 1;
+
+    return osal_task_create(thandle,
+                            stacksize,
+                            func,
+                            param,
+                            priority,
+                            "soem_worker_rt");
+}
+
+
+/*
+下面四个函数是soem在esp-idf平台下 创建/销毁/上锁/解锁 一个互斥锁mutual exclusion；
+在FreeRTOS里，信号量semaphore和互斥锁mutex共用了同一套xSemaphore... API家族，所以名字容易搞混;
+SOEMv2.0用Mutex保护：Mailbox buffer池、Mailbox发送队列、多任务共享的数据结构；
+*/
+void *osal_mutex_create(void)//创建互斥锁
+{
+    return (void *)xSemaphoreCreateMutex();
+}
+
+void osal_mutex_destroy(void *mutex)//销毁互斥锁
+{
+    if (mutex != NULL) {   /* 销毁一个不存在的mutex会导致崩溃，这里先检查锁指针是否为空，以便以后无脑调用 */
+        vSemaphoreDelete((SemaphoreHandle_t)mutex);
+    }
+}
+
+void osal_mutex_lock(void *mutex)//给互斥锁上锁，阻塞式
+{
+    if (mutex != NULL) {
+        /* 第二个参数表示：为了拿到这个锁，我最多愿意阻塞等待多少个tick；
+        portMAX_DELAY表示永久等待，直到锁被释放； */
+        (void)xSemaphoreTake((SemaphoreHandle_t)mutex, portMAX_DELAY);
+    }
+}
+
+void osal_mutex_unlock(void *mutex)//给互斥锁解锁
+{
+    if (mutex != NULL) {
+        (void)xSemaphoreGive((SemaphoreHandle_t)mutex);
+    }
+}

--- a/soem/port/osal/osal.c
+++ b/soem/port/osal/osal.c
@@ -103,7 +103,7 @@ int osal_monotonic_sleep(ec_timet *ts)
         }
 
         uint32_t busy_usec = (remaining_usec > 1000)
-                                ? 1000 : (uint32_t)remaining_usec;
+                             ? 1000 : (uint32_t)remaining_usec;
         esp_rom_delay_us(busy_usec);
     }
 }
@@ -175,8 +175,8 @@ int osal_thread_create(void *thandle, int stacksize, void *func, void *param)
 int osal_thread_create_rt(void *thandle, int stacksize, void *func, void *param)
 {
     UBaseType_t priority = (configMAX_PRIORITIES > 2)
-                               ? configMAX_PRIORITIES - 2
-                               : configMAX_PRIORITIES - 1; /* exception: only 1 priority level. */
+                           ? configMAX_PRIORITIES - 2
+                           : configMAX_PRIORITIES - 1; /* exception: only 1 priority level. */
 
     return osal_task_create(thandle, stacksize, func, param, priority, "soem_worker_rt");
 }

--- a/soem/port/osal/osal.c
+++ b/soem/port/osal/osal.c
@@ -1,5 +1,8 @@
-//soem core的实现，需要平台底层软件操作系统的支持
-//所以编撰本osal.c源文件，提供ESP-IDF/FreeRTOS接口适配，包括时间、休眠、任务、内存和互斥锁等
+/*
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ */
 
 #include "osal.h"
 
@@ -12,38 +15,30 @@
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 
-
-/*
-两个用于时间格式转换的内部辅助函数；
-ESP-IDF的esp_timer_get_time()使用微妙整数结构，比如1234567us；
-而SOEM里的时间采用struct timespec结构，包含秒和纳秒，比如1s+234567000ns；
-所以需要一个时间格式的翻译器；
-*/
-static void usec_to_timespec(int64_t usec, ec_timet *ts)//将idf的us转成soem的(s+ns)
+/* Time format conversion, from us to (s, ns).
+   Same as osal_timespec_from_usec macro. */
+static void usec_to_timespec(int64_t usec, ec_timet *ts)
 {
     ts->tv_sec = (time_t)(usec / 1000000);
     ts->tv_nsec = (long)((usec % 1000000) * 1000);
 }
 
-static int64_t timespec_to_usec(const ec_timet *ts)//将soem的(s+ns)转成idf的us，供idf的单调时钟比较
+/* Time format conversion, from (s, ns) to us. */
+static int64_t timespec_to_usec(const ec_timet *ts)
 {
     return (int64_t)ts->tv_sec * 1000000 +
            (int64_t)ts->tv_nsec / 1000;
 }
 
-/*
-esp_timer_get_time()返回自系统启动以来的单调递增微秒数；
-转成soem时间格式后，适合拿来做超时、耗时测试等；
-*/
+/* Get monotonic time in (s, ns) format.
+   SOEM timeout handling requires time since system startup. */
 void osal_get_monotonic_time(ec_timet *ts)
 {
     usec_to_timespec(esp_timer_get_time(), ts);
 }
 
-/*
-gettimeofday()返回自1970年1月1日以来的秒和微秒，反映的是系统所认为的现实时间；
-转成soem时间格式后，适合拿来做日志时间戳、DC初始化等；最小移植用不到；P4上电后的系统现实时间不一定准；
-*/
+/* Get current time(wall-clock/real-time) in (s, ns) format.
+   Used for SOEM logging timestamp and DC initialization. */
 ec_timet osal_current_time(void)
 {
     struct timeval tv;
@@ -57,45 +52,40 @@ ec_timet osal_current_time(void)
     return ts;
 }
 
-/*
-计算soem时间格式下两个时间点的差值；再用指针把结果传出去；
-*/
+/* Calculate the time difference between two SOEM time points.
+   Computes (end - start) and stores the result in diff. */
 void osal_time_diff(ec_timet *start, ec_timet *end, ec_timet *diff)
 {
-    osal_timespecsub(end, start, diff);//运算宏
+    osal_timespecsub(end, start, diff); /* macro. */
 }
 
-/*
-基于现在的soem格式的单增时间，往后延一些微秒数(会转成soem时间格式)；
-做加法后就设置了一个截止时间点(超时判定时间点)，soem时间格式；
-并用指针传出去；
-*/
+/* Set an expiration timepoint in (s, ns) format.
+   Use the current monotonic time as base. Convert timeout duration(us) to (s, ns) and add it.
+   Store the result in self->stop_time. */
 void osal_timer_start(osal_timert *self, uint32 timeout_usec)
 {
     ec_timet now;
     ec_timet timeout;
 
     osal_get_monotonic_time(&now);
-    osal_timespec_from_usec(timeout_usec, &timeout);
-    osal_timespecadd(&now, &timeout, &self->stop_time);//运算宏
+    osal_timespec_from_usec(timeout_usec, &timeout); /* macro, use static usec_to_timespec() is also OK. */
+    osal_timespecadd(&now, &timeout, &self->stop_time); /* macro. */
 }
 
-/*
-当前单调递增时间与所设定的截止时间点(超时判定时间点)比大小；
-返回1表示超时了；
-soem core收ecat报文的时候，经常会用这个机制，等从站响应->没收到->检查是否超时->没超时就继续等，超时了就返回失败；
-*/
+/* Check if the expiration timepoint saved in self->stop_time has been reached.
+   Return TRUE if expired(include '='), FALSE otherwise. */
 boolean osal_timer_is_expired(osal_timert *self)
 {
     ec_timet now;
 
     osal_get_monotonic_time(&now);
-    return osal_timespeccmp(&now, &self->stop_time, >=) ? TRUE : FALSE;//运算宏
+    return osal_timespeccmp(&now, &self->stop_time, >=) ? TRUE : FALSE; /* macro. */
 }
 
-/*
-休眠到某个绝对时间点；函数内部会先把目标时间转换成us数；
-*/
+/* Sleep until a specific absolute timepoint(deadline) given by @param ts.
+   Internally convert into us and FreeRTOS tick number.
+   Use FreeRTOS blocking delay for whole ticks and busy-wait for remaining sub-tick interval.
+   Each busy-wait step limited to max 1ms, will re-read monotonic time. */
 int osal_monotonic_sleep(ec_timet *ts)
 {
     const int64_t target_usec = timespec_to_usec(ts);
@@ -108,35 +98,23 @@ int osal_monotonic_sleep(ec_timet *ts)
             return 0;
         }
 
-        /*
-         * 较长等待先让出CPU；最后不足一个FreeRTOS tick的部分使用
-         * 微秒忙等，避免所有短延时都被向上取整为一个完整tick。
-         */
         if (remaining_usec >= tick_usec) {
             TickType_t ticks = (TickType_t)(remaining_usec / tick_usec);
-
-            if (ticks > 0) {
-                vTaskDelay(ticks);
-                continue;
-            }
+            vTaskDelay(ticks);
+            continue;
         }
 
-        /*
-         * 每次忙等最多1 ms，循环后重新读取单调时钟，
-         * 避免大延时长期占用CPU。
-         */
         uint32_t busy_usec = (remaining_usec > 1000)
-                                 ? 1000
-                                 : (uint32_t)remaining_usec;
+                                ? 1000 : (uint32_t)remaining_usec;
         esp_rom_delay_us(busy_usec);
     }
 }
 
-/*
-休眠一段时间，形参单位us；
-内部使用绝对截止时间，FreeRTOS提前或延迟唤醒后会重新计算剩余时间，避免简单vTaskDelay产生持续累计漂移；
-仍不是严格实时定时，freertos调度、其他任务和中断都会产生抖动；
-*/
+/* Delay the current task for the specified number of us given by @param usec.
+   Calculate the absolute deadline timepoint based on current monotonic time,
+   then call osal_monotonic_sleep().
+   Not a hard real-time delay, actual wake-up timepoint may be later than expected,
+   due to FreeRTOS scheduling, other task preemption and interrupt handling. */
 int osal_usleep(uint32 usec)
 {
     ec_timet deadline;
@@ -145,26 +123,28 @@ int osal_usleep(uint32 usec)
     return osal_monotonic_sleep(&deadline);
 }
 
-/*
-下面两个函数是soem申请/释放一块动态内存；
-当前最小移植就是直接调用ESP-IDF的普通heap，以后若DMA或cache对齐有特殊要求再调整；
-*/
+/* Allocate memory on the heap. */
 void *osal_malloc(size_t size)
 {
     return malloc(size);
 }
 
+/* Free memory on the heap. */
 void osal_free(void *ptr)
 {
     free(ptr);
 }
 
-static int osal_task_create(void *thandle,
-                            int stacksize,
-                            void *func,
-                            void *param,
-                            UBaseType_t priority,
-                            const char *name)
+/* Create a FreeRTOS task for SOEM thread abstraction.
+   @param thandle, Pointer to storage for the created FreeRTOS task handle.
+   @param stacksize, ESP-IDF requested stack size in bytes, defaults to 4096B.
+   @param func, Pointer to the task entry function.
+   @param param, Argument passed to the task entry function.
+   @param priority, FreeRTOS task priority.
+   @param name, FreeRTOS task name used for debugging.
+*/
+static int osal_task_create(void *thandle, int stacksize, void *func,
+                            void *param, UBaseType_t priority, const char *name)
 {
     TaskHandle_t *handle = (TaskHandle_t *)thandle;
     TaskFunction_t entry = (TaskFunction_t)func;
@@ -174,90 +154,60 @@ static int osal_task_create(void *thandle,
         return 0;
     }
 
-    /*
-     * ESP-IDF版本的xTaskCreate栈参数单位是字节。
-     * SOEM通过void *传入线程入口，这里转换为FreeRTOS任务入口类型。
-     */
-    BaseType_t result = xTaskCreate(entry,
-                                    name,
-                                    stack_bytes,
-                                    param,
-                                    priority,
-                                    handle);
+    BaseType_t result = xTaskCreate(entry, name, stack_bytes, param, priority, handle);
 
     return result == pdPASS ? 1 : 0;
 }
 
-/*
-上面、这个、下面 三个函数是一体的；
-SOEM里的thread，在ESP-IDF里要变成freertos task；
-SOEM主要可能在这些场景使用线程：并行PDO Mapping、示例中的周期任务、状态监控任务；
-这是创建普通soem后台任务，默认任务优先级是5；
-而下面_rt后缀版本的是创建实时性要求更高的soem后台任务，默认任务优先级更高(数更小)；
-设计上面static内部辅助函数的目的是抽出公共部分，只留不同的priority和name作为传参，避免重复coding；
-目前不一定用到，仅为移植完备性考虑；
-*/
+/* Create an ordinary SOEM background task with default priority 5.
+   If default priority exceeds the highest possible value, set to highest.
+   FreeRTOS legal priority range is 0 to (configMAX_PRIORITIES - 1). */
 int osal_thread_create(void *thandle, int stacksize, void *func, void *param)
 {
-    UBaseType_t priority = 5;
+    UBaseType_t priority = 5; /* ESP-IDF port own strategy, can be customized. */
 
     if (priority >= configMAX_PRIORITIES) {
         priority = configMAX_PRIORITIES - 1;
     }
 
-    return osal_task_create(thandle,
-                            stacksize,
-                            func,
-                            param,
-                            priority,
-                            "soem_worker");
+    return osal_task_create(thandle, stacksize, func, param, priority, "soem_worker");
 }
 
-int osal_thread_create_rt(void *thandle,
-                          int stacksize,
-                          void *func,
-                          void *param)
+/* Create a higher-priority SOEM background task with the second highest priority. */
+int osal_thread_create_rt(void *thandle, int stacksize, void *func, void *param)
 {
     UBaseType_t priority = (configMAX_PRIORITIES > 2)
                                ? configMAX_PRIORITIES - 2
-                               : configMAX_PRIORITIES - 1;
+                               : configMAX_PRIORITIES - 1; /* exception: only 1 priority level. */
 
-    return osal_task_create(thandle,
-                            stacksize,
-                            func,
-                            param,
-                            priority,
-                            "soem_worker_rt");
+    return osal_task_create(thandle, stacksize, func, param, priority, "soem_worker_rt");
 }
 
-
-/*
-下面四个函数是soem在esp-idf平台下 创建/销毁/上锁/解锁 一个互斥锁mutual exclusion；
-在FreeRTOS里，信号量semaphore和互斥锁mutex共用了同一套xSemaphore... API家族，所以名字容易搞混;
-SOEMv2.0用Mutex保护：Mailbox buffer池、Mailbox发送队列、多任务共享的数据结构；
-*/
-void *osal_mutex_create(void)//创建互斥锁
+/* Create a FreeRTOS mutex for SOEM mutual exclusion.
+   Notice FreeRTOS mutexes use the semaphore API also. */
+void *osal_mutex_create(void)
 {
     return (void *)xSemaphoreCreateMutex();
 }
 
-void osal_mutex_destroy(void *mutex)//销毁互斥锁
+/* Destroy a FreeRTOS mutex. Check in case non-existent mutex cause crash. */
+void osal_mutex_destroy(void *mutex)
 {
-    if (mutex != NULL) {   /* 销毁一个不存在的mutex会导致崩溃，这里先检查锁指针是否为空，以便以后无脑调用 */
+    if (mutex != NULL) {
         vSemaphoreDelete((SemaphoreHandle_t)mutex);
     }
 }
 
-void osal_mutex_lock(void *mutex)//给互斥锁上锁，阻塞式
+/* Lock a FreeRTOS mutex, blocking wait forever until it becomes available. */
+void osal_mutex_lock(void *mutex)
 {
     if (mutex != NULL) {
-        /* 第二个参数表示：为了拿到这个锁，我最多愿意阻塞等待多少个tick；
-        portMAX_DELAY表示永久等待，直到锁被释放； */
         (void)xSemaphoreTake((SemaphoreHandle_t)mutex, portMAX_DELAY);
     }
 }
 
-void osal_mutex_unlock(void *mutex)//给互斥锁解锁
+/* Unlock a previously acquired FreeRTOS mutex. */
+void osal_mutex_unlock(void *mutex)
 {
     if (mutex != NULL) {
         (void)xSemaphoreGive((SemaphoreHandle_t)mutex);

--- a/soem/port/osal/osal.c
+++ b/soem/port/osal/osal.c
@@ -1,14 +1,12 @@
 /*
  * This software is dual-licensed under GPLv3 and a commercial
- * license. See the file LICENSE.md distributed with this software for
+ * license. See the LICENSE file distributed with this software for
  * full license information.
  */
 
 #include "osal.h"
-
 #include <stdlib.h>
 #include <sys/time.h>
-
 #include "esp_rom_sys.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"

--- a/soem/port/osal/osal_defs.h
+++ b/soem/port/osal/osal_defs.h
@@ -1,3 +1,9 @@
+/*
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the LICENSE file distributed with this software for
+ * full license information.
+ */
+
 #ifndef ESP_SOEM_OSAL_DEFS_H
 #define ESP_SOEM_OSAL_DEFS_H
 
@@ -7,7 +13,6 @@ extern "C" {
 
 #include <stdio.h>
 #include <time.h>
-
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"

--- a/soem/port/osal/osal_defs.h
+++ b/soem/port/osal/osal_defs.h
@@ -1,7 +1,6 @@
 #ifndef ESP_SOEM_OSAL_DEFS_H
-#define ESP_SOEM_OSAL_DEFS_H//类型定义文件，负责把SOEM使用的平台类型映射到ESP-IDF
-                            //该文件名必须交osal_defs.h，因为soem公共头文件osal.h内部会直接#include它
-                            //以后CMake会让source/soem_port优先进入头文件搜索路径，从而选择我们的ESP-IDF版，而不是Linux版的osal_defs.h
+#define ESP_SOEM_OSAL_DEFS_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -13,47 +12,31 @@ extern "C" {
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 
-/*
- * SOEM仅在启用EC_DEBUG时输出内部调试信息。
- * 正常构建中将EC_PRINT编译为空操作，避免影响周期通信。
- */
 #ifdef EC_DEBUG
-#define EC_PRINT(...) printf(__VA_ARGS__)
+#define EC_PRINT(...) printf(__VA_ARGS__) /* print debug info */
 #else
 #define EC_PRINT(...) \
     do {              \
     } while (0)
 #endif
 
-/*
- * EtherCAT帧头、Datagram和ESC寄存器结构必须严格按协议字节布局，
- * 禁止编译器在结构体成员之间插入对齐填充。
- */
+/* EtherCAT protocol structures must not contain compiler-inserted padding. */
 #ifndef OSAL_PACKED
 #define OSAL_PACKED_BEGIN
 #define OSAL_PACKED __attribute__((packed))
 #define OSAL_PACKED_END
 #endif
 
-/*
- * SOEM公共OSAL使用ec_timet表示时间。
- * ESP-IDF的C运行库支持struct timespec，可直接保持SOEM接口语义。
- */
-#define ec_timet struct timespec                    //SOEM时间类型 → struct timespec
+/* Map SOEM time type to esp-idf timespec, both in (s, ns). */
+#define ec_timet struct timespec
 
-/*
- * 将SOEM线程抽象映射到FreeRTOS任务。
- * OSAL_THREAD_FUNC宏用于保持SOEM示例和平台代码的函数声明兼容。
- */
-#define OSAL_THREAD_HANDLE TaskHandle_t             //SOEM线程句柄 → FreeRTOS TaskHandle_t
-#define OSAL_THREAD_FUNC void                       //SOEM线程函数 → FreeRTOS void
-#define OSAL_THREAD_FUNC_RT void                    //SOEM线程函数 → FreeRTOS void
+/* Map SOEM thread abstractions to FreeRTOS tasks. */
+#define OSAL_THREAD_HANDLE TaskHandle_t
+#define OSAL_THREAD_FUNC void
+#define OSAL_THREAD_FUNC_RT void
 
-/*
- * FreeRTOS mutex由SemaphoreHandle_t表示。
- * 具体创建、销毁、加锁和解锁逻辑在osal.c中实现。
- */
-#define osal_mutext SemaphoreHandle_t               //SOEM互斥锁 → FreeRTOS SemaphoreHandle_t
+/* Map SOEM mutual exclusion type to FreeRTOS semaphore handle. */
+#define osal_mutext SemaphoreHandle_t
 
 #ifdef __cplusplus
 }

--- a/soem/port/osal/osal_defs.h
+++ b/soem/port/osal/osal_defs.h
@@ -1,0 +1,62 @@
+#ifndef ESP_SOEM_OSAL_DEFS_H
+#define ESP_SOEM_OSAL_DEFS_H//类型定义文件，负责把SOEM使用的平台类型映射到ESP-IDF
+                            //该文件名必须交osal_defs.h，因为soem公共头文件osal.h内部会直接#include它
+                            //以后CMake会让source/soem_port优先进入头文件搜索路径，从而选择我们的ESP-IDF版，而不是Linux版的osal_defs.h
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <time.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+/*
+ * SOEM仅在启用EC_DEBUG时输出内部调试信息。
+ * 正常构建中将EC_PRINT编译为空操作，避免影响周期通信。
+ */
+#ifdef EC_DEBUG
+#define EC_PRINT(...) printf(__VA_ARGS__)
+#else
+#define EC_PRINT(...) \
+    do {              \
+    } while (0)
+#endif
+
+/*
+ * EtherCAT帧头、Datagram和ESC寄存器结构必须严格按协议字节布局，
+ * 禁止编译器在结构体成员之间插入对齐填充。
+ */
+#ifndef OSAL_PACKED
+#define OSAL_PACKED_BEGIN
+#define OSAL_PACKED __attribute__((packed))
+#define OSAL_PACKED_END
+#endif
+
+/*
+ * SOEM公共OSAL使用ec_timet表示时间。
+ * ESP-IDF的C运行库支持struct timespec，可直接保持SOEM接口语义。
+ */
+#define ec_timet struct timespec                    //SOEM时间类型 → struct timespec
+
+/*
+ * 将SOEM线程抽象映射到FreeRTOS任务。
+ * OSAL_THREAD_FUNC宏用于保持SOEM示例和平台代码的函数声明兼容。
+ */
+#define OSAL_THREAD_HANDLE TaskHandle_t             //SOEM线程句柄 → FreeRTOS TaskHandle_t
+#define OSAL_THREAD_FUNC void                       //SOEM线程函数 → FreeRTOS void
+#define OSAL_THREAD_FUNC_RT void                    //SOEM线程函数 → FreeRTOS void
+
+/*
+ * FreeRTOS mutex由SemaphoreHandle_t表示。
+ * 具体创建、销毁、加锁和解锁逻辑在osal.c中实现。
+ */
+#define osal_mutext SemaphoreHandle_t               //SOEM互斥锁 → FreeRTOS SemaphoreHandle_t
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/soem/port/oshw/nicdrv.c
+++ b/soem/port/oshw/nicdrv.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "esp_soem.h"
 #include "esp_eth.h"
 #include "esp_err.h"
 #include "freertos/FreeRTOS.h"
@@ -25,9 +24,6 @@ enum {
    primary or redundant. NOT real hardware MAC address. */
 const uint16 priMAC[3] = EC_PRIMARY_MAC_ARRAY;
 const uint16 secMAC[3] = EC_SECONDARY_MAC_ARRAY;
-
-/* Application-owned Ethernet driver handle used during port setup. */
-static esp_eth_handle_t s_bound_eth;
 
 static esp_err_t ecx_esp_eth_rx(esp_eth_handle_t hdl, uint8_t *buffer, uint32_t length, void *priv);
 static int ecx_inframe(ecx_portt *port, uint8 idx, int stacknumber);
@@ -103,55 +99,37 @@ uint8 ecx_getindex(ecx_portt *port)
 
 /* Initialize a SOEM network port backed by an ESP-IDF Ethernet driver.
    @param ifname, Logical network interface name, must be "esp_eth".
-   However, the actual Ethernet interface is provided via the bound Ethernet handle.
+   The Ethernet interface handle is provided through the port structure.
    @param secondary, Non-zero to enable redundant mode, not supported yet.
    @return >0 if OK, 0 if failed. */
 int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
 {
-    if ((ifname == NULL) || (strcmp(ifname, "esp_eth") != 0)) {
-        return 0;
-    }
-    if (s_bound_eth == NULL) {
-        return 0;
-    }
-    if (secondary) {
+    if ((port == NULL) ||
+        (ifname == NULL) ||
+        (strcmp(ifname, "esp_eth") != 0) ||
+        (port->eth_handle == NULL) ||
+        secondary) {
         return 0;
     }
 
-    port->getindex_mutex = osal_mutex_create();
-    port->tx_mutex = osal_mutex_create();
-    port->rx_mutex = osal_mutex_create();
-    if ((port->getindex_mutex == NULL) ||
-        (port->tx_mutex == NULL) ||
-        (port->rx_mutex == NULL)) {
-        return 0;
-    }
+    port->getindex_mutex = NULL;
+    port->tx_mutex = NULL;
+    port->rx_mutex = NULL;
+    port->rx_sem = NULL;
     port->sockhandle = -1;
-    /* Attach the application-owned Ethernet driver to this port. */
-    port->eth_handle = s_bound_eth;
-    /* Notify waiting SOEM tasks when receive activity occurs. */
-    port->rx_sem = xSemaphoreCreateBinary();
-    if (port->rx_sem == NULL) {
-        return 0;
-    }
-    /* Register the SOEM RX callback as the Ethernet driver's input path,
-       invoked when new Ethernet frame received, port must be passed as cb's private arg. */
-    if (esp_eth_update_input_path((esp_eth_handle_t)port->eth_handle,
-                                  ecx_esp_eth_rx, port) != ESP_OK) {
-        return 0;
-    }
     port->lastidx = 0;
     port->redstate = ECT_RED_NONE;
     port->redport = NULL;
     /* Point the generic stack view at storage owned by the primary port. */
-    port->stack.sock = &(port->sockhandle);
-    port->stack.txbuf = &(port->txbuf);
-    port->stack.txbuflength = &(port->txbuflength);
-    port->stack.tempbuf = &(port->tempinbuf);
-    port->stack.rxbuf = &(port->rxbuf);
-    port->stack.rxbufstat = &(port->rxbufstat);
-    port->stack.rxsa = &(port->rxsa);
+    port->stack.sock = &port->sockhandle;
+    port->stack.txbuf = &port->txbuf;
+    port->stack.txbuflength = &port->txbuflength;
+    port->stack.tempbuf = &port->tempinbuf;
+    port->stack.rxbuf = &port->rxbuf;
+    port->stack.rxbufstat = &port->rxbufstat;
+    port->stack.rxsa = &port->rxsa;
     port->stack.rxcnt = 0;
+
     /* Clear all the Rx buffer slots to EMPTY. */
     ecx_clear_rxbufstat(&(port->rxbufstat[0]));
 
@@ -161,12 +139,64 @@ int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
     }
     ec_setupheader(&(port->txbuf2));
 
+    port->getindex_mutex = osal_mutex_create();
+    port->tx_mutex = osal_mutex_create();
+    port->rx_mutex = osal_mutex_create();
+    if ((port->getindex_mutex == NULL) ||
+        (port->tx_mutex == NULL) ||
+        (port->rx_mutex == NULL)) {
+        goto fail;
+    }
+
+    /* Notify waiting SOEM tasks when receive activity occurs. */
+    port->rx_sem = xSemaphoreCreateBinary();
+    if (port->rx_sem == NULL) {
+        goto fail;
+    }
+
+    /* Register the SOEM RX callback as the Ethernet driver's input path,
+       invoked when new Ethernet frame received, port must be passed as cb's private arg. */
+    if (esp_eth_update_input_path((esp_eth_handle_t)port->eth_handle,
+                                  ecx_esp_eth_rx, port) != ESP_OK) {
+        goto fail;
+    }
+
     return 1;
+
+fail:
+    if (port->rx_sem != NULL) {
+        vSemaphoreDelete((SemaphoreHandle_t)port->rx_sem);
+        port->rx_sem = NULL;
+    }
+    osal_mutex_destroy(port->getindex_mutex);
+    osal_mutex_destroy(port->tx_mutex);
+    osal_mutex_destroy(port->rx_mutex);
+    port->getindex_mutex = NULL;
+    port->tx_mutex = NULL;
+    port->rx_mutex = NULL;
+    port->eth_handle = NULL;
+
+    return 0;
 }
 
 /* Detach the Ethernet receive path and release port resources. */
 int ecx_closenic(ecx_portt *port)
 {
+    if (port == NULL) {
+        return 0;
+    }
+
+    if (port->eth_handle != NULL) {
+        (void)esp_eth_update_input_path(
+            (esp_eth_handle_t)port->eth_handle, NULL, NULL);
+        port->eth_handle = NULL; /* The Ethernet driver remains owned by the application. */
+    }
+
+    if (port->rx_sem != NULL) {
+        vSemaphoreDelete((SemaphoreHandle_t)port->rx_sem);
+        port->rx_sem = NULL;
+    }
+
     osal_mutex_destroy(port->getindex_mutex);
     osal_mutex_destroy(port->tx_mutex);
     osal_mutex_destroy(port->rx_mutex);
@@ -174,27 +204,7 @@ int ecx_closenic(ecx_portt *port)
     port->tx_mutex = NULL;
     port->rx_mutex = NULL;
 
-    if (port->eth_handle != NULL) {
-        (void)esp_eth_update_input_path((esp_eth_handle_t)port->eth_handle, NULL, NULL);
-    }
-    if (port->rx_sem != NULL) {
-        vSemaphoreDelete((SemaphoreHandle_t)port->rx_sem);
-        port->rx_sem = NULL;
-    }
-    /* The Ethernet driver remains owned by the application. */
-    port->eth_handle = NULL;
-
     return 0;
-}
-
-/* Save the application-owned Ethernet driver for the next port setup. */
-esp_err_t esp_soem_bind_eth(esp_eth_handle_t eth)
-{
-    if (eth == NULL) {
-        return ESP_ERR_INVALID_ARG;
-    }
-    s_bound_eth = eth;
-    return ESP_OK;
 }
 
 /* Transmit a prepared Ethernet frame through ESP-IDF Ethernet driver.

--- a/soem/port/oshw/nicdrv.c
+++ b/soem/port/oshw/nicdrv.c
@@ -4,76 +4,62 @@
  * full license information.
  */
 
-#include "oshw.h"   /*会带上soem.h->nicdrv.h，所以 ecx_portt、ETH_P_ECAT、ec_etherheadert 都能用*/
-#include "osal.h"   /*提供osal_mutex_create/lock/unlock*/
+#include "oshw.h"
+#include "osal.h"
 
+#include <stdlib.h>
 #include <string.h>
+
 #include "esp_soem.h"
 #include "esp_eth.h"
 #include "esp_err.h"
-
-#include <stdlib.h>   /* 要用到free()：释放驱动 eth驱动分配的临时RXbuffer */
-#include "freertos/FreeRTOS.h"  /*要用到semaphore了*/
+#include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 
-
 enum {
-    ECT_RED_NONE = 0,   /*no redundancy，single NIC mode，单网卡模式*/
-    ECT_RED_DOUBLE      /*双网卡冗余，第一版不做*/
+    ECT_RED_NONE = 0,
+    ECT_RED_DOUBLE
 };
 
-/*
-eth frame的源MAC地址字段(6Byte)，来自应用工程build目录生成的ec_options.h；
-只是逻辑地址，用来区分主路径/冗余路径，不是IP101芯片的真实MAC地址；
-*/
-const uint16 priMAC[3] = EC_PRIMARY_MAC_ARRAY;      /*Primary source MAC address used for EtherCAT*/
-const uint16 secMAC[3] = EC_SECONDARY_MAC_ARRAY;    /*Secondary source MAC address used for EtherCAT*/
+/* Logical source MAC address used by SOEM for network path identification,
+   primary or redundant. NOT real hardware MAC address. */
+const uint16 priMAC[3] = EC_PRIMARY_MAC_ARRAY;
+const uint16 secMAC[3] = EC_SECONDARY_MAC_ARRAY;
 
-/* 应用层bind进来的eth句柄，setupnic()再写入port */
+/* Application-owned Ethernet driver handle used during port setup. */
 static esp_eth_handle_t s_bound_eth;
 
-/* 先声明再使用 */
 static esp_err_t ecx_esp_eth_rx(esp_eth_handle_t hdl, uint8_t *buffer, uint32_t length, void *priv);
 static int ecx_inframe(ecx_portt *port, uint8 idx, int stacknumber);
 
-/*
-内部辅助函数，setup时把rxbuf[]每个槽的状态初始化为空，槽状态都在ec_type.h里提供；
-*/
+/* Clear the status of all Rx buffer slots to EMPTY. */
 static void ecx_clear_rxbufstat(int *rxbufstat)
 {
-    int i;
-    for (i = 0; i < EC_MAXBUF; i++) {
-        rxbufstat[i] = EC_BUF_EMPTY; /* 空闲状态，ecx_getindex 可以占用*/
+    for (int i = 0; i < EC_MAXBUF; i++) {
+        rxbufstat[i] = EC_BUF_EMPTY;
     }
 }
 
-/*
-填eth帧的目的MAC(6Byte)、源MAC(6Byte)和EtherType(2Byte)字段内容，都是固定内容；
-以后每个txbuf[i]的前14Byte都是这三个内容，SOEM会在ecx_setupnic()里预先填一次；
-省得每次发的时候重复填这些字段，节省开销；每次发的时候只要填payload字段就行了；
-*/
+/* Initialize the invariant Ethernet header fields of a TX buffer slot. */
 void ec_setupheader(void *p)
 {
     ec_etherheadert *bp = p;
 
-    /* eth帧的目的MAC字段6Byte，全1表示以太网广播地址；
-    虽然ESC不在意该字段内容，但SOEM为了该eth frame不被普通以太网设备莫名过滤掉，所以用了一个合法、通用的地址类型 */
+    /* Use Ethernet broadcast address as destination MAC to avoid unintended filtering. */
     bp->da0 = oshw_htons(0xffff);
     bp->da1 = oshw_htons(0xffff);
     bp->da2 = oshw_htons(0xffff);
 
-    /* eth帧的源MAC字段6Byte，别当回事，虚构的*/
+    /* Use SOEM's predefined primary source MAC pattern. */
     bp->sa0 = oshw_htons(priMAC[0]);
     bp->sa1 = oshw_htons(priMAC[1]);
     bp->sa2 = oshw_htons(priMAC[2]);
 
-    /* eth帧的EtherType字段2Byte，固定为0x88A4，表示EtherCAT on EtherNet */
+    /* EtherCAT over EtherNet uses EtherType 0x88A4. */
     bp->etype = oshw_htons(ETH_P_ECAT);
 }
 
-/*
-setbufstat 几乎是直接赋值。冗余口第一版不会有，但 Linux 有这段判断，照抄以免以后和 SOEM 行为不一致
-*/
+/* Set the status of a Rx buffer slot. If redundancy enabled, update as well. */
 void ecx_setbufstat(ecx_portt *port, uint8 idx, int bufstat)
 {
     port->rxbufstat[idx] = bufstat;
@@ -82,28 +68,20 @@ void ecx_setbufstat(ecx_portt *port, uint8 idx, int bufstat)
     }
 }
 
-/*
-从 0 ~ EC_MAXBUF-1 这几个帧缓冲槽位里，找一个当前没被占用的槽位，把它标记为“已分配”，然后返回这个槽位号 idx；
-这个idx后面会同时用于txbuf[]、rxbuf[]、rxbufstat[idx]，并且填进 EtherCAT Datagram 的 Index 字段；
-*/
+/* Allocate an Rx buffer index with mutex protection.
+   Search for an empty slot starting from the next index after the last allocated one, not always [0].
+   @return idx, shared by txbuf[], rxbuf[], rxbufstat[], and ECAT datagram's Index field to match the response.
+   Preserve the upstream SOEM behavior: if no empty slot found after a full search, reuse the next index. */
 uint8 ecx_getindex(ecx_portt *port)
 {
-    uint8 idx;
-    uint8 cnt; //已经尝试了多少个槽
-
-    /* 可能同时有多个任务调用ecx_getindex()；
-    假设两个任务都看到idx=5是空闲的，都要用它，就冲突了，所以要用互斥锁保护；
-    找 buffer index 这件事一次只能一个任务做 */
     osal_mutex_lock(port->getindex_mutex);
 
-    idx = port->lastidx + 1; //从上一次分配的槽位的下一个开始check，不是每次都从0开始，这是一种简单的循环轮转Round-Robin思路
+    uint8 idx = port->lastidx + 1;
     if (idx >= EC_MAXBUF) {
         idx = 0;
     }
 
-    cnt = 0;
-    /* 最多转一圈 16 次，找 EMPTY 槽；
-    注意！！16 个槽都忙时，Linux 仍会占用转完一圈后的那个 idx（可能覆盖旧槽）。第一版保持这个行为，不要自己“优化” */
+    uint8 cnt = 0; /* Number of slots examined this round. */
     while ((port->rxbufstat[idx] != EC_BUF_EMPTY) && (cnt < EC_MAXBUF)) {
         idx++;
         cnt++;
@@ -112,67 +90,60 @@ uint8 ecx_getindex(ecx_portt *port)
         }
     }
 
-    port->rxbufstat[idx] = EC_BUF_ALLOC; //不调用ecx_setbufstat()，直接赋值，表示已占住序号
+    port->rxbufstat[idx] = EC_BUF_ALLOC;
     if (port->redstate != ECT_RED_NONE) {
-        port->redport->rxbufstat[idx] = EC_BUF_ALLOC; //双网卡冗余模式的兼容代码，这一版不要管
+        port->redport->rxbufstat[idx] = EC_BUF_ALLOC;
     }
+
     port->lastidx = idx;
 
-    osal_mutex_unlock(port->getindex_mutex); //释放锁
+    osal_mutex_unlock(port->getindex_mutex);
     return idx;
 }
 
-/*
-会被soem core的ecx_init()调用；
-初始化网卡端口port，这一步只做内存初始化，并不打开网卡，还没有真正挂上esp_eth()；
-把soem原本通过网卡名字打开Linux网卡的方式，改造成应用先初始化ESP-IDF Ethernet，再把eth_handle交给SOEM使用；
-但soem core的ecx_setupnic()没有这个句柄参数，只有网口名字符串指针，因此需要加一层绑定；
-*/
+/* Initialize a SOEM network port backed by an ESP-IDF Ethernet driver.
+   @param ifname, Logical network interface name, must be "esp_eth".
+   However, the actual Ethernet interface is provided via the bound Ethernet handle.
+   @param secondary, Non-zero to enable redundant mode, not supported yet.
+   @return >0 if OK, 0 if failed. */
 int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
 {
-    int i;
-
-    /* 要求用户在应用层调用ecx_init()传参数的时候，网卡名字必须用”esp_eth“，否则认为非法
-    这个和oshw_find_adapters()里给网卡取名字是两回事，虽然那里也固定取为esp_eth，那个还没懂，先不管*/
     if ((ifname == NULL) || (strcmp(ifname, "esp_eth") != 0)) {
         return 0;
     }
     if (s_bound_eth == NULL) {
-        return 0; /* 用户应用层忘了先 bind，或 bind 在 init 之后 */
+        return 0;
     }
-
-    if (secondary) { /* 第一版不做第二块网卡 */
+    if (secondary) {
         return 0;
     }
 
-    port->getindex_mutex = osal_mutex_create();//创建取序号锁，保护tx/rx buf[]槽位的分配
-    port->tx_mutex = osal_mutex_create();//创建发送锁，保护txbuf[]的写入
-    port->rx_mutex = osal_mutex_create();//创建接收锁，保护rxbuf[]的读取
+    port->getindex_mutex = osal_mutex_create();
+    port->tx_mutex = osal_mutex_create();
+    port->rx_mutex = osal_mutex_create();
     if ((port->getindex_mutex == NULL) ||
         (port->tx_mutex == NULL) ||
         (port->rx_mutex == NULL)) {
         return 0;
-    } //任意一把锁创建失败，就认为nic初始化失败；失败时没有释放前面可能已创建好的锁(资源泄漏)，后续考虑补cleanup
-
-    /* 下面几乎都是初始化底层通信相关的软件变量状态 */
-    port->sockhandle = -1; //套接字句柄，P4不用
-    port->eth_handle = s_bound_eth; //重要！！挂esp_eth句柄，由应用层bind进来的静态全局变量桥接
-    /* 重要！创建收包通知信号量，并挂到ecat port */
+    }
+    port->sockhandle = -1;
+    /* Attach the application-owned Ethernet driver to this port. */
+    port->eth_handle = s_bound_eth;
+    /* Notify waiting SOEM tasks when receive activity occurs. */
     port->rx_sem = xSemaphoreCreateBinary();
     if (port->rx_sem == NULL) {
         return 0;
     }
-    /* 重要！注册eth驱动回调函数ecx_esp_eth_rx()，负责接收以太网帧，在以太网任务里被调用，不是那种ISR回调函数；
-    形参priv 必须是 port，回调才能写到这份 ecx_portt 的 rxbuf */
-    if (esp_eth_update_input_path((esp_eth_handle_t)port->eth_handle, ecx_esp_eth_rx, port) != ESP_OK) {
+    /* Register the SOEM RX callback as the Ethernet driver's input path,
+       invoked when new Ethernet frame received, port must be passed as cb's private arg. */
+    if (esp_eth_update_input_path((esp_eth_handle_t)port->eth_handle,
+                                  ecx_esp_eth_rx, port) != ESP_OK) {
         return 0;
     }
     port->lastidx = 0;
     port->redstate = ECT_RED_NONE;
     port->redport = NULL;
-
-    /* stack 是“指针包”，让收发代码用同一套写法访问本口缓冲(双端口模式下会用到，单端口兼容一下)；
-    用于描述ecx_portt类型变量的内部成员保存在内存哪里 */
+    /* Point the generic stack view at storage owned by the primary port. */
     port->stack.sock = &(port->sockhandle);
     port->stack.txbuf = &(port->txbuf);
     port->stack.txbuflength = &(port->txbuflength);
@@ -181,24 +152,21 @@ int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
     port->stack.rxbufstat = &(port->rxbufstat);
     port->stack.rxsa = &(port->rxsa);
     port->stack.rxcnt = 0;
+    /* Clear all the Rx buffer slots to EMPTY. */
+    ecx_clear_rxbufstat(&(port->rxbufstat[0]));
 
-    ecx_clear_rxbufstat(&(port->rxbufstat[0])); //把rxbuf[]每个槽的状态初始化为空
-
-    /* 重要！
-    给txbuf[]的每个槽位都先预填好其前(6+6+2)Byte的eth header内容(目的MAC、源MAC、EtherType)；
-    在初始化的时候做好这些固定的东西，以后真正运行起来的时候就省事了，只要管payload内容就行了*/
-    for (i = 0; i < EC_MAXBUF; i++) {
+    /* Prefill Ethernet header fields in every TX buffer slot to save runtime overhead. */
+    for (int i = 0; i < EC_MAXBUF; i++) {
         ec_setupheader(&(port->txbuf[i]));
-        port->rxbufstat[i] = EC_BUF_EMPTY;//这一步可以不用，上面ecx_clear_rxbufstat()已经搞过了
     }
-    ec_setupheader(&(port->txbuf2));//第一版不用冗余，txbuf2不用管，但可以先兼容着，以后再细究
+    ec_setupheader(&(port->txbuf2));
 
-    return 1; /* SOEM 约定：>0 表示成功 */
+    return 1;
 }
 
+/* Detach the Ethernet receive path and release port resources. */
 int ecx_closenic(ecx_portt *port)
 {
-    /* 销毁三把互斥锁，清空指针 */
     osal_mutex_destroy(port->getindex_mutex);
     osal_mutex_destroy(port->tx_mutex);
     osal_mutex_destroy(port->rx_mutex);
@@ -206,85 +174,64 @@ int ecx_closenic(ecx_portt *port)
     port->tx_mutex = NULL;
     port->rx_mutex = NULL;
 
-    /* 反注册 callback，意味着以后不要再把RX Frame交给SOEM callback了；
-    ESP-IDF源码设计这个注册函数的时候，就弄成没有input path时，驱动会自己free后续RXbuffer */
     if (port->eth_handle != NULL) {
         (void)esp_eth_update_input_path((esp_eth_handle_t)port->eth_handle, NULL, NULL);
     }
-    /* 销毁收包通知信号量，并清空ecat port相关指针*/
     if (port->rx_sem != NULL) {
         vSemaphoreDelete((SemaphoreHandle_t)port->rx_sem);
         port->rx_sem = NULL;
     }
-
-    /* 仅清空句柄关联关系，不调用esp_eth_stop()，网卡驱动是应用创建的，所有权属于应用，soem只是借用eth句柄 */
+    /* The Ethernet driver remains owned by the application. */
     port->eth_handle = NULL;
 
     return 0;
 }
 
-/* 为解决接口不匹配问题(soem core的ecx_setupnic()没有eth句柄参数，只有网口名字符串指针)，自己写的一个桥接函数；
-先找一个地方，把应用创建好的 eth handle句柄 暂存到s_bound_eth。
-整体逻辑：
-以太网驱动创建成功后归结为eth_handle；
-但soem core的ecx_init(*字符串)，内部调用ecx_setupnic(*字符串)；
-产生了矛盾，类型不对，eth_handle传不进去；
-而且，eth_handle属于应用层函数里的局部变量，soem core是访问不到的；
-因此，设计一个bind(eth_handle)函数，在里面让s_bound_eth = eth_handle，应用层调用bind()；
-再在ecx_setupnic(额外重点：规定传“esp_eth”网卡名)函数里把s_bound_eth挂到ecx_pottt上；
- */
+/* Save the application-owned Ethernet driver for the next port setup. */
 esp_err_t esp_soem_bind_eth(esp_eth_handle_t eth)
 {
     if (eth == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
-    s_bound_eth = eth; //nicdrv.c里的静态全局变量
+    s_bound_eth = eth;
     return ESP_OK;
 }
 
-/*
-把已经在txbuf[idx]里填好的eth frame交给esp_eth_transmit()发出去；
-找到buf[]的idx槽位，找到其uint8长度，调用esp_eth_transmit()；
-*/
+/* Transmit a prepared Ethernet frame through ESP-IDF Ethernet driver.
+   Eth header prefilled. ECAT header and datagrams assembled by SOEM core.
+   Call esp_eth_transmit() to ask esp_eth driver send the whole eth frame. ESP_OK doesn't mean bitstream has already on the wire.
+   @return lp, Number of bytes sent. */
 int ecx_outframe(ecx_portt *port, uint8 idx, int stacknumber)
 {
-    int lp;
-    esp_eth_handle_t eth;
+    (void)stacknumber; /* Only the primary path is supported. */
 
-    (void)stacknumber; /* 第一版只有主口 */
+    /* Mark the slot as awaiting the returned EtherCAT frame with the same datagram index. */
+    port->rxbufstat[idx] = EC_BUF_TX;
 
-    lp = port->txbuflength[idx]; /* SOEM 填报文时已经写好的整帧长度 */
-    port->rxbufstat[idx] = EC_BUF_TX; //由EC_BUF_ALLOC变为EC_BUF_TX，表示请求已经发送，现在等它的返回帧
-
-    eth = (esp_eth_handle_t)port->eth_handle;
+    int lp = port->txbuflength[idx];
+    esp_eth_handle_t eth = (esp_eth_handle_t)port->eth_handle;
     if ((eth == NULL) ||
-        (esp_eth_transmit(eth, port->txbuf[idx], (size_t)lp) != ESP_OK)) { //成功仅指成功交给eth驱动，并非物理比特流发完
-        port->rxbufstat[idx] = EC_BUF_EMPTY; //若发送失败，就把状态恢复为空闲，否则这个槽会一直占着
+        (esp_eth_transmit(eth, port->txbuf[idx], (size_t)lp) != ESP_OK)) {
+        port->rxbufstat[idx] = EC_BUF_EMPTY; /* In case the slot occupied still. */
         return -1;
     }
-    return lp; //返回发送成功的整帧长度
+    return lp;
 }
 
-/*
-即使第一版不做双网卡，也要实现它，因为soem core是先调用这个函数，再根据是否有redundancy决定怎么发；
-没有冗余口就永远走primary port；
-port->txbuf[idx] 本质是一块字节内存，但它开头正好放了Ethernet Header，
-于是把这块内存的起始地址强制看成ec_etherheadert类型指针，
-以后就能直接用ehp->sa1的方式访问这段内存；
-*/
+/* Prepare the path(only primary yet) marker and transmit the frame. */
 int ecx_outframe_red(ecx_portt *port, uint8 idx)
 {
-    ec_etherheadert *ehp = (ec_etherheadert *)&(port->txbuf[idx]);//常用技巧
+    ec_etherheadert *ehp = (ec_etherheadert *)&(port->txbuf[idx]);
+    ehp->sa1 = oshw_htons(priMAC[1]); /* Mark the frame as primary-path traffic. */
 
-    ehp->sa1 = oshw_htons(priMAC[1]);//与 Linux 相同：主路径用 priMAC 的第二个 uint16，不要深究，等以后做冗余了再深入
     return ecx_outframe(port, idx, 0);
 }
 
-/*
-重点！！所有return之前都必须要free(buffer)，这里的buffer不是ecat接口的rxbuf[]，而是以太网驱动分配的临时RxBuffer，
-如果以太网驱动注册了callback()，在调用该cb()的时候驱动会把这个buffer的所有权交给回调函数，因此必须在cb()返回前把这段
-临时内存释放掉，否则会导致内存泄漏，可用内存越来越少。
-*/
+/* Callback function registered with esp_eth driver, called by eth rx task.
+   @param buffer, Ethernet driver's temporary Rx buffer, ownership transferred to callback, free it before return.
+   @param priv, Private argument passed to the callback, must be the ecx_portt pointer.
+   Store a received EtherCAT frame in its indexed SOEM RX buffer.
+   */
 static esp_err_t ecx_esp_eth_rx(esp_eth_handle_t hdl, uint8_t *buffer, uint32_t length, void *priv)
 {
     ecx_portt *port = (ecx_portt *)priv;
@@ -292,101 +239,91 @@ static esp_err_t ecx_esp_eth_rx(esp_eth_handle_t hdl, uint8_t *buffer, uint32_t 
     ec_comt *ecp;
     uint8 idxf;
     uint16 copy_len;
-
     (void)hdl;
 
-    /* 有效性检查，尤其是这一帧eth帧的字节数，至少要比eth帧头(6+6+2)Byte与ecat帧头2Byte之和要大 */
+    /* Drop frames too short to contain Ethernet and EtherCAT headers. */
     if ((buffer == NULL) || (port == NULL) || (length < (ETH_HEADERSIZE + EC_HEADERSIZE))) {
         free(buffer);
         return ESP_OK;
     }
 
-    /* 有效性检查，看这一帧eth帧的EtherType字段是否为ECAT要求的0x88A4 */
+    /* Ignore non-EtherCAT Ethernet frames. */
     ehp = (ec_etherheadert *)buffer;
     if (ehp->etype != oshw_htons(ETH_P_ECAT)) {
         free(buffer);
         return ESP_OK;
     }
 
-    /* ETH_HEADERSIZE是以太网帧头长度14Byte，意味着ecp直接skip、摸到ECAT帧的帧头
-    然后，直接从ecat帧帧头后的第一个报文的index字段 读取编号 亦作为槽位号*/
+    /* Skip eth header. Use the first ECAT datagram index to select the matching SOEM RX slot. */
     ecp = (ec_comt *)(buffer + ETH_HEADERSIZE);
     idxf = ecp->index;
 
-    /* 阻塞式上锁保护共享资源rxbuf[]，此时可能同时有多个任务在访问，形成冲突 */
     osal_mutex_lock(port->rx_mutex);
-    /* (idxf < EC_MAXBUF)防止数组越界！
-    (port->rxbufstat[idxf] == EC_BUF_TX)表示确实曾经从这个槽发送出去了一帧，现在正在等待它回来，状态对！！*/
+
     if ((idxf < EC_MAXBUF) && (port->rxbufstat[idxf] == EC_BUF_TX)) {
-        /*算出要拷贝的字节数，发的时候连着以太网帧头一起发，先在收的时候直接跳过以太网帧头，只拷贝payload部分，因为应用层已经不会再关心了*/
+        /* Truncate the copy length to the actual received length(may shorter than Tx). */
         copy_len = (uint16)(port->txbuflength[idxf] - ETH_HEADERSIZE);
-        /*进行边界保护，防止读buffer越界！！！！比如原来发了100Byte，理论上返回的时候也有对应长度100Byte，
-        但假设因为某些异常，实际只收了60Byte(实际收到的字节数由形参length传入)，去掉eth帧头14Byte，剩下46Byte，
-        因此必须做一次copy_len截断，如果还傻傻地memcpy()，就要越界读内存了，闯祸！*/
         if (copy_len > (length - ETH_HEADERSIZE)) {
             copy_len = (uint16)(length - ETH_HEADERSIZE);
         }
-        /* memcpy(目的地址，源地址，字节长度)；这里可以明显看到收的时候是跳过以太网帧头的！！*/
+
+        /* Only copy the payload feild(ECAT header and datagrams). */
         memcpy(port->rxbuf[idxf], buffer + ETH_HEADERSIZE, copy_len);
-        /*这行不要管，这是双网卡冗余模式下才用的，第一版没有*/
+
         port->rxsa[idxf] = oshw_ntohs(ehp->sa1);
-        /* 改变rxbuf状态，现在以太网帧已经收到，并且已经从eth驱动临时buf里拷贝到正确的SOEM的rxbuffer里；
-        但SOEM上层还没有真正的取走并解析这些内容，所以暂时只能RCVD，不能COMPLETE */
+
+        /* Change the RX buffer slot status to RCVD, waiting for SOEM core to read. */
         port->rxbufstat[idxf] = EC_BUF_RCVD;
-        /* soem的二值rx信号量给出，表示接收状态发生变化，通知所有等包的任务都醒来看看 */
+
+        /* Wake one waiter so it can recheck its requested RX slot. */
         if (port->rx_sem != NULL) {
             (void)xSemaphoreGive((SemaphoreHandle_t)port->rx_sem);
         }
     }
-    osal_mutex_unlock(port->rx_mutex);//释放锁
+    osal_mutex_unlock(port->rx_mutex);
 
-    free(buffer);//callback负责释放eth驱动分配的临时RxBuffer
+    free(buffer);
     return ESP_OK;
 }
 
-/*
-内部辅助函数，检查ecat port接收完成函数，非阻塞地看一眼槽状态，顺手返回最后报文的wkc；
-soem底层就是这样设计的，若关心前面报文的wkc，在上层代码里再按位置解析；
-返回0表示frame收到了，但是没有从站成功执行该报文(地址不对、配置不对等等)；
-返回-1表示连返回帧都没收到；这是两种完全不同的fail；
-被ecx_waitinframe_red()调用；
-*/
+/* Check an indexed RX slot and return its final datagram's working counter.
+   Called by ecx_waitinframe_red().
+   @return wkc, Final ECAT datagram's wkc field, -1 means no frame received, 0 means received but no slave executed. */
 static int ecx_inframe(ecx_portt *port, uint8 idx, int stacknumber)
 {
     uint16 l;
-    int rval = EC_NOFRAME; /* EC_NOFRAME是-1，有深意*/
+    int rval = EC_NOFRAME; /* Equal to -1 on purpose. */
     uint8 *rxbuf;
 
-    (void)stacknumber;//第一版不用
+    (void)stacknumber;
 
-    /* 此时callback也可能在访问rxbuf[]，因此上锁保护一下共享资源*/
-    osal_mutex_lock(port->rx_mutex);//上锁
-    /* RCVD表示帧已经回来，并且数据已经放进ecat port的rxbuf[idx]，等待上层读取、解析 */
+    osal_mutex_lock(port->rx_mutex);
+    /* Check the intended Rx buffer slot status. */
     if ((idx < EC_MAXBUF) && (port->rxbufstat[idx] == EC_BUF_RCVD)) {
         rxbuf = port->rxbuf[idx];
-        /* 与ecat协议紧密相关，最有特色，最有ecat味道；
-        ecat帧帧头低11位是该ecat帧内所有报文的字节长度，把它取出赋给l；
-        直接用l作为数组元素偏移，可以直接找到最后报文的wkc字段，取出赋给rval；举例意会，总之很巧妙！！！ */
+
+        /* ECAT header's low 11bits indicate total length of all datagrams.
+           Use it as array offset to find the last datagram's working counter(in little endian). */
         l = rxbuf[0] + ((uint16)(rxbuf[1] & 0x0f) << 8);
         rval = rxbuf[l] + ((uint16)rxbuf[l + 1] << 8);
+
+        /* Change the RX buffer slot status to COMPLETE, waiting for SOEM core to read. */
         port->rxbufstat[idx] = EC_BUF_COMPLETE;
     }
-    osal_mutex_unlock(port->rx_mutex);//解锁
+    osal_mutex_unlock(port->rx_mutex);
     return rval;
 }
 
-/*
-rx_sem是整个ecat port所有槽位共享的信号量，不是某个idx专用，
-因此“醒来后还要再检查是否是想要的那个idx唤醒的我”，如果不是就要计算出愿意等待的最新的剩余时间；
-这就是本函数的功能本质；转成rtos tick数是因为操作系统的操作粒度就是按tick来的；
-*/
+/* Calculate time remaining before a deadline and convert it into FreeRTOS ticks.
+   @param timer, Absolute deadline timepoint.
+   The actual timing precision is limited by FreeRTOS tick period, not suitable for high-precision cyclic timing. */
 static TickType_t ecx_remaining_ticks(osal_timert *timer)
 {
     ec_timet now;
     int64_t rem_us;
     TickType_t ticks;
 
-    /* 先获取soem格式下的当前时间(s+ns)，再去和绝对截至时间(s+ns)做差并转换，计算出剩余时间 in us；*/
+    /* Firstly, calculate the remaining time in us. */
     osal_get_monotonic_time(&now);
     rem_us = ((int64_t)timer->stop_time.tv_sec - (int64_t)now.tv_sec) * 1000000LL +
              ((int64_t)timer->stop_time.tv_nsec - (int64_t)now.tv_nsec) / 1000LL;
@@ -394,12 +331,9 @@ static TickType_t ecx_remaining_ticks(osal_timert *timer)
         return 0;
     }
 
-    /* 经典向上取整除法，+999就是把us向上顶到ms，再整除1000取整到ms(宁可多等1ms，也不能少等)；
-    再调用freertos的pdMS_TO_TICKS()把ms数转成freertos的tick数；
-    最后为避免Take(0)空转(陷入忙等待占用CPU)，要保护一下，不足1tick的也至少等1个节拍；
-    但rtos tick会带来精度问题，
-    比如rtos tick的单位是10ms，而ecat timeout是2ms，就不能表示了，硬生生把timeout拖成10ms；
-    这一版先跑起来问题不大，以后高性能要再优化，尤其是真正处理PDO周期时间时要再细究；*/
+    /* Secondly, round the remaining microseconds to milliseconds, and convert to FreeRTOS ticks.
+       Ensure at least one tick of blocking time to avoid a zero-timeout busy loop.
+       So, the real waiting precision is limited by the OS tick granularity. */
     ticks = pdMS_TO_TICKS((uint32_t)((rem_us + 999) / 1000));
     if (ticks == 0) {
         ticks = 1;
@@ -407,25 +341,15 @@ static TickType_t ecx_remaining_ticks(osal_timert *timer)
     return ticks;
 }
 
-/* 重要！！！内部函数，由对外公开的ecx_waitinframe()调用；
-本函数主要工作是：
-do {
-    先检查自己的 idx 到没到;
-    if (到了)
-        break;
-    if (还有时间)
-        睡到 rx_sem 上;
-} while (还没到 && 还没超时)。
-Rx Callback某时刻：
-Frame 回来->放入 rxbuf[X]->rxbufstat[X] = RCVD->xSemaphoreGive(rx_sem)；
-_red是冗余模式的意思，第一版不做，但兼容起来；*/
+/* Wait for the returned ECAT frame with specified index.
+   @param timer, Absolute deadline timepoint used to limit the total waiting time in this receive attempt.
+   Rx semaphore is shared by all Rx buffer slot, need recheck the index after each wakeup.
+   Also need recalculate the remaining waiting time.
+   @return wkc, Final ECAT datagram's wkc field, -1 means no frame received, 0 means received but no slave executed. */
 static int ecx_waitinframe_red(ecx_portt *port, uint8 idx, osal_timert *timer)
 {
     int wkc = EC_NOFRAME;
 
-    /* 先检查再Take，是标准的condition 1st, blocking 2nd模式；
-    rxbufstat[idx]是关键条件，如果该条件已经满足就直接返回，只有条件不满足时才需要阻塞等待；
-    task每次被唤醒以后，先从检查while里的条件开始；*/
     do {
         wkc = ecx_inframe(port, idx, 0);
         if (wkc > EC_NOFRAME) {
@@ -440,8 +364,8 @@ static int ecx_waitinframe_red(ecx_portt *port, uint8 idx, osal_timert *timer)
     return wkc;
 }
 
-/* 基本只是一个外壳函数(对用户暴露的接口)，实际干活的是ecx_waitinframe_red()；
-但也额外做了一件事，传入timeout in us，算出soem格式的绝对截至时间；*/
+/* Public API, function wrapper for ecx_waitinframe_red().
+   @param timeout, Maximum waiting time from now on in microseconds, convert to absolute deadline timepoint. */
 int ecx_waitinframe(ecx_portt *port, uint8 idx, int timeout)
 {
     osal_timert timer;
@@ -450,31 +374,27 @@ int ecx_waitinframe(ecx_portt *port, uint8 idx, int timeout)
     return ecx_waitinframe_red(port, idx, &timer);
 }
 
-/* soem上层百分百会调用的最最最重要的函数之一！！！send receive confirm；
-发一帧，然后等待返回；如果一帧都没等到，在总timeout内尝试重新发送；总timeout被称为一次transaction；
-但注意，只在根本没等到返回帧的情况下再重发，标志是软件里的wkc<0；
-里面用了两个运行定时器timer，非常值得关注；
-timer1：总timeout，用于控制整个SR confirm过程的持续时间，总预算；
-timer2：单次发送+等待的超时时间，用于控制每次发送一帧后的等待时间；
-*/
+/* Send a prepared Ethernet frame and retry until a response arrives or the transaction deadline expires.
+   @param timeout, Timeout in microseconds.
+   timer1 limits the total budget of the whole send/receive transaction.
+   timer2 limits each individual wait after transmission(need recalculate), less than EC_TIMEOUTRET.
+   @return wkc, Final ECAT datagram's wkc field, -1 means no frame received, 0 means received but no slave executed. */
 int ecx_srconfirm(ecx_portt *port, uint8 idx, int timeout)
 {
     int wkc = EC_NOFRAME;
     osal_timert timer1, timer2;
 
-    /* 针对当前时间，设置一个总的超时时间，绝对截至时间，控制整个SR过程 */
     osal_timer_start(&timer1, (uint32)timeout);
 
     do {
-        /* 发一帧，每次重发retry会再走ecx_outframe()，槽状态重新变成BUF_TX */
         ecx_outframe_red(port, idx);
-        /* 限一限传入单次等待超时参数的大小 */
+
         if (timeout < EC_TIMEOUTRET) {
             osal_timer_start(&timer2, (uint32)timeout);
         } else {
             osal_timer_start(&timer2, EC_TIMEOUTRET);
         }
-        /* 阻塞等返回帧，睡到rx_sem上，直到收到返回帧或超时 */
+
         wkc = ecx_waitinframe_red(port, idx, &timer2);
     } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired(&timer1));
 

--- a/soem/port/oshw/nicdrv.c
+++ b/soem/port/oshw/nicdrv.c
@@ -103,10 +103,10 @@ uint8 ecx_getindex(ecx_portt *port)
 int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
 {
     if ((port == NULL) ||
-        (ifname == NULL) ||
-        (strcmp(ifname, "esp_eth") != 0) ||
-        (port->eth_handle == NULL) ||
-        secondary) {
+            (ifname == NULL) ||
+            (strcmp(ifname, "esp_eth") != 0) ||
+            (port->eth_handle == NULL) ||
+            secondary) {
         return 0;
     }
 
@@ -141,8 +141,8 @@ int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
     port->tx_mutex = osal_mutex_create();
     port->rx_mutex = osal_mutex_create();
     if ((port->getindex_mutex == NULL) ||
-        (port->tx_mutex == NULL) ||
-        (port->rx_mutex == NULL)) {
+            (port->tx_mutex == NULL) ||
+            (port->rx_mutex == NULL)) {
         goto fail;
     }
 
@@ -219,7 +219,7 @@ int ecx_outframe(ecx_portt *port, uint8 idx, int stacknumber)
     int lp = port->txbuflength[idx];
     esp_eth_handle_t eth = (esp_eth_handle_t)port->eth_handle;
     if ((eth == NULL) ||
-        (esp_eth_transmit(eth, port->txbuf[idx], (size_t)lp) != ESP_OK)) {
+            (esp_eth_transmit(eth, port->txbuf[idx], (size_t)lp) != ESP_OK)) {
         port->rxbufstat[idx] = EC_BUF_EMPTY; /* In case the slot occupied still. */
         return -1;
     }
@@ -229,7 +229,7 @@ int ecx_outframe(ecx_portt *port, uint8 idx, int stacknumber)
 /* Prepare the path(only primary yet) marker and transmit the frame. */
 int ecx_outframe_red(ecx_portt *port, uint8 idx)
 {
-    ec_etherheadert *ehp = (ec_etherheadert *)&(port->txbuf[idx]);
+    ec_etherheadert *ehp = (ec_etherheadert *) & (port->txbuf[idx]);
     ehp->sa1 = oshw_htons(priMAC[1]); /* Mark the frame as primary-path traffic. */
 
     return ecx_outframe(port, idx, 0);
@@ -275,7 +275,7 @@ static esp_err_t ecx_esp_eth_rx(esp_eth_handle_t hdl, uint8_t *buffer, uint32_t 
             copy_len = (uint16)(length - ETH_HEADERSIZE);
         }
 
-        /* Only copy the payload feild(ECAT header and datagrams). */
+        /* Only copy the payload field (ECAT header and datagrams). */
         memcpy(port->rxbuf[idxf], buffer + ETH_HEADERSIZE, copy_len);
 
         port->rxsa[idxf] = oshw_ntohs(ehp->sa1);

--- a/soem/port/oshw/nicdrv.c
+++ b/soem/port/oshw/nicdrv.c
@@ -1,0 +1,482 @@
+/*
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ */
+
+#include "oshw.h"   /*会带上soem.h->nicdrv.h，所以 ecx_portt、ETH_P_ECAT、ec_etherheadert 都能用*/
+#include "osal.h"   /*提供osal_mutex_create/lock/unlock*/
+
+#include <string.h>
+#include "esp_soem.h"
+#include "esp_eth.h"
+#include "esp_err.h"
+
+#include <stdlib.h>   /* 要用到free()：释放驱动 eth驱动分配的临时RXbuffer */
+#include "freertos/FreeRTOS.h"  /*要用到semaphore了*/
+#include "freertos/semphr.h"
+
+
+enum {
+    ECT_RED_NONE = 0,   /*no redundancy，single NIC mode，单网卡模式*/
+    ECT_RED_DOUBLE      /*双网卡冗余，第一版不做*/
+};
+
+/*
+eth frame的源MAC地址字段(6Byte)，来自应用工程build目录生成的ec_options.h；
+只是逻辑地址，用来区分主路径/冗余路径，不是IP101芯片的真实MAC地址；
+*/
+const uint16 priMAC[3] = EC_PRIMARY_MAC_ARRAY;      /*Primary source MAC address used for EtherCAT*/
+const uint16 secMAC[3] = EC_SECONDARY_MAC_ARRAY;    /*Secondary source MAC address used for EtherCAT*/
+
+/* 应用层bind进来的eth句柄，setupnic()再写入port */
+static esp_eth_handle_t s_bound_eth;
+
+/* 先声明再使用 */
+static esp_err_t ecx_esp_eth_rx(esp_eth_handle_t hdl, uint8_t *buffer, uint32_t length, void *priv);
+static int ecx_inframe(ecx_portt *port, uint8 idx, int stacknumber);
+
+/*
+内部辅助函数，setup时把rxbuf[]每个槽的状态初始化为空，槽状态都在ec_type.h里提供；
+*/
+static void ecx_clear_rxbufstat(int *rxbufstat)
+{
+    int i;
+    for (i = 0; i < EC_MAXBUF; i++) {
+        rxbufstat[i] = EC_BUF_EMPTY; /* 空闲状态，ecx_getindex 可以占用*/
+    }
+}
+
+/*
+填eth帧的目的MAC(6Byte)、源MAC(6Byte)和EtherType(2Byte)字段内容，都是固定内容；
+以后每个txbuf[i]的前14Byte都是这三个内容，SOEM会在ecx_setupnic()里预先填一次；
+省得每次发的时候重复填这些字段，节省开销；每次发的时候只要填payload字段就行了；
+*/
+void ec_setupheader(void *p)
+{
+    ec_etherheadert *bp = p;
+
+    /* eth帧的目的MAC字段6Byte，全1表示以太网广播地址；
+    虽然ESC不在意该字段内容，但SOEM为了该eth frame不被普通以太网设备莫名过滤掉，所以用了一个合法、通用的地址类型 */
+    bp->da0 = oshw_htons(0xffff);
+    bp->da1 = oshw_htons(0xffff);
+    bp->da2 = oshw_htons(0xffff);
+
+    /* eth帧的源MAC字段6Byte，别当回事，虚构的*/
+    bp->sa0 = oshw_htons(priMAC[0]);
+    bp->sa1 = oshw_htons(priMAC[1]);
+    bp->sa2 = oshw_htons(priMAC[2]);
+
+    /* eth帧的EtherType字段2Byte，固定为0x88A4，表示EtherCAT on EtherNet */
+    bp->etype = oshw_htons(ETH_P_ECAT);
+}
+
+/*
+setbufstat 几乎是直接赋值。冗余口第一版不会有，但 Linux 有这段判断，照抄以免以后和 SOEM 行为不一致
+*/
+void ecx_setbufstat(ecx_portt *port, uint8 idx, int bufstat)
+{
+    port->rxbufstat[idx] = bufstat;
+    if (port->redstate != ECT_RED_NONE) {
+        port->redport->rxbufstat[idx] = bufstat;
+    }
+}
+
+/*
+从 0 ~ EC_MAXBUF-1 这几个帧缓冲槽位里，找一个当前没被占用的槽位，把它标记为“已分配”，然后返回这个槽位号 idx；
+这个idx后面会同时用于txbuf[]、rxbuf[]、rxbufstat[idx]，并且填进 EtherCAT Datagram 的 Index 字段；
+*/
+uint8 ecx_getindex(ecx_portt *port)
+{
+    uint8 idx;
+    uint8 cnt; //已经尝试了多少个槽
+
+    /* 可能同时有多个任务调用ecx_getindex()；
+    假设两个任务都看到idx=5是空闲的，都要用它，就冲突了，所以要用互斥锁保护；
+    找 buffer index 这件事一次只能一个任务做 */
+    osal_mutex_lock(port->getindex_mutex);
+
+    idx = port->lastidx + 1; //从上一次分配的槽位的下一个开始check，不是每次都从0开始，这是一种简单的循环轮转Round-Robin思路
+    if (idx >= EC_MAXBUF) {
+        idx = 0;
+    }
+
+    cnt = 0;
+    /* 最多转一圈 16 次，找 EMPTY 槽；
+    注意！！16 个槽都忙时，Linux 仍会占用转完一圈后的那个 idx（可能覆盖旧槽）。第一版保持这个行为，不要自己“优化” */
+    while ((port->rxbufstat[idx] != EC_BUF_EMPTY) && (cnt < EC_MAXBUF)) {
+        idx++;
+        cnt++;
+        if (idx >= EC_MAXBUF) {
+            idx = 0;
+        }
+    }
+
+    port->rxbufstat[idx] = EC_BUF_ALLOC; //不调用ecx_setbufstat()，直接赋值，表示已占住序号
+    if (port->redstate != ECT_RED_NONE) {
+        port->redport->rxbufstat[idx] = EC_BUF_ALLOC; //双网卡冗余模式的兼容代码，这一版不要管
+    }
+    port->lastidx = idx;
+
+    osal_mutex_unlock(port->getindex_mutex); //释放锁
+    return idx;
+}
+
+/*
+会被soem core的ecx_init()调用；
+初始化网卡端口port，这一步只做内存初始化，并不打开网卡，还没有真正挂上esp_eth()；
+把soem原本通过网卡名字打开Linux网卡的方式，改造成应用先初始化ESP-IDF Ethernet，再把eth_handle交给SOEM使用；
+但soem core的ecx_setupnic()没有这个句柄参数，只有网口名字符串指针，因此需要加一层绑定；
+*/
+int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
+{
+    int i;
+
+    /* 要求用户在应用层调用ecx_init()传参数的时候，网卡名字必须用”esp_eth“，否则认为非法
+    这个和oshw_find_adapters()里给网卡取名字是两回事，虽然那里也固定取为esp_eth，那个还没懂，先不管*/
+    if ((ifname == NULL) || (strcmp(ifname, "esp_eth") != 0)) {
+        return 0;
+    }
+    if (s_bound_eth == NULL) {
+        return 0; /* 用户应用层忘了先 bind，或 bind 在 init 之后 */
+    }
+
+    if (secondary) { /* 第一版不做第二块网卡 */
+        return 0;
+    }
+
+    port->getindex_mutex = osal_mutex_create();//创建取序号锁，保护tx/rx buf[]槽位的分配
+    port->tx_mutex = osal_mutex_create();//创建发送锁，保护txbuf[]的写入
+    port->rx_mutex = osal_mutex_create();//创建接收锁，保护rxbuf[]的读取
+    if ((port->getindex_mutex == NULL) ||
+        (port->tx_mutex == NULL) ||
+        (port->rx_mutex == NULL)) {
+        return 0;
+    } //任意一把锁创建失败，就认为nic初始化失败；失败时没有释放前面可能已创建好的锁(资源泄漏)，后续考虑补cleanup
+
+    /* 下面几乎都是初始化底层通信相关的软件变量状态 */
+    port->sockhandle = -1; //套接字句柄，P4不用
+    port->eth_handle = s_bound_eth; //重要！！挂esp_eth句柄，由应用层bind进来的静态全局变量桥接
+    /* 重要！创建收包通知信号量，并挂到ecat port */
+    port->rx_sem = xSemaphoreCreateBinary();
+    if (port->rx_sem == NULL) {
+        return 0;
+    }
+    /* 重要！注册eth驱动回调函数ecx_esp_eth_rx()，负责接收以太网帧，在以太网任务里被调用，不是那种ISR回调函数；
+    形参priv 必须是 port，回调才能写到这份 ecx_portt 的 rxbuf */
+    if (esp_eth_update_input_path((esp_eth_handle_t)port->eth_handle, ecx_esp_eth_rx, port) != ESP_OK) {
+        return 0;
+    }
+    port->lastidx = 0;
+    port->redstate = ECT_RED_NONE;
+    port->redport = NULL;
+
+    /* stack 是“指针包”，让收发代码用同一套写法访问本口缓冲(双端口模式下会用到，单端口兼容一下)；
+    用于描述ecx_portt类型变量的内部成员保存在内存哪里 */
+    port->stack.sock = &(port->sockhandle);
+    port->stack.txbuf = &(port->txbuf);
+    port->stack.txbuflength = &(port->txbuflength);
+    port->stack.tempbuf = &(port->tempinbuf);
+    port->stack.rxbuf = &(port->rxbuf);
+    port->stack.rxbufstat = &(port->rxbufstat);
+    port->stack.rxsa = &(port->rxsa);
+    port->stack.rxcnt = 0;
+
+    ecx_clear_rxbufstat(&(port->rxbufstat[0])); //把rxbuf[]每个槽的状态初始化为空
+
+    /* 重要！
+    给txbuf[]的每个槽位都先预填好其前(6+6+2)Byte的eth header内容(目的MAC、源MAC、EtherType)；
+    在初始化的时候做好这些固定的东西，以后真正运行起来的时候就省事了，只要管payload内容就行了*/
+    for (i = 0; i < EC_MAXBUF; i++) {
+        ec_setupheader(&(port->txbuf[i]));
+        port->rxbufstat[i] = EC_BUF_EMPTY;//这一步可以不用，上面ecx_clear_rxbufstat()已经搞过了
+    }
+    ec_setupheader(&(port->txbuf2));//第一版不用冗余，txbuf2不用管，但可以先兼容着，以后再细究
+
+    return 1; /* SOEM 约定：>0 表示成功 */
+}
+
+int ecx_closenic(ecx_portt *port)
+{
+    /* 销毁三把互斥锁，清空指针 */
+    osal_mutex_destroy(port->getindex_mutex);
+    osal_mutex_destroy(port->tx_mutex);
+    osal_mutex_destroy(port->rx_mutex);
+    port->getindex_mutex = NULL;
+    port->tx_mutex = NULL;
+    port->rx_mutex = NULL;
+
+    /* 反注册 callback，意味着以后不要再把RX Frame交给SOEM callback了；
+    ESP-IDF源码设计这个注册函数的时候，就弄成没有input path时，驱动会自己free后续RXbuffer */
+    if (port->eth_handle != NULL) {
+        (void)esp_eth_update_input_path((esp_eth_handle_t)port->eth_handle, NULL, NULL);
+    }
+    /* 销毁收包通知信号量，并清空ecat port相关指针*/
+    if (port->rx_sem != NULL) {
+        vSemaphoreDelete((SemaphoreHandle_t)port->rx_sem);
+        port->rx_sem = NULL;
+    }
+
+    /* 仅清空句柄关联关系，不调用esp_eth_stop()，网卡驱动是应用创建的，所有权属于应用，soem只是借用eth句柄 */
+    port->eth_handle = NULL;
+
+    return 0;
+}
+
+/* 为解决接口不匹配问题(soem core的ecx_setupnic()没有eth句柄参数，只有网口名字符串指针)，自己写的一个桥接函数；
+先找一个地方，把应用创建好的 eth handle句柄 暂存到s_bound_eth。
+整体逻辑：
+以太网驱动创建成功后归结为eth_handle；
+但soem core的ecx_init(*字符串)，内部调用ecx_setupnic(*字符串)；
+产生了矛盾，类型不对，eth_handle传不进去；
+而且，eth_handle属于应用层函数里的局部变量，soem core是访问不到的；
+因此，设计一个bind(eth_handle)函数，在里面让s_bound_eth = eth_handle，应用层调用bind()；
+再在ecx_setupnic(额外重点：规定传“esp_eth”网卡名)函数里把s_bound_eth挂到ecx_pottt上；
+ */
+esp_err_t esp_soem_bind_eth(esp_eth_handle_t eth)
+{
+    if (eth == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    s_bound_eth = eth; //nicdrv.c里的静态全局变量
+    return ESP_OK;
+}
+
+/*
+把已经在txbuf[idx]里填好的eth frame交给esp_eth_transmit()发出去；
+找到buf[]的idx槽位，找到其uint8长度，调用esp_eth_transmit()；
+*/
+int ecx_outframe(ecx_portt *port, uint8 idx, int stacknumber)
+{
+    int lp;
+    esp_eth_handle_t eth;
+
+    (void)stacknumber; /* 第一版只有主口 */
+
+    lp = port->txbuflength[idx]; /* SOEM 填报文时已经写好的整帧长度 */
+    port->rxbufstat[idx] = EC_BUF_TX; //由EC_BUF_ALLOC变为EC_BUF_TX，表示请求已经发送，现在等它的返回帧
+
+    eth = (esp_eth_handle_t)port->eth_handle;
+    if ((eth == NULL) ||
+        (esp_eth_transmit(eth, port->txbuf[idx], (size_t)lp) != ESP_OK)) { //成功仅指成功交给eth驱动，并非物理比特流发完
+        port->rxbufstat[idx] = EC_BUF_EMPTY; //若发送失败，就把状态恢复为空闲，否则这个槽会一直占着
+        return -1;
+    }
+    return lp; //返回发送成功的整帧长度
+}
+
+/*
+即使第一版不做双网卡，也要实现它，因为soem core是先调用这个函数，再根据是否有redundancy决定怎么发；
+没有冗余口就永远走primary port；
+port->txbuf[idx] 本质是一块字节内存，但它开头正好放了Ethernet Header，
+于是把这块内存的起始地址强制看成ec_etherheadert类型指针，
+以后就能直接用ehp->sa1的方式访问这段内存；
+*/
+int ecx_outframe_red(ecx_portt *port, uint8 idx)
+{
+    ec_etherheadert *ehp = (ec_etherheadert *)&(port->txbuf[idx]);//常用技巧
+
+    ehp->sa1 = oshw_htons(priMAC[1]);//与 Linux 相同：主路径用 priMAC 的第二个 uint16，不要深究，等以后做冗余了再深入
+    return ecx_outframe(port, idx, 0);
+}
+
+/*
+重点！！所有return之前都必须要free(buffer)，这里的buffer不是ecat接口的rxbuf[]，而是以太网驱动分配的临时RxBuffer，
+如果以太网驱动注册了callback()，在调用该cb()的时候驱动会把这个buffer的所有权交给回调函数，因此必须在cb()返回前把这段
+临时内存释放掉，否则会导致内存泄漏，可用内存越来越少。
+*/
+static esp_err_t ecx_esp_eth_rx(esp_eth_handle_t hdl, uint8_t *buffer, uint32_t length, void *priv)
+{
+    ecx_portt *port = (ecx_portt *)priv;
+    ec_etherheadert *ehp;
+    ec_comt *ecp;
+    uint8 idxf;
+    uint16 copy_len;
+
+    (void)hdl;
+
+    /* 有效性检查，尤其是这一帧eth帧的字节数，至少要比eth帧头(6+6+2)Byte与ecat帧头2Byte之和要大 */
+    if ((buffer == NULL) || (port == NULL) || (length < (ETH_HEADERSIZE + EC_HEADERSIZE))) {
+        free(buffer);
+        return ESP_OK;
+    }
+
+    /* 有效性检查，看这一帧eth帧的EtherType字段是否为ECAT要求的0x88A4 */
+    ehp = (ec_etherheadert *)buffer;
+    if (ehp->etype != oshw_htons(ETH_P_ECAT)) {
+        free(buffer);
+        return ESP_OK;
+    }
+
+    /* ETH_HEADERSIZE是以太网帧头长度14Byte，意味着ecp直接skip、摸到ECAT帧的帧头
+    然后，直接从ecat帧帧头后的第一个报文的index字段 读取编号 亦作为槽位号*/
+    ecp = (ec_comt *)(buffer + ETH_HEADERSIZE);
+    idxf = ecp->index;
+
+    /* 阻塞式上锁保护共享资源rxbuf[]，此时可能同时有多个任务在访问，形成冲突 */
+    osal_mutex_lock(port->rx_mutex);
+    /* (idxf < EC_MAXBUF)防止数组越界！
+    (port->rxbufstat[idxf] == EC_BUF_TX)表示确实曾经从这个槽发送出去了一帧，现在正在等待它回来，状态对！！*/
+    if ((idxf < EC_MAXBUF) && (port->rxbufstat[idxf] == EC_BUF_TX)) {
+        /*算出要拷贝的字节数，发的时候连着以太网帧头一起发，先在收的时候直接跳过以太网帧头，只拷贝payload部分，因为应用层已经不会再关心了*/
+        copy_len = (uint16)(port->txbuflength[idxf] - ETH_HEADERSIZE);
+        /*进行边界保护，防止读buffer越界！！！！比如原来发了100Byte，理论上返回的时候也有对应长度100Byte，
+        但假设因为某些异常，实际只收了60Byte(实际收到的字节数由形参length传入)，去掉eth帧头14Byte，剩下46Byte，
+        因此必须做一次copy_len截断，如果还傻傻地memcpy()，就要越界读内存了，闯祸！*/
+        if (copy_len > (length - ETH_HEADERSIZE)) {
+            copy_len = (uint16)(length - ETH_HEADERSIZE);
+        }
+        /* memcpy(目的地址，源地址，字节长度)；这里可以明显看到收的时候是跳过以太网帧头的！！*/
+        memcpy(port->rxbuf[idxf], buffer + ETH_HEADERSIZE, copy_len);
+        /*这行不要管，这是双网卡冗余模式下才用的，第一版没有*/
+        port->rxsa[idxf] = oshw_ntohs(ehp->sa1);
+        /* 改变rxbuf状态，现在以太网帧已经收到，并且已经从eth驱动临时buf里拷贝到正确的SOEM的rxbuffer里；
+        但SOEM上层还没有真正的取走并解析这些内容，所以暂时只能RCVD，不能COMPLETE */
+        port->rxbufstat[idxf] = EC_BUF_RCVD;
+        /* soem的二值rx信号量给出，表示接收状态发生变化，通知所有等包的任务都醒来看看 */
+        if (port->rx_sem != NULL) {
+            (void)xSemaphoreGive((SemaphoreHandle_t)port->rx_sem);
+        }
+    }
+    osal_mutex_unlock(port->rx_mutex);//释放锁
+
+    free(buffer);//callback负责释放eth驱动分配的临时RxBuffer
+    return ESP_OK;
+}
+
+/*
+内部辅助函数，检查ecat port接收完成函数，非阻塞地看一眼槽状态，顺手返回最后报文的wkc；
+soem底层就是这样设计的，若关心前面报文的wkc，在上层代码里再按位置解析；
+返回0表示frame收到了，但是没有从站成功执行该报文(地址不对、配置不对等等)；
+返回-1表示连返回帧都没收到；这是两种完全不同的fail；
+被ecx_waitinframe_red()调用；
+*/
+static int ecx_inframe(ecx_portt *port, uint8 idx, int stacknumber)
+{
+    uint16 l;
+    int rval = EC_NOFRAME; /* EC_NOFRAME是-1，有深意*/
+    uint8 *rxbuf;
+
+    (void)stacknumber;//第一版不用
+
+    /* 此时callback也可能在访问rxbuf[]，因此上锁保护一下共享资源*/
+    osal_mutex_lock(port->rx_mutex);//上锁
+    /* RCVD表示帧已经回来，并且数据已经放进ecat port的rxbuf[idx]，等待上层读取、解析 */
+    if ((idx < EC_MAXBUF) && (port->rxbufstat[idx] == EC_BUF_RCVD)) {
+        rxbuf = port->rxbuf[idx];
+        /* 与ecat协议紧密相关，最有特色，最有ecat味道；
+        ecat帧帧头低11位是该ecat帧内所有报文的字节长度，把它取出赋给l；
+        直接用l作为数组元素偏移，可以直接找到最后报文的wkc字段，取出赋给rval；举例意会，总之很巧妙！！！ */
+        l = rxbuf[0] + ((uint16)(rxbuf[1] & 0x0f) << 8);
+        rval = rxbuf[l] + ((uint16)rxbuf[l + 1] << 8);
+        port->rxbufstat[idx] = EC_BUF_COMPLETE;
+    }
+    osal_mutex_unlock(port->rx_mutex);//解锁
+    return rval;
+}
+
+/*
+rx_sem是整个ecat port所有槽位共享的信号量，不是某个idx专用，
+因此“醒来后还要再检查是否是想要的那个idx唤醒的我”，如果不是就要计算出愿意等待的最新的剩余时间；
+这就是本函数的功能本质；转成rtos tick数是因为操作系统的操作粒度就是按tick来的；
+*/
+static TickType_t ecx_remaining_ticks(osal_timert *timer)
+{
+    ec_timet now;
+    int64_t rem_us;
+    TickType_t ticks;
+
+    /* 先获取soem格式下的当前时间(s+ns)，再去和绝对截至时间(s+ns)做差并转换，计算出剩余时间 in us；*/
+    osal_get_monotonic_time(&now);
+    rem_us = ((int64_t)timer->stop_time.tv_sec - (int64_t)now.tv_sec) * 1000000LL +
+             ((int64_t)timer->stop_time.tv_nsec - (int64_t)now.tv_nsec) / 1000LL;
+    if (rem_us <= 0) {
+        return 0;
+    }
+
+    /* 经典向上取整除法，+999就是把us向上顶到ms，再整除1000取整到ms(宁可多等1ms，也不能少等)；
+    再调用freertos的pdMS_TO_TICKS()把ms数转成freertos的tick数；
+    最后为避免Take(0)空转(陷入忙等待占用CPU)，要保护一下，不足1tick的也至少等1个节拍；
+    但rtos tick会带来精度问题，
+    比如rtos tick的单位是10ms，而ecat timeout是2ms，就不能表示了，硬生生把timeout拖成10ms；
+    这一版先跑起来问题不大，以后高性能要再优化，尤其是真正处理PDO周期时间时要再细究；*/
+    ticks = pdMS_TO_TICKS((uint32_t)((rem_us + 999) / 1000));
+    if (ticks == 0) {
+        ticks = 1;
+    }
+    return ticks;
+}
+
+/* 重要！！！内部函数，由对外公开的ecx_waitinframe()调用；
+本函数主要工作是：
+do {
+    先检查自己的 idx 到没到;
+    if (到了)
+        break;
+    if (还有时间)
+        睡到 rx_sem 上;
+} while (还没到 && 还没超时)。
+Rx Callback某时刻：
+Frame 回来->放入 rxbuf[X]->rxbufstat[X] = RCVD->xSemaphoreGive(rx_sem)；
+_red是冗余模式的意思，第一版不做，但兼容起来；*/
+static int ecx_waitinframe_red(ecx_portt *port, uint8 idx, osal_timert *timer)
+{
+    int wkc = EC_NOFRAME;
+
+    /* 先检查再Take，是标准的condition 1st, blocking 2nd模式；
+    rxbufstat[idx]是关键条件，如果该条件已经满足就直接返回，只有条件不满足时才需要阻塞等待；
+    task每次被唤醒以后，先从检查while里的条件开始；*/
+    do {
+        wkc = ecx_inframe(port, idx, 0);
+        if (wkc > EC_NOFRAME) {
+            break;
+        }
+        if ((port->rx_sem != NULL) && !osal_timer_is_expired(timer)) {
+            (void)xSemaphoreTake((SemaphoreHandle_t)port->rx_sem,
+                                 ecx_remaining_ticks(timer));
+        }
+    } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired(timer));
+
+    return wkc;
+}
+
+/* 基本只是一个外壳函数(对用户暴露的接口)，实际干活的是ecx_waitinframe_red()；
+但也额外做了一件事，传入timeout in us，算出soem格式的绝对截至时间；*/
+int ecx_waitinframe(ecx_portt *port, uint8 idx, int timeout)
+{
+    osal_timert timer;
+
+    osal_timer_start(&timer, (uint32)timeout);
+    return ecx_waitinframe_red(port, idx, &timer);
+}
+
+/* soem上层百分百会调用的最最最重要的函数之一！！！send receive confirm；
+发一帧，然后等待返回；如果一帧都没等到，在总timeout内尝试重新发送；总timeout被称为一次transaction；
+但注意，只在根本没等到返回帧的情况下再重发，标志是软件里的wkc<0；
+里面用了两个运行定时器timer，非常值得关注；
+timer1：总timeout，用于控制整个SR confirm过程的持续时间，总预算；
+timer2：单次发送+等待的超时时间，用于控制每次发送一帧后的等待时间；
+*/
+int ecx_srconfirm(ecx_portt *port, uint8 idx, int timeout)
+{
+    int wkc = EC_NOFRAME;
+    osal_timert timer1, timer2;
+
+    /* 针对当前时间，设置一个总的超时时间，绝对截至时间，控制整个SR过程 */
+    osal_timer_start(&timer1, (uint32)timeout);
+
+    do {
+        /* 发一帧，每次重发retry会再走ecx_outframe()，槽状态重新变成BUF_TX */
+        ecx_outframe_red(port, idx);
+        /* 限一限传入单次等待超时参数的大小 */
+        if (timeout < EC_TIMEOUTRET) {
+            osal_timer_start(&timer2, (uint32)timeout);
+        } else {
+            osal_timer_start(&timer2, EC_TIMEOUTRET);
+        }
+        /* 阻塞等返回帧，睡到rx_sem上，直到收到返回帧或超时 */
+        wkc = ecx_waitinframe_red(port, idx, &timer2);
+    } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired(&timer1));
+
+    return wkc;
+}

--- a/soem/port/oshw/nicdrv.c
+++ b/soem/port/oshw/nicdrv.c
@@ -269,7 +269,7 @@ static esp_err_t ecx_esp_eth_rx(esp_eth_handle_t hdl, uint8_t *buffer, uint32_t 
     osal_mutex_lock(port->rx_mutex);
 
     if ((idxf < EC_MAXBUF) && (port->rxbufstat[idxf] == EC_BUF_TX)) {
-        /* Truncate the copy length to the actual received length(may shorter than Tx). */
+        /* Limit the copy to the actual received frame length. */
         copy_len = (uint16)(port->txbuflength[idxf] - ETH_HEADERSIZE);
         if (copy_len > (length - ETH_HEADERSIZE)) {
             copy_len = (uint16)(length - ETH_HEADERSIZE);

--- a/soem/port/oshw/nicdrv.c
+++ b/soem/port/oshw/nicdrv.c
@@ -1,15 +1,13 @@
 /*
  * This software is dual-licensed under GPLv3 and a commercial
- * license. See the file LICENSE.md distributed with this software for
+ * license. See the LICENSE file distributed with this software for
  * full license information.
  */
 
 #include "oshw.h"
 #include "osal.h"
-
 #include <stdlib.h>
 #include <string.h>
-
 #include "esp_eth.h"
 #include "esp_err.h"
 #include "freertos/FreeRTOS.h"

--- a/soem/port/oshw/nicdrv.h
+++ b/soem/port/oshw/nicdrv.h
@@ -1,6 +1,6 @@
 /*
  * This software is dual-licensed under GPLv3 and a commercial
- * license. See the file LICENSE.md distributed with this software for
+ * license. See the LICENSE file distributed with this software for
  * full license information.
  */
 

--- a/soem/port/oshw/nicdrv.h
+++ b/soem/port/oshw/nicdrv.h
@@ -1,0 +1,131 @@
+/*
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ */
+
+/*
+本头文件旨在描述ECAT网卡端口在内存里长什么样；
+soem core(比如ec_base.c、ec_main.c)会拿着一个ecx_portt，往里面的txbuf[idx]填报文，再调用ecx_outframe()发出去;
+ec_bufT、uint8、EC_MAXBUF能用，是因为真正编译时include顺序是：某个.c->oshw.h->soem.h->ec_type.h(这里面有定义这些)、nicdrv.h等；
+*/
+#ifndef _nicdrvh_
+#define _nicdrvh_ //文件名必须和Linux版的完全一致，因为soem core源码里已经写死了包含这些头文件
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// #include <pthread.h> //linux才用，freertos不用
+
+/*
+指针结构：同一套 TX/RX 缓冲可以通过 stack 指到主口或冗余口。
+第一版只用主口，但字段布局必须和 SOEM 其它端口保持一致。
+创建这个结构体的目的是，用于描述ecx_portt结构体类型的变量的内部成员保存在内存哪里；
+它本身作为ecx_portt结构体类型的变量的成员之一；
+*/
+/** pointer structure to Tx and Rx stacks */
+typedef struct
+{
+   /** socket connection used */
+   int *sock;
+   /** tx buffer */
+   ec_bufT (*txbuf)[EC_MAXBUF];
+   /** tx buffer lengths */
+   int (*txbuflength)[EC_MAXBUF];
+   /** temporary receive buffer */
+   ec_bufT *tempbuf;
+   /** rx buffers */
+   ec_bufT (*rxbuf)[EC_MAXBUF];
+   /** rx buffer status fields */
+   int (*rxbufstat)[EC_MAXBUF];
+   /** received MAC source address (middle word) */
+   int (*rxsa)[EC_MAXBUF];
+   /** number of received frames */
+   uint64 rxcnt;
+} ec_stackT;
+
+/** pointer structure to buffers for redundant port */
+typedef struct
+{
+   ec_stackT stack;
+   int sockhandle;
+   /** rx buffers */
+   ec_bufT rxbuf[EC_MAXBUF];
+   /** rx buffer status */
+   int rxbufstat[EC_MAXBUF];
+   /** rx MAC source address */
+   int rxsa[EC_MAXBUF];
+   /** temporary rx buffer */
+   ec_bufT tempinbuf;
+} ecx_redportt;
+
+/*
+非常重要的一个结构体，描述一个网卡端口在内存里的布局，说的有点抽象了，主要是包含了：
+txbuf[16]，每一个元素都是一个固定大小的uint8数组，对应一个ECAT帧
+rxbuf[16]，同上，一个元素又叫一个槽
+rxbufstat[16]，接收缓存区的状态
+lastidx，最近一次ecx_getindex()分到的槽号；SOEM会在ECAT报文的index字段填入该值；
+lastidx，也可以看作是最近一次的ecat帧序号(ECAT协议本身没有，是SOEM为了实现ECAT自己加的，并且阉割了ECAT对报文编号的功能)；
+三把锁，保护 取序号、发送、接收 这三个操作
+esp追加的以太网句柄和收包通知信号量
+*/
+/** pointer structure to buffers, vars and mutexes for port instantiation */
+typedef struct
+{
+   ec_stackT stack;
+   int sockhandle;
+   /** rx buffers */
+   ec_bufT rxbuf[EC_MAXBUF];     /* ec_bufT是uint8[EC_BUFSIZE=1518]这个数组类型的别名，这里EC_MAXBUF=16 */
+   /** rx buffer status */
+   int rxbufstat[EC_MAXBUF];     /* 取值在ec_type.h里*/
+   /** rx MAC source address */
+   int rxsa[EC_MAXBUF];
+   /** temporary rx buffer */
+   ec_bufT tempinbuf;
+   /** temporary rx buffer status */
+   int tempinbufs;
+   /** transmit buffers */
+   ec_bufT txbuf[EC_MAXBUF];//每个slot都是8bit位宽、1518长度的数组，tx软件只负责(6+6+2 + 1500(at most))Byte，CRC硬件负责
+   /** transmit buffer lengths */
+   int txbuflength[EC_MAXBUF];
+   /** temporary tx buffer */
+   ec_bufT txbuf2;
+   /** temporary tx buffer length */
+   int txbuflength2;
+   /** last used frame index */
+   uint8 lastidx;                /* 上一次分配的是哪个槽位，也是最近一次的ecat帧序号 */
+   /** current redundancy state */
+   int redstate;
+   /** pointer to redundancy port and buffers */
+   ecx_redportt *redport;
+   // pthread_mutex_t getindex_mutex;  //以下三个是Linux版的pthread，要改成freertos
+   // pthread_mutex_t tx_mutex;
+   // pthread_mutex_t rx_mutex;
+   osal_mutext getindex_mutex;   //保护“取一个空闲帧序号”，osal_mutext在osal_defs.h里已经定义为SemaphoreHandle_t
+   osal_mutext tx_mutex;         //保护发送路径；第一版冗余不用，先留着
+   osal_mutext rx_mutex;         //保护接收路径上的缓冲状态
+
+   void *eth_handle;             //以后放 esp_eth_handle_t，现在还用不到
+   void *rx_sem;                 //以后收包通知用，用来代替 Linux 的 ppoll
+} ecx_portt;
+
+//以下这些都是nicdrv.c将来要实现的接口和要用到变量，都不要删
+extern const uint16 priMAC[3];
+extern const uint16 secMAC[3];
+
+void ec_setupheader(void *p);
+int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary);
+int ecx_closenic(ecx_portt *port);
+void ecx_setbufstat(ecx_portt *port, uint8 idx, int bufstat);
+uint8 ecx_getindex(ecx_portt *port);
+int ecx_outframe(ecx_portt *port, uint8 idx, int sock);
+int ecx_outframe_red(ecx_portt *port, uint8 idx);
+int ecx_waitinframe(ecx_portt *port, uint8 idx, int timeout);
+int ecx_srconfirm(ecx_portt *port, uint8 idx, int timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/soem/port/oshw/nicdrv.h
+++ b/soem/port/oshw/nicdrv.h
@@ -14,86 +14,83 @@ extern "C" {
 /* Pointer-based view of a SOEM port's TX/RX buffers and state.
    Provides a common access interface so the same frame-processing code
    can operate on either the primary or redundant port storage. */
-typedef struct
-{
-   int *sock;
+typedef struct {
+    int *sock;
 
-   ec_bufT (*txbuf)[EC_MAXBUF];
-   int (*txbuflength)[EC_MAXBUF];
-   ec_bufT *tempbuf;
-   ec_bufT (*rxbuf)[EC_MAXBUF];
-   int (*rxbufstat)[EC_MAXBUF];
-   int (*rxsa)[EC_MAXBUF];
+    ec_bufT(*txbuf)[EC_MAXBUF];
+    int (*txbuflength)[EC_MAXBUF];
+    ec_bufT *tempbuf;
+    ec_bufT(*rxbuf)[EC_MAXBUF];
+    int (*rxbufstat)[EC_MAXBUF];
+    int (*rxsa)[EC_MAXBUF];
 
-   /* Number of received frames on this port path. */
-   uint64 rxcnt;
+    /* Number of received frames on this port path. */
+    uint64 rxcnt;
 } ec_stackT;
 
 /* Runtime context for the optional SOEM redundant network port. */
-typedef struct
-{
-   ec_stackT stack;
-   int sockhandle;
-   ec_bufT rxbuf[EC_MAXBUF];
-   int rxbufstat[EC_MAXBUF];
-   int rxsa[EC_MAXBUF];
-   ec_bufT tempinbuf;
+typedef struct {
+    ec_stackT stack;
+    int sockhandle;
+    ec_bufT rxbuf[EC_MAXBUF];
+    int rxbufstat[EC_MAXBUF];
+    int rxsa[EC_MAXBUF];
+    ec_bufT tempinbuf;
 } ecx_redportt;
 
 /* Runtime context for a SOEM network port.
    Hold the Tx/Rx buffer pool, buffer state, redundancy info, ESP-IDF Ethernet driver handle
    used by SOEM frame transmission and reception paths. */
-typedef struct
-{
-   /* Pointer view of the ECAT port Tx/Rx buffers and associated state,
-      the storage itself is owned by ecx_portt. */
-   ec_stackT stack;
-   /* Not used by ESP-IDF Ethernet. Legacy socket handle retained for SOEM structure compatibility. */
-   int sockhandle;
+typedef struct {
+    /* Pointer view of the ECAT port Tx/Rx buffers and associated state,
+       the storage itself is owned by ecx_portt. */
+    ec_stackT stack;
+    /* Not used by ESP-IDF Ethernet. Legacy socket handle retained for SOEM structure compatibility. */
+    int sockhandle;
 
-   /* Rx buffer pool with EC_MAXBUF slots, each slot has EC_BUFSIZE bytes and
-      stores one received EtherCAT frame(ECAT Header + ECAT Datagrams). */
-   ec_bufT rxbuf[EC_MAXBUF];
-   /* Status flag for each Rx buffer slot */
-   int rxbufstat[EC_MAXBUF];
-   /* Source MAC address(middle 16bits) associated with each rx frame, stored for redundancy handling. */
-   int rxsa[EC_MAXBUF];
-   /* One temporary Rx buffer slot used by SOEM redundancy logic. */
-   ec_bufT tempinbuf;
-   /* Temporary Rx buffer slot status */
-   int tempinbufs;
+    /* Rx buffer pool with EC_MAXBUF slots, each slot has EC_BUFSIZE bytes and
+       stores one received EtherCAT frame(ECAT Header + ECAT Datagrams). */
+    ec_bufT rxbuf[EC_MAXBUF];
+    /* Status flag for each Rx buffer slot */
+    int rxbufstat[EC_MAXBUF];
+    /* Source MAC address(middle 16bits) associated with each rx frame, stored for redundancy handling. */
+    int rxsa[EC_MAXBUF];
+    /* One temporary Rx buffer slot used by SOEM redundancy logic. */
+    ec_bufT tempinbuf;
+    /* Temporary Rx buffer slot status */
+    int tempinbufs;
 
-   /* TX buffer pool, same type and size as rxbuf[].
-      But each slot stores one complete Ethernet frame(CRC excluded) ready for transmission. */
-   ec_bufT txbuf[EC_MAXBUF];
-   /* Number of bytes to transmit for each Tx buffer slot. */
-   int txbuflength[EC_MAXBUF];
-   /* One temporary Tx buffer slot used by SOEM redundancy path. */
-   ec_bufT txbuf2;
-   /* Number of bytes to transmit for the temporary Tx buffer slot. */
-   int txbuflength2;
+    /* TX buffer pool, same type and size as rxbuf[].
+       But each slot stores one complete Ethernet frame(CRC excluded) ready for transmission. */
+    ec_bufT txbuf[EC_MAXBUF];
+    /* Number of bytes to transmit for each Tx buffer slot. */
+    int txbuflength[EC_MAXBUF];
+    /* One temporary Tx buffer slot used by SOEM redundancy path. */
+    ec_bufT txbuf2;
+    /* Number of bytes to transmit for the temporary Tx buffer slot. */
+    int txbuflength2;
 
-   /* Index of the most recently allocated buffer slot.
-      ecx_getindex() uses it as the starting point when searching for the next free slot. */
-   uint8 lastidx;
+    /* Index of the most recently allocated buffer slot.
+       ecx_getindex() uses it as the starting point when searching for the next free slot. */
+    uint8 lastidx;
 
-   /* Current redundancy state */
-   int redstate;
-   /* Pointer to redundancy port and buffers */
-   ecx_redportt *redport;
+    /* Current redundancy state */
+    int redstate;
+    /* Pointer to redundancy port and buffers */
+    ecx_redportt *redport;
 
-   /* Mutex protecting Rx/Tx buffer slot allocation and lastidx. */
-   osal_mutext getindex_mutex;
-   /* Mutex protecting write access to shared transmit-side operations. */
-   osal_mutext tx_mutex;
-   /* Mutex protecting read access to Rx buffers and their associated state. */
-   osal_mutext rx_mutex;
+    /* Mutex protecting Rx/Tx buffer slot allocation and lastidx. */
+    osal_mutext getindex_mutex;
+    /* Mutex protecting write access to shared transmit-side operations. */
+    osal_mutext tx_mutex;
+    /* Mutex protecting read access to Rx buffers and their associated state. */
+    osal_mutext rx_mutex;
 
-   /* Borrow ESP-IDF Ethernet driver handle. */
-   void *eth_handle;
+    /* Borrow ESP-IDF Ethernet driver handle. */
+    void *eth_handle;
 
-   /* FreeRTOS semaphore used to notify waiting SOEM code of Rx activity. */
-   void *rx_sem;
+    /* FreeRTOS semaphore used to notify waiting SOEM code of Rx activity. */
+    void *rx_sem;
 } ecx_portt;
 
 extern const uint16 priMAC[3];

--- a/soem/port/oshw/nicdrv.h
+++ b/soem/port/oshw/nicdrv.h
@@ -4,113 +4,98 @@
  * full license information.
  */
 
-/*
-本头文件旨在描述ECAT网卡端口在内存里长什么样；
-soem core(比如ec_base.c、ec_main.c)会拿着一个ecx_portt，往里面的txbuf[idx]填报文，再调用ecx_outframe()发出去;
-ec_bufT、uint8、EC_MAXBUF能用，是因为真正编译时include顺序是：某个.c->oshw.h->soem.h->ec_type.h(这里面有定义这些)、nicdrv.h等；
-*/
 #ifndef _nicdrvh_
-#define _nicdrvh_ //文件名必须和Linux版的完全一致，因为soem core源码里已经写死了包含这些头文件
+#define _nicdrvh_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// #include <pthread.h> //linux才用，freertos不用
-
-/*
-指针结构：同一套 TX/RX 缓冲可以通过 stack 指到主口或冗余口。
-第一版只用主口，但字段布局必须和 SOEM 其它端口保持一致。
-创建这个结构体的目的是，用于描述ecx_portt结构体类型的变量的内部成员保存在内存哪里；
-它本身作为ecx_portt结构体类型的变量的成员之一；
-*/
-/** pointer structure to Tx and Rx stacks */
+/* Pointer-based view of a SOEM port's TX/RX buffers and state.
+   Provides a common access interface so the same frame-processing code
+   can operate on either the primary or redundant port storage. */
 typedef struct
 {
-   /** socket connection used */
    int *sock;
-   /** tx buffer */
+
    ec_bufT (*txbuf)[EC_MAXBUF];
-   /** tx buffer lengths */
    int (*txbuflength)[EC_MAXBUF];
-   /** temporary receive buffer */
    ec_bufT *tempbuf;
-   /** rx buffers */
    ec_bufT (*rxbuf)[EC_MAXBUF];
-   /** rx buffer status fields */
    int (*rxbufstat)[EC_MAXBUF];
-   /** received MAC source address (middle word) */
    int (*rxsa)[EC_MAXBUF];
-   /** number of received frames */
+
+   /* Number of received frames on this port path. */
    uint64 rxcnt;
 } ec_stackT;
 
-/** pointer structure to buffers for redundant port */
+/* Runtime context for the optional SOEM redundant network port. */
 typedef struct
 {
    ec_stackT stack;
    int sockhandle;
-   /** rx buffers */
    ec_bufT rxbuf[EC_MAXBUF];
-   /** rx buffer status */
    int rxbufstat[EC_MAXBUF];
-   /** rx MAC source address */
    int rxsa[EC_MAXBUF];
-   /** temporary rx buffer */
    ec_bufT tempinbuf;
 } ecx_redportt;
 
-/*
-非常重要的一个结构体，描述一个网卡端口在内存里的布局，说的有点抽象了，主要是包含了：
-txbuf[16]，每一个元素都是一个固定大小的uint8数组，对应一个ECAT帧
-rxbuf[16]，同上，一个元素又叫一个槽
-rxbufstat[16]，接收缓存区的状态
-lastidx，最近一次ecx_getindex()分到的槽号；SOEM会在ECAT报文的index字段填入该值；
-lastidx，也可以看作是最近一次的ecat帧序号(ECAT协议本身没有，是SOEM为了实现ECAT自己加的，并且阉割了ECAT对报文编号的功能)；
-三把锁，保护 取序号、发送、接收 这三个操作
-esp追加的以太网句柄和收包通知信号量
-*/
-/** pointer structure to buffers, vars and mutexes for port instantiation */
+/* Runtime context for a SOEM network port.
+   Hold the Tx/Rx buffer pool, buffer state, redundancy info, ESP-IDF Ethernet driver handle
+   used by SOEM frame transmission and reception paths. */
 typedef struct
 {
+   /* Pointer view of the ECAT port Tx/Rx buffers and associated state,
+      the storage itself is owned by ecx_portt. */
    ec_stackT stack;
+   /* Not used by ESP-IDF Ethernet. Legacy socket handle retained for SOEM structure compatibility. */
    int sockhandle;
-   /** rx buffers */
-   ec_bufT rxbuf[EC_MAXBUF];     /* ec_bufT是uint8[EC_BUFSIZE=1518]这个数组类型的别名，这里EC_MAXBUF=16 */
-   /** rx buffer status */
-   int rxbufstat[EC_MAXBUF];     /* 取值在ec_type.h里*/
-   /** rx MAC source address */
-   int rxsa[EC_MAXBUF];
-   /** temporary rx buffer */
-   ec_bufT tempinbuf;
-   /** temporary rx buffer status */
-   int tempinbufs;
-   /** transmit buffers */
-   ec_bufT txbuf[EC_MAXBUF];//每个slot都是8bit位宽、1518长度的数组，tx软件只负责(6+6+2 + 1500(at most))Byte，CRC硬件负责
-   /** transmit buffer lengths */
-   int txbuflength[EC_MAXBUF];
-   /** temporary tx buffer */
-   ec_bufT txbuf2;
-   /** temporary tx buffer length */
-   int txbuflength2;
-   /** last used frame index */
-   uint8 lastidx;                /* 上一次分配的是哪个槽位，也是最近一次的ecat帧序号 */
-   /** current redundancy state */
-   int redstate;
-   /** pointer to redundancy port and buffers */
-   ecx_redportt *redport;
-   // pthread_mutex_t getindex_mutex;  //以下三个是Linux版的pthread，要改成freertos
-   // pthread_mutex_t tx_mutex;
-   // pthread_mutex_t rx_mutex;
-   osal_mutext getindex_mutex;   //保护“取一个空闲帧序号”，osal_mutext在osal_defs.h里已经定义为SemaphoreHandle_t
-   osal_mutext tx_mutex;         //保护发送路径；第一版冗余不用，先留着
-   osal_mutext rx_mutex;         //保护接收路径上的缓冲状态
 
-   void *eth_handle;             //以后放 esp_eth_handle_t，现在还用不到
-   void *rx_sem;                 //以后收包通知用，用来代替 Linux 的 ppoll
+   /* Rx buffer pool with EC_MAXBUF slots, each slot has EC_BUFSIZE bytes and
+      stores one received EtherCAT frame(ECAT Header + ECAT Datagrams). */
+   ec_bufT rxbuf[EC_MAXBUF];
+   /* Status flag for each Rx buffer slot */
+   int rxbufstat[EC_MAXBUF];
+   /* Source MAC address(middle 16bits) associated with each rx frame, stored for redundancy handling. */
+   int rxsa[EC_MAXBUF];
+   /* One temporary Rx buffer slot used by SOEM redundancy logic. */
+   ec_bufT tempinbuf;
+   /* Temporary Rx buffer slot status */
+   int tempinbufs;
+
+   /* TX buffer pool, same type and size as rxbuf[].
+      But each slot stores one complete Ethernet frame(CRC excluded) ready for transmission. */
+   ec_bufT txbuf[EC_MAXBUF];
+   /* Number of bytes to transmit for each Tx buffer slot. */
+   int txbuflength[EC_MAXBUF];
+   /* One temporary Tx buffer slot used by SOEM redundancy path. */
+   ec_bufT txbuf2;
+   /* Number of bytes to transmit for the temporary Tx buffer slot. */
+   int txbuflength2;
+
+   /* Index of the most recently allocated buffer slot.
+      ecx_getindex() uses it as the starting point when searching for the next free slot. */
+   uint8 lastidx;
+
+   /* Current redundancy state */
+   int redstate;
+   /* Pointer to redundancy port and buffers */
+   ecx_redportt *redport;
+
+   /* Mutex protecting Rx/Tx buffer slot allocation and lastidx. */
+   osal_mutext getindex_mutex;
+   /* Mutex protecting write access to shared transmit-side operations. */
+   osal_mutext tx_mutex;
+   /* Mutex protecting read access to Rx buffers and their associated state. */
+   osal_mutext rx_mutex;
+
+   /* Borrow ESP-IDF Ethernet driver handle. */
+   void *eth_handle;
+
+   /* FreeRTOS semaphore used to notify waiting SOEM code of Rx activity. */
+   void *rx_sem;
 } ecx_portt;
 
-//以下这些都是nicdrv.c将来要实现的接口和要用到变量，都不要删
 extern const uint16 priMAC[3];
 extern const uint16 secMAC[3];
 

--- a/soem/port/oshw/oshw.c
+++ b/soem/port/oshw/oshw.c
@@ -1,11 +1,10 @@
 /*
  * This software is dual-licensed under GPLv3 and a commercial
- * license. See the file LICENSE.md distributed with this software for
+ * license. See the LICENSE file distributed with this software for
  * full license information.
  */
 
 #include "oshw.h"
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/soem/port/oshw/oshw.c
+++ b/soem/port/oshw/oshw.c
@@ -1,0 +1,54 @@
+/*
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ */
+
+ #include "oshw.h"
+
+ #include <stdlib.h>   /* malloc / free */
+ #include <string.h>   /* strncpy */
+
+/*
+两个字节序转换函数；
+host to network和network to host，s指16位无符号整型(unsigned short)；
+ESP32P4内部存储用小端；eth frame规定用大端解读；ecat报文规定用小端解读；
+字节序，针对空间存储时，小端指低低高高；针对网络传输时，大端指先传高字节，再传低字节；皆vice versa；
+隐含认知，对CPU的访问(读/写)都按由低地址到高地址的顺序来的；
+*/
+uint16 oshw_htons(uint16 host) //mainly aim at eth frame's MAC and EtherType fields
+{
+    return (uint16)((host << 8) | (host >> 8)); //存储形式上，把0xABCD变成0xCDAB
+}
+
+uint16 oshw_ntohs(uint16 network)
+{
+    return oshw_htons(network); //与htons一样，都是对调一次
+}
+
+/*
+网卡列表桩，枚举与释放
+*/
+ec_adaptert *oshw_find_adapters(void)
+{
+    ec_adaptert *adapter = (ec_adaptert *)malloc(sizeof(ec_adaptert));
+    if (adapter == NULL) {
+        return NULL;
+    }
+
+    adapter->next = NULL; //P4只有一块网卡，所以next为NULL
+    strncpy(adapter->name, "esp_eth", EC_MAXLEN_ADAPTERNAME - 1); //把esp_eth当作P4网卡名字，固定写死
+    adapter->name[EC_MAXLEN_ADAPTERNAME - 1] = '\0'; //strncpy之后手动在最后一格写 '\0'，防止名字刚好填满数组时没有结束符
+    strncpy(adapter->desc, "esp_eth", EC_MAXLEN_ADAPTERNAME - 1);
+    adapter->desc[EC_MAXLEN_ADAPTERNAME - 1] = '\0';
+    return adapter;
+}
+
+void oshw_free_adapters(ec_adaptert *adapter)
+{
+    while (adapter) {
+        ec_adaptert *next = adapter->next;
+        free(adapter);
+        adapter = next;
+    }
+}

--- a/soem/port/oshw/oshw.c
+++ b/soem/port/oshw/oshw.c
@@ -4,46 +4,40 @@
  * full license information.
  */
 
- #include "oshw.h"
+#include "oshw.h"
 
- #include <stdlib.h>   /* malloc / free */
- #include <string.h>   /* strncpy */
+#include <stdlib.h>
+#include <string.h>
 
-/*
-两个字节序转换函数；
-host to network和network to host，s指16位无符号整型(unsigned short)；
-ESP32P4内部存储用小端；eth frame规定用大端解读；ecat报文规定用小端解读；
-字节序，针对空间存储时，小端指低低高高；针对网络传输时，大端指先传高字节，再传低字节；皆vice versa；
-隐含认知，对CPU的访问(读/写)都按由低地址到高地址的顺序来的；
-*/
-uint16 oshw_htons(uint16 host) //mainly aim at eth frame's MAC and EtherType fields
+/* Unsigned short byte order changes from host memory(little-endian) to network analysis(big-endian),
+   mainly used for eth frame's MAC and EtherType fields. But for payload field(EtherCAT frame),
+   it's still little-endian. */
+uint16 oshw_htons(uint16 host)
 {
-    return (uint16)((host << 8) | (host >> 8)); //存储形式上，把0xABCD变成0xCDAB
+    return (uint16)((host << 8) | (host >> 8));
 }
-
 uint16 oshw_ntohs(uint16 network)
 {
-    return oshw_htons(network); //与htons一样，都是对调一次
+    return oshw_htons(network); /* same as oshw_htons */
 }
 
-/*
-网卡列表桩，枚举与释放
-*/
+/* Expose the ESP-IDF Ethernet interface as a virtual SOEM adapter(imitate linux version).
+   Fix 'esp_eth' as nic name and description.
+   Only support single nic yet. */
 ec_adaptert *oshw_find_adapters(void)
 {
-    ec_adaptert *adapter = (ec_adaptert *)malloc(sizeof(ec_adaptert));
+    ec_adaptert *adapter = (ec_adaptert *)malloc(sizeof(ec_adaptert)); /* nic info list node */
     if (adapter == NULL) {
         return NULL;
     }
 
-    adapter->next = NULL; //P4只有一块网卡，所以next为NULL
-    strncpy(adapter->name, "esp_eth", EC_MAXLEN_ADAPTERNAME - 1); //把esp_eth当作P4网卡名字，固定写死
-    adapter->name[EC_MAXLEN_ADAPTERNAME - 1] = '\0'; //strncpy之后手动在最后一格写 '\0'，防止名字刚好填满数组时没有结束符
+    adapter->next = NULL;
+    strncpy(adapter->name, "esp_eth", EC_MAXLEN_ADAPTERNAME - 1);
+    adapter->name[EC_MAXLEN_ADAPTERNAME - 1] = '\0'; /* manually ending with '\0' */
     strncpy(adapter->desc, "esp_eth", EC_MAXLEN_ADAPTERNAME - 1);
     adapter->desc[EC_MAXLEN_ADAPTERNAME - 1] = '\0';
     return adapter;
 }
-
 void oshw_free_adapters(ec_adaptert *adapter)
 {
     while (adapter) {

--- a/soem/port/oshw/oshw.h
+++ b/soem/port/oshw/oshw.h
@@ -4,9 +4,6 @@
  * full license information.
  */
 
- /*
- 直接完全不改，照抄linux版
- */
 #ifndef _oshw_
 #define _oshw_
 
@@ -14,13 +11,13 @@
 extern "C" {
 #endif
 
-#include "soem/soem.h"  //直接拉进整条SOEM头文件链
+#include "soem/soem.h"
 #include "nicdrv.h"
 
-uint16 oshw_htons(uint16 hostshort);            //16位无符号短整型数 从host主机字节序 转换为 network网络字节序(以太网头用大端)
+uint16 oshw_htons(uint16 hostshort);
 uint16 oshw_ntohs(uint16 networkshort);
-ec_adaptert *oshw_find_adapters(void);          //列出本机网卡，P4上会写死一个名字
-void oshw_free_adapters(ec_adaptert *adapter);  //释放网卡列表
+ec_adaptert *oshw_find_adapters(void);
+void oshw_free_adapters(ec_adaptert *adapter);
 
 #ifdef __cplusplus
 }

--- a/soem/port/oshw/oshw.h
+++ b/soem/port/oshw/oshw.h
@@ -1,0 +1,29 @@
+/*
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ */
+
+ /*
+ 直接完全不改，照抄linux版
+ */
+#ifndef _oshw_
+#define _oshw_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "soem/soem.h"  //直接拉进整条SOEM头文件链
+#include "nicdrv.h"
+
+uint16 oshw_htons(uint16 hostshort);            //16位无符号短整型数 从host主机字节序 转换为 network网络字节序(以太网头用大端)
+uint16 oshw_ntohs(uint16 networkshort);
+ec_adaptert *oshw_find_adapters(void);          //列出本机网卡，P4上会写死一个名字
+void oshw_free_adapters(ec_adaptert *adapter);  //释放网卡列表
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/soem/port/oshw/oshw.h
+++ b/soem/port/oshw/oshw.h
@@ -1,6 +1,6 @@
 /*
  * This software is dual-licensed under GPLv3 and a commercial
- * license. See the file LICENSE.md distributed with this software for
+ * license. See the LICENSE file distributed with this software for
  * full license information.
  */
 


### PR DESCRIPTION
# Summary

ESP-IDF port of [SOEM](https://github.com/OpenEtherCATsociety/SOEM) v2.0.0.

The app owns `esp_eth`. The port sends/receives raw EtherType `0x88A4` and exposes SOEM `ecx_*` via `esp_soem_init()`.

Usage, Kconfig, scope, and license: [soem/README.md](soem/README.md).  
Hardware demo: [examples/ecat_io/README.md](soem/examples/ecat_io/README.md).

# Key Features

- Upstream SOEM v2.0.0 as a pinned Git submodule
- OSAL on FreeRTOS (`esp_timer`, mutexes, tasks)
- OSHW on `esp_eth` (raw EtherCAT frames, single NIC)
- Resource limits and timeouts in Kconfig
- `EC_MAX_MAPT` fixed to 1 (upstream: values greater than 1 have known races)
- Example `ecat_io` on ESP32-P4: discovery, state machine, 10 ms cyclic LRW

# Component Structure

```text
soem/
├── CMakeLists.txt / Kconfig / LICENSE / README.md / idf_component.yml
├── .build-test-rules.yml
├── soem/                 # upstream submodule (do not reformat)
├── port/                 # FreeRTOS OSAL + esp_eth OSHW + esp_soem.h
└── examples/ecat_io/     # ESP32-P4 + LAN9252 digital IO
```
# Testing
Local hardware only: ESP-IDF v6.0.2, ESP32-P4-Function-EV-Board (internal EMAC + IP101), one LAN9252 slave.

`ecat_io` reached OP. 10 ms LRW: SW1 pressed → LED3 on, released → off. Unplugging the cable hits `ESP_ERROR_CHECK` and resets, as the example documents.