### PR TITLE
feat(expat): Update to v2.8.4

### DIFF
--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.8.2"
+version: "2.8.4"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:

--- a/expat/port/include/expat_config.h
+++ b/expat/port/include/expat_config.h
@@ -70,7 +70,7 @@
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.8.2"
+#define PACKAGE_STRING "expat 2.8.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -79,13 +79,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.8.2"
+#define PACKAGE_VERSION "2.8.4"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.8.2"
+#define VERSION "2.8.4"
 
 /* whether byteorder is bigendian */
 /* #undef WORDS_BIGENDIAN */

--- a/expat/sbom_libexpat.yml
+++ b/expat/sbom_libexpat.yml
@@ -1,7 +1,12 @@
 name: libexpat
-version: 2.8.2
+version: 2.8.4
 cpe: cpe:2.3:a:libexpat_project:libexpat:{}:*:*:*:*:*:*:*
 supplier: 'Organization: libexpat_project'
 description: Fast streaming XML parser written in C99
 url: https://github.com/libexpat/libexpat/
-hash: c61098da494eea1cbd091118118dcee417faacea
+hash: 12cf0b1f25f026a022fe728ad8f7e3d017285b80
+cve-exclude-list:
+  - cve: CVE-2026-76956
+    reason: Resolved in version 2.8.4 with commit 40daa9996d616e66a75dea41ed2b18f2c3901b9f
+  - cve: CVE-2026-76957
+    reason: Resolved in version 2.8.4 with commit 127b7d4beb8fe7e5ce5cb021c2e56379c95863d0


### PR DESCRIPTION
# Change description
This PR updates libexpat to v2.8.4 which fixes following vulnerabilities:

1. [CVE-2026-76956](https://nvd.nist.gov/vuln/detail/cve-2026-76956)
2. [CVE-2026-76957](https://nvd.nist.gov/vuln/detail/cve-2026-76957)
