### PR TITLE
fix(spi_nand_flash_fatfs): drop deprecated FatFs register on IDF v6

### DIFF
--- a/spi_nand_flash_fatfs/CHANGELOG.md
+++ b/spi_nand_flash_fatfs/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.1.1]
+- fix: call `esp_vfs_fat_register` with `esp_vfs_fat_conf_t` on ESP-IDF v6.0+ (the `_cfg` name is deprecated there). Keep `esp_vfs_fat_register_cfg` for v5.3–v5.x and the 4-argument register API for older IDF.
+
 ## [1.1.0]
 
 ### Added

--- a/spi_nand_flash_fatfs/idf_component.yml
+++ b/spi_nand_flash_fatfs/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.1.0"
+version: "1.1.1"
 description: "FATFS integration for SPI NAND Flash"
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash_fatfs
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash_fatfs/src/vfs_fat_spinandflash.c
+++ b/spi_nand_flash_fatfs/src/vfs_fat_spinandflash.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <esp_check.h>
+#include "esp_idf_version.h"
 #include "esp_log.h"
 #include "esp_vfs.h"
 #include "esp_vfs_fat.h"
@@ -40,12 +41,16 @@ esp_err_t esp_vfs_fat_nand_mount(const char *base_path, spi_nand_flash_device_t 
     ESP_GOTO_ON_ERROR(spi_nand_flash_get_page_size(nand_device, &page_size), fail, TAG, "");
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
-    esp_vfs_fat_conf_t conf = {
+    const esp_vfs_fat_conf_t conf = {
         .base_path = base_path,
         .fat_drive = drv,
         .max_files = mount_config->max_files,
     };
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ESP_GOTO_ON_ERROR(esp_vfs_fat_register(&conf, &fs), fail, TAG, "esp_vfs_fat_register failed");
+#else
     ESP_GOTO_ON_ERROR(esp_vfs_fat_register_cfg(&conf, &fs), fail, TAG, "esp_vfs_fat_register failed");
+#endif
 #else
     ESP_GOTO_ON_ERROR(esp_vfs_fat_register(base_path, drv, mount_config->max_files, &fs),
                       fail, TAG, "esp_vfs_fat_register failed");


### PR DESCRIPTION
### Handle FatFs VFS register rename on ESP-IDF v6

On ESP-IDF v6.0 the FatFs VFS registration API was renamed: the conf-struct signature moved from `esp_vfs_fat_register_cfg` back to `esp_vfs_fat_register`, and the old `_cfg` symbol is now deprecated. `spi_nand_flash_fatfs` still called the deprecated name, so builds against IDF v6 emitted a deprecation warning.

#### Change

`esp_vfs_fat_nand_mount()` now dispatches on `ESP_IDF_VERSION`:

| ESP-IDF   | Call |
| --------- | ---- |
| ≥ 6.0     | `esp_vfs_fat_register(&conf, &fs)` (new conf-struct signature) |
| 5.3 – 5.x | `esp_vfs_fat_register_cfg(&conf, &fs)` |
| < 5.3     | legacy 4-arg `esp_vfs_fat_register(base_path, drv, max_files, &fs)` |

Also:
- Adds `#include "esp_idf_version.h"` so the version macros resolve without relying on transitive includes.
- Marks the `esp_vfs_fat_conf_t` local as `const` (it's read-only after init).
- Bumps `spi_nand_flash_fatfs` 1.1.0 → 1.1.1 and adds a CHANGELOG entry.

No changes to the BDL path (`esp_vfs_fat_bdl_*` on IDF 6.1+) — that path never used `_cfg`.