### PR TITLE
fix(esp_ext_part_tables): replace BUILD_COMPONENTS with TARGET_EXISTS for build system v2

### DIFF
--- a/esp_ext_part_tables/CMakeLists.txt
+++ b/esp_ext_part_tables/CMakeLists.txt
@@ -17,7 +17,6 @@ idf_component_register(SRCS ${srcs}
 # LittleFS, so its header is not on our include path and the __has_include() probe in
 # esp_mbr_utils.c cannot see it; detect the component here instead. Consumers can
 # still force it by defining ESP_EXT_PART_HAS_LITTLEFS themselves.
-idf_build_get_property(build_components BUILD_COMPONENTS)
-if("joltwallet__littlefs" IN_LIST build_components OR "littlefs" IN_LIST build_components)
-    target_compile_definitions(${COMPONENT_LIB} PRIVATE ESP_EXT_PART_HAS_LITTLEFS=1)
-endif()
+target_compile_definitions(${COMPONENT_LIB} PRIVATE
+    "$<$<OR:$<TARGET_EXISTS:idf::joltwallet__littlefs>,$<TARGET_EXISTS:idf::littlefs>>:ESP_EXT_PART_HAS_LITTLEFS=1>")
+

--- a/esp_ext_part_tables/idf_component.yml
+++ b/esp_ext_part_tables/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.4.0"
+version: "0.5.0"
 description: ESP External Partition Tables
 url: https://github.com/espressif/idf-extra-components/tree/master/esp_ext_part_tables
 issues: https://github.com/espressif/idf-extra-components/issues


### PR DESCRIPTION
# Change description
- `esp_ext_part_tables` detected LittleFS by reading the `BUILD_COMPONENTS` build property and setting `ESP_EXT_PART_HAS_LITTLEFS` when `joltwallet__littlefs` or `littlefs` was in that list.
- Build system v2 does not provide `BUILD_COMPONENTS`. `idf_build_get_property(... BUILD_COMPONENTS)` is a hard error, so any app that pulls this component fails at configure under `IDF_BUILD_V2=1`. The same configure succeeds on v1.
This component must not `REQUIRES` LittleFS. The header is therefore not on our include path, so `__has_include("esp_littlefs.h")` cannot see it. Presence still has to be detected at CMake time.
- Use `$<TARGET_EXISTS:idf::…>` instead, which is the documented ESP-IDF replacement and works on both v1 and v2. Keep both target names (`idf::joltwallet__littlefs` and `idf::littlefs`). Do not add a v1 `BUILD_COMPONENTS` fallback: that path would fail again under v2.

# Testing
- [x] `IDF_BUILD_V2=1` configure/build of `esp_ext_part_tables/test_apps` (override_path to this tree)
- [x]  Repeat with `IDF_BUILD_V2` unset (v1)
