### PR TITLE
fix(spi_nand_flash): correct ECC status extraction in PACK_2BITS_STATUS and PACK_3BITS_STATUS

### DIFF
--- a/spi_nand_flash/CHANGELOG.md
+++ b/spi_nand_flash/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Versioning policy: see [VERSIONING.md](VERSIONING.md). From **v1.0.0** onward this component follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4]
+- fix: correct ECC status bit extraction in PACK_2BITS_STATUS and PACK_3BITS_STATUS
+
 ## [1.4.3]
 - fix: add STAT_BUSY hang timeout in wait_for_ready
 

--- a/spi_nand_flash/idf_component.yml
+++ b/spi_nand_flash/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.4.3"
+version: "1.4.4"
 description: Driver for accessing SPI NAND Flash
 url: https://github.com/espressif/idf-extra-components/tree/master/spi_nand_flash
 issues: https://github.com/espressif/idf-extra-components/issues

--- a/spi_nand_flash/src/nand_impl.c
+++ b/spi_nand_flash/src/nand_impl.c
@@ -434,9 +434,12 @@ fail:
     return ret;
 }
 
-#define ECC_STATUS_SHIFT 4
-#define PACK_2BITS_STATUS(status, bit1, bit0)         (((status) & ((bit1) | (bit0))) >> ECC_STATUS_SHIFT)
-#define PACK_3BITS_STATUS(status, bit2, bit1, bit0)   (((status) & ((bit2) | (bit1) | (bit0))) >> ECC_STATUS_SHIFT)
+// Each STAT_ECCx bit flag may live at an arbitrary bit position in the status byte.
+// `!!(status & bitN)` collapses that flag down to 0b0 or 0b1 regardless of its
+// original position, so it can then be shifted into its correct place (bit N)
+// in the packed result, producing a plain 0..3 / 0..7 value matching nand_ecc_status_t.
+#define PACK_2BITS_STATUS(status, bit1, bit0)         ((!!((status) & (bit1)) << 1) | !!((status) & (bit0)))
+#define PACK_3BITS_STATUS(status, bit2, bit1, bit0)   ((!!((status) & (bit2)) << 2) | (!!((status) & (bit1)) << 1) | !!((status) & (bit0)))
 
 static bool is_ecc_error(spi_nand_flash_device_t *dev, uint8_t status)
 {

--- a/spi_nand_flash/src/nand_impl.c
+++ b/spi_nand_flash/src/nand_impl.c
@@ -434,8 +434,9 @@ fail:
     return ret;
 }
 
-#define PACK_2BITS_STATUS(status, bit1, bit0)         ((((status) & (bit1)) << 1) | ((status) & (bit0)))
-#define PACK_3BITS_STATUS(status, bit2, bit1, bit0)   ((((status) & (bit2)) << 2) | (((status) & (bit1)) << 1) | ((status) & (bit0)))
+#define ECC_STATUS_SHIFT 4
+#define PACK_2BITS_STATUS(status, bit1, bit0)         (((status) & ((bit1) | (bit0))) >> ECC_STATUS_SHIFT)
+#define PACK_3BITS_STATUS(status, bit2, bit1, bit0)   (((status) & ((bit2) | (bit1) | (bit0))) >> ECC_STATUS_SHIFT)
 
 static bool is_ecc_error(spi_nand_flash_device_t *dev, uint8_t status)
 {


### PR DESCRIPTION
# Change description
Please refer to the original PR: https://github.com/espressif/idf-extra-components/pull/813

The number of corrected ECC bit is read from two or three bits of the STATUS register.
`PACK_2BITS_STATUS` and `PACK_3BITS_STATUS` in `spi_nand_flash/src/nand_impl.c` shifted the masked ECC status bits in the wrong direction. The resulting value never equals any `nand_ecc_status_t` enumerator, so every comparison against that enum fails. As a consequence the driver never reports an uncorrectable read error, and the data refresh threshold never triggers.
