### PR TITLE
docs(network_provisioning): Add warning about network_prov_mgr_wait deadlocks (IEC-597)

### DIFF
--- a/network_provisioning/include/network_provisioning/manager.h
+++ b/network_provisioning/include/network_provisioning/manager.h
@@ -464,6 +464,11 @@ void network_prov_mgr_stop_provisioning(void);
  * i.e. till event NETWORK_PROV_END is emitted.
  *
  * This will not block if provisioning is not started or not initialized.
+ *
+ * Do not call this API in callbacks from the default event loop task or from
+ * the ESP timer task. The service is stopped from those tasks, so waiting
+ * there prevents the stop from completing and this API never
+ * returns.
  */
 void network_prov_mgr_wait(void);
 


### PR DESCRIPTION
# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Description

I stumbled accross a behavior that I did not expect and I think should be documented more clearly
for the user of network_provisioning.

`network_prov_mgr_wait()` blocks until `prov_state` becomes
`NETWORK_PROV_STATE_IDLE`. That assignment happens in `prov_stop_and_notify()`,
called from `network_prov_mgr_event_handler_internal()` on the default event
loop task, in response to a `NETWORK_PROV_MGR_STOP` event that
`cleanup_delay_timer_cb()` posts from the  ESP timer task.

Calling the API from either of those tasks deadlocks, because the task that
has to complete the teardown is the one blocked in the wait. Since the wait
uses `vTaskDelay()`, the task yields and the task watchdog does not fire, so
the result is a silent hang rather than a panic. It only happens while
a stop is in progress. When the service is already idle the API returns
immediately.

This PR is documentation only, no functional change.