### PR TITLE
feat(esp_delta_ota): add resume feature to delta_ota (IEC-590)

### DIFF
--- a/esp_delta_ota/include/esp_delta_ota.h
+++ b/esp_delta_ota/include/esp_delta_ota.h
@@ -21,6 +21,20 @@ extern "C" {
 
 typedef void *esp_delta_ota_handle_t;
 
+typedef struct {
+    const void *data;
+    size_t size;
+} esp_delta_ota_state_t;
+
+typedef struct {
+    size_t patch_offset;
+    size_t output_offset;
+} esp_delta_ota_resume_info_t;
+
+// Callback invoked with a resumable state after a patch chunk was processed successfully.
+// The state data is owned by esp_delta_ota and is only valid for the duration of the callback.
+typedef esp_err_t (*esp_delta_ota_checkpoint_cb_t)(const esp_delta_ota_state_t *state, void *user_data);
+
 // Callback for reading the source data
 typedef esp_err_t (*src_read_cb_t)(uint8_t *buf_p, size_t size, int src_offset);
 typedef esp_err_t (*src_read_cb_with_user_ctx_t)(uint8_t *buf_p, size_t size, int src_offset, void *user_data);
@@ -39,6 +53,7 @@ typedef struct esp_delta_ota_cfg {
         merged_stream_write_cb_with_user_ctx_t write_cb_with_user_data;     /*!< Write Callback with user data */
         merged_stream_write_cb_t write_cb DEPRECATED_ATTRIBUTE;             /*!< Write Callback */
     };
+    esp_delta_ota_checkpoint_cb_t checkpoint_cb; /*!< Optional checkpoint callback */
 } esp_delta_ota_cfg_t;
 
 #undef DEPRECATED_ATTRIBUTE
