### PR TITLE
fix(spi_nand_flash): correct ECC status extraction in PACK_2BITS_STATUS and PACK_3BITS_STATUS (IEC-591)

### DIFF
--- a/spi_nand_flash/CHANGELOG.md
+++ b/spi_nand_flash/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this component will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [VERSIONING.md](VERSIONING.md) for this component's versioning policy.
 
-## [Unreleased]
+## [1.4.4] - 2026-09-10
+
+### Fixed
+
+- Extraction of ECC status bits
 
 ### Changed
+
 - Demote per-page/per-block traces (`is_bad`, `erase_block`, `is_free`) from debug to verbose log level, since they flooded the log during any full-chip scan or erase
 
 ## [1.4.3]
@@ -147,4 +152,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Initial release with basic NAND flash support based on dhara nand library
 - Support for Winbond, Alliance and Gigadevice devices
 - Added test application for the same
-

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.3"
+version: "1.4.4"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/priv_include/spi_nand_oper.h
+++ b/spi_nand_flash/priv_include/spi_nand_oper.h
@@ -50,13 +50,13 @@ typedef struct spi_nand_transaction_t spi_nand_transaction_t;
 #define REG_CONFIG          0xB0
 #define REG_STATUS          0xC0
 
-#define STAT_BUSY           1 << 0
-#define STAT_WRITE_ENABLED  1 << 1
-#define STAT_ERASE_FAILED   1 << 2
-#define STAT_PROGRAM_FAILED 1 << 3
-#define STAT_ECC0           1 << 4
-#define STAT_ECC1           1 << 5
-#define STAT_ECC2           1 << 6
+#define STAT_BUSY           (1 << 0)
+#define STAT_WRITE_ENABLED  (1 << 1)
+#define STAT_ERASE_FAILED   (1 << 2)
+#define STAT_PROGRAM_FAILED (1 << 3)
+#define STAT_ECC0           (1 << 4)
+#define STAT_ECC1           (1 << 5)
+#define STAT_ECC2           (1 << 6)
 
 size_t spi_nand_get_dma_alignment(void);
 esp_err_t spi_nand_execute_transaction(spi_nand_flash_device_t *handle, spi_nand_transaction_t *transaction);

--- a/spi_nand_flash/src/nand_impl.c
+++ b/spi_nand_flash/src/nand_impl.c
@@ -442,8 +442,13 @@ fail:
     return ret;
 }
 
-#define PACK_2BITS_STATUS(status, bit1, bit0)         ((((status) & (bit1)) << 1) | ((status) & (bit0)))
-#define PACK_3BITS_STATUS(status, bit2, bit1, bit0)   ((((status) & (bit2)) << 2) | (((status) & (bit1)) << 1) | ((status) & (bit0)))
+// Collapse each ECC status flag down to 0b0 or 0b1 regardless of its original position,
+// shift it into the correct place (bit n) and pack the result into a nand_ecc_status_t value.
+#define PACK_2BITS_STATUS(status, bit1, bit0)         ((!!((status) & (bit1)) << 1) | \
+                                                        !!((status) & (bit0)))
+#define PACK_3BITS_STATUS(status, bit2, bit1, bit0)   ((!!((status) & (bit2)) << 2) | \
+                                                       (!!((status) & (bit1)) << 1) | \
+                                                        !!((status) & (bit0)))
 
 static bool is_ecc_error(spi_nand_flash_device_t *dev, uint8_t status)
 {


### PR DESCRIPTION
# Summary

The number of corrected ECC bit is read from two or three bits of the STATUS register.
`PACK_2BITS_STATUS` and `PACK_3BITS_STATUS` in `spi_nand_flash/src/nand_impl.c` shifted the masked ECC status bits in the wrong direction. The resulting value never equals any `nand_ecc_status_t` enumerator, so every comparison against that enum fails. As a consequence the driver never reports an uncorrectable read error, and the data refresh threshold never triggers.

# Root cause

The ECC status bits are defined at bit 4 and above in the status register (`spi_nand_oper.h`):

```c
#define STAT_ECC0           1 << 4
#define STAT_ECC1           1 << 5
#define STAT_ECC2           1 << 6
```

The macros to extract these bits from the register value masks them and then shift them further
left instead of down to positions 0-2:

```c
#define PACK_3BITS_STATUS(status, bit2, bit1, bit0) \
    ((((status) & (bit2)) << 2) | (((status) & (bit1)) << 1) | ((status) & (bit0)))
```

For the five defined values in the ECC status bits this results in: 

| ECC Bits  | Meaning                               | Macro result should be  | Macro result  is|
|-----------|---------------------------------------|---------------------|--------------|
| `000`     | no errors                             | 0                   | 0            |
| `001`     | 1-3 bits corrected                    | 1                   | **16**       |
| `010`     | uncorrectable                         | 2                   | **64**       |
| `011`     | 4-6 bits corrected                    | 3                   | **80**       |
| `101`     | 7-8 bits corrected                    | 5                   | **272**      |

The `is_ecc_error()` tries to map the extracted values to `nand_ecc_status_t` values:

```
NAND_ECC_OK = 0,
NAND_ECC_1_TO_3_BITS_CORRECTED = 1,
NAND_ECC_NOT_CORRECTED = 2,
NAND_ECC_4_TO_6_BITS_CORRECTED = 3,
NAND_ECC_7_8_BITS_CORRECTED = 5,
```

Only `000` can be mapped correctly.

# Impact

`is_ecc_error()` cannot match `NAND_ECC_NOT_CORRECTED`, so `nand_read()` returns `ESP_OK` for a
page the ECC could not correct, and passes the corrupt data to the caller.
Therefore `dhara_glue.c` never refreshes pages with faulty bits and never detects an uncorrectable read.
An unrecoverable read error is reported as success.

# Checklist

- [x] Component contains License
- [x] Component contains README.md
- [x] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

