### PR TITLE
fix(spi_nand_flash): add STAT_BUSY hang timeout in wait_for_ready

### DIFF
--- a/spi_nand_flash/CHANGELOG.md
+++ b/spi_nand_flash/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Versioning policy: see [VERSIONING.md](VERSIONING.md). From **v1.0.0** onward this component follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3]
+- fix: add STAT_BUSY hang timeout in wait_for_ready
+
 ## [1.4.2]
 - fix: use Internal Data Move same-parity handling for GigaDevice chips that require it (GD5F2GQ5, GD5F2GM7, GD5F4GQ6, GD5F4GM8, GD5F4GM7, GD5F8GM8), without treating them as hardware dual-plane
 

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.2"
+version: "1.4.3"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/src/nand_impl.c
+++ b/spi_nand_flash/src/nand_impl.c
@@ -3,10 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * SPDX-FileContributor: 2015-2024 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileContributor: 2015-2026 Espressif Systems (Shanghai) CO LTD
  */
 
 #include <string.h>
+#include <inttypes.h>
 #include "esp_check.h"
 #include "esp_err.h"
 #include "spi_nand_oper.h"
@@ -15,6 +16,10 @@
 #include "nand_device_types.h"
 
 #define ROM_WAIT_THRESHOLD_US 1000
+/* Vendor tables pass typical tR/tPROG/tBERS; datasheet max is often several
+ * times that. Bound hangs at 10× typical plus one tick so max/tick rounding
+ * cannot false-timeout. Wrong if actual BUSY exceeds 10× the delay passed in. */
+#define NAND_WAIT_READY_TIMEOUT_MULT 10U
 
 static const char *TAG = "nand_hal";
 
@@ -169,6 +174,16 @@ static esp_err_t wait_for_ready(spi_nand_flash_device_t *dev, uint32_t expected_
         esp_rom_delay_us(expected_operation_time_us);
     }
 
+    /* Hang bound only. Success path still polls until BUSY clears. */
+    uint64_t timeout_us = (uint64_t)expected_operation_time_us * NAND_WAIT_READY_TIMEOUT_MULT;
+    uint32_t timeout_ms = (uint32_t)((timeout_us + 999U) / 1000U);
+    if (timeout_ms == 0) {
+        timeout_ms = 1;
+    }
+    TickType_t timeout_ticks = (timeout_ms + portTICK_PERIOD_MS - 1U) / portTICK_PERIOD_MS;
+    timeout_ticks += 1;
+    TickType_t start_tick = xTaskGetTickCount();
+
     while (true) {
         uint8_t status;
         ESP_RETURN_ON_ERROR(spi_nand_read_register(dev, REG_STATUS, &status), TAG, "");
@@ -178,6 +193,13 @@ static esp_err_t wait_for_ready(spi_nand_flash_device_t *dev, uint32_t expected_
                 *status_out = status;
             }
             break;
+        }
+
+        if ((xTaskGetTickCount() - start_tick) >= timeout_ticks) {
+            ESP_LOGE(TAG, "STAT_BUSY timeout: status=0x%02x, expected_op=%" PRIu32 " us, waited=%" PRIu32 " ms",
+                     status, expected_operation_time_us,
+                     (uint32_t)timeout_ticks * portTICK_PERIOD_MS);
+            return ESP_ERR_TIMEOUT;
         }
 
         if (expected_operation_time_us >= ROM_WAIT_THRESHOLD_US) {


### PR DESCRIPTION
# Change description
## Summary
- Bound `wait_for_ready()` so a stuck/missing chip cannot hang forever on `STAT_BUSY` (e.g. after `PAGE_READ`).
- Hang limit is **10×** the vendor-table typical delay (`tR` / `tPROG` / `tBERS`), ceiled to FreeRTOS ticks, plus one tick; success path still polls until `BUSY` clears and returns `ESP_ERR_TIMEOUT` on expiry.
## Why
`STAT_BUSY` is not guaranteed to clear (no chip, stuck status, etc.). An unbounded poll loops forever. Using typical delay alone as the timeout is too tight (e.g. Winbond erase typ ~2.5 ms, datasheet max ~10 ms), so the bound is 10× typical.