@@ -51,6 +66,22 @@ typedef struct esp_delta_ota_cfg {
  *         - esp_delta_ota_handle_t handle
  */
 esp_delta_ota_handle_t esp_delta_ota_init(esp_delta_ota_cfg_t *cfg);
+
+/**
+ * @brief Resumes a delta OTA process from a previously saved state.
+ *
+ * The returned offsets identify where the external patch input and merged output
+ * streams have to be resumed by the caller.
+ *
+ * @param[in] cfg          pointer to esp_delta_ota_cfg_t structure.
+ * @param[in] state        previously saved opaque delta OTA state.
+ * @param[out] resume_info restored patch and output offsets.
+ * @return - NULL   On failure
+ *         - esp_delta_ota_handle_t handle
+ */
+esp_delta_ota_handle_t esp_delta_ota_resume(esp_delta_ota_cfg_t *cfg,
+                                             const esp_delta_ota_state_t *state,
+                                             esp_delta_ota_resume_info_t *resume_info);
 
 /**
  * @brief This function performs the patch applying operation on the source data.

--- a/esp_delta_ota/src/esp_delta_ota.c
+++ b/esp_delta_ota/src/esp_delta_ota.c
@@ -27,9 +27,57 @@ typedef struct esp_delta_ota_ctx {
         merged_stream_write_cb_with_user_ctx_t write_cb_with_user_data;
         merged_stream_write_cb_t write_cb;
     };
+    esp_delta_ota_checkpoint_cb_t checkpoint_cb;
     struct detools_apply_patch_t *apply_patch;
     int src_offset;
+
+    uint8_t *state_buf;
+    size_t state_buf_capacity;
+    size_t state_buf_offset;
+
+    const uint8_t *state_read_buf;
+    size_t state_read_size;
+    size_t state_read_offset;
 } esp_delta_ota_ctx;
+
+static int esp_delta_ota_state_write_cb(void *arg_p, const void *buf_p, size_t size)
+{
+    esp_delta_ota_ctx *ctx = (esp_delta_ota_ctx *)arg_p;
+    if (!ctx || (!buf_p && size != 0) || size > SIZE_MAX - ctx->state_buf_offset) {
+        return -1;
+    }
+
+    size_t required = ctx->state_buf_offset + size;
+    if (required > ctx->state_buf_capacity) {
+        uint8_t *new_buf = realloc(ctx->state_buf, required);
+        if (!new_buf) {
+            return -1;
+        }
+        ctx->state_buf = new_buf;
+        ctx->state_buf_capacity = required;
+    }
+
+    if (size != 0) {
+        memcpy(ctx->state_buf + ctx->state_buf_offset, buf_p, size);
+    }
+    ctx->state_buf_offset = required;
+    return 0;
+}
+
+static int esp_delta_ota_state_read_cb(void *arg_p, void *buf_p, size_t size)
+{
+    esp_delta_ota_ctx *ctx = (esp_delta_ota_ctx *)arg_p;
+    if (!ctx || (!buf_p && size != 0) || ctx->state_read_offset > ctx->state_read_size ||
+            size > ctx->state_read_size - ctx->state_read_offset) {
+        return -1;
+    }
+
+    if (size != 0) {
+        memcpy(buf_p, ctx->state_read_buf + ctx->state_read_offset, size);
+    }
+    ctx->state_read_offset += size;
+    return 0;
+}
 
 static int esp_delta_ota_write_cb(void *arg_p, const uint8_t *buf_p, size_t size)
 {
@@ -88,6 +136,10 @@ static int esp_delta_ota_seek_cb(void *arg_p, int offset)
 
 esp_delta_ota_handle_t esp_delta_ota_init(esp_delta_ota_cfg_t *cfg)
 {
+    if (!cfg) {
+        return NULL;
+    }
+
     esp_delta_ota_ctx *ctx = calloc(1, sizeof(esp_delta_ota_ctx));
     if (!ctx) {
         ESP_LOGE(TAG, "Unable to allocate memory");
@@ -96,6 +148,7 @@ esp_delta_ota_handle_t esp_delta_ota_init(esp_delta_ota_cfg_t *cfg)
     ctx->user_data = cfg->user_data;
     ctx->read_cb = cfg->read_cb;
     ctx->write_cb_with_user_data = cfg->write_cb_with_user_data;
+    ctx->checkpoint_cb = cfg->checkpoint_cb;
     ctx->apply_patch = calloc(1, sizeof(struct detools_apply_patch_t));
     if (!ctx->apply_patch) {
         ESP_LOGE(TAG, "Unable to allocate memory");
@@ -115,6 +168,42 @@ esp_delta_ota_handle_t esp_delta_ota_init(esp_delta_ota_cfg_t *cfg)
     return (esp_delta_ota_handle_t)ctx;
 }
 
+esp_delta_ota_handle_t esp_delta_ota_resume(esp_delta_ota_cfg_t *cfg,
+                                             const esp_delta_ota_state_t *state,
+                                             esp_delta_ota_resume_info_t *resume_info)
+{
+    if (!cfg || !state || !state->data || state->size == 0 || !resume_info) {
+        return NULL;
+    }
+
+    esp_delta_ota_handle_t handle = esp_delta_ota_init(cfg);
+    if (!handle) {
+        return NULL;
+    }
+
+    esp_delta_ota_ctx *ctx = (esp_delta_ota_ctx *)handle;
+    ctx->state_read_buf = (const uint8_t *)state->data;
+    ctx->state_read_size = state->size;
+    ctx->state_read_offset = 0;
+    ctx->src_offset = 0;
+
+    int ret = detools_apply_patch_restore(ctx->apply_patch, &esp_delta_ota_state_read_cb);
+    if (ret < 0 || ctx->state_read_offset != ctx->state_read_size) {
+        ESP_LOGE(TAG, "Error while restoring delta_ota state: %s",
+                 ret < 0 ? detools_error_as_string(ret) : "invalid state size");
+        esp_delta_ota_deinit(handle);
+        return NULL;
+    }
+
+    ctx->state_read_buf = NULL;
+    ctx->state_read_size = 0;
+    ctx->state_read_offset = 0;
+
+    resume_info->patch_offset = detools_apply_patch_get_patch_offset(ctx->apply_patch);
+    resume_info->output_offset = detools_apply_patch_get_to_offset(ctx->apply_patch);
+    return handle;
+}
+
 esp_err_t esp_delta_ota_feed_patch(esp_delta_ota_handle_t handle, const uint8_t *buf, int size)
 {
     if (handle == NULL) {
@@ -127,6 +216,26 @@ esp_err_t esp_delta_ota_feed_patch(esp_delta_ota_handle_t handle, const uint8_t 
         ESP_LOGE(TAG, "Error while applying patch: %s", detools_error_as_string(err));
         return ESP_FAIL;
     }
+
+    if (ctx->checkpoint_cb && ctx->apply_patch->state != detools_apply_patch_state_init_t) {
+        ctx->state_buf_offset = 0;
+        err = detools_apply_patch_dump(ctx->apply_patch, &esp_delta_ota_state_write_cb);
+        if (err != 0) {
+            ESP_LOGE(TAG, "Error while dumping delta_ota state: %s", detools_error_as_string(err));
+            return ESP_FAIL;
+        }
+
+        esp_delta_ota_state_t state = {
+            .data = ctx->state_buf,
+            .size = ctx->state_buf_offset,
+        };
+        esp_err_t checkpoint_err = ctx->checkpoint_cb(&state, ctx->user_data);
+        if (checkpoint_err != ESP_OK) {
+            ESP_LOGE(TAG, "Error in checkpoint_cb(): %s", esp_err_to_name(checkpoint_err));
+            return ESP_FAIL;
+        }
+    }
+
     return ESP_OK;
 }
 
@@ -152,6 +261,8 @@ esp_err_t esp_delta_ota_deinit(esp_delta_ota_handle_t handle)
     }
     esp_delta_ota_ctx *ctx = (esp_delta_ota_ctx *)handle;
 
+    free(ctx->state_buf);
+    ctx->state_buf = NULL;
     free(ctx->apply_patch);
     ctx->apply_patch = NULL;
     free(ctx);


### PR DESCRIPTION
# Checklist

- [X] Component contains License
- [X] Component contains README.md
- [X] Component contains idf_component.yml file with `url` field defined
- [X] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [X] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description

This is a draft implementation of resume support for esp_delta_ota as requested in https://github.com/espressif/idf-extra-components/issues/760.
Any feedback would be appreciated :)
